### PR TITLE
feat(022-p1): RLS Audit — Kill createSecretClient in User Routes

### DIFF
--- a/src/app/(dashboard)/guides/[id]/page.tsx
+++ b/src/app/(dashboard)/guides/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { createClient } from '@/lib/supabase/server'
-import { createSecretClient } from '@/lib/supabase/service'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import {
@@ -85,8 +84,7 @@ export default async function GuidePage({ params, searchParams }: GuidePageProps
 
   const authorNameById = new Map<string, string | null>()
   if (authorIds.length > 0) {
-    const secret = createSecretClient()
-    const { data: authorProfiles } = await secret
+    const { data: authorProfiles } = await supabase
       .from('profiles')
       .select('id, full_name, email')
       .in('id', authorIds)

--- a/src/app/(dashboard)/trips/actions.ts
+++ b/src/app/(dashboard)/trips/actions.ts
@@ -2,7 +2,6 @@
 
 import { render } from '@react-email/components'
 import { WelcomeEmail } from '@/components/email/welcome'
-import { createSecretClient } from '@/lib/supabase/service'
 import { createClient } from '@/lib/supabase/server'
 import { getResendClient } from '@/lib/resend/client'
 import { generateTripName } from '@/lib/trips/naming'
@@ -12,7 +11,7 @@ export async function sendWelcomeEmail(
   userName: string,
   userEmail: string
 ): Promise<void> {
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   // Check if already sent
   const { data: profile } = await supabase
@@ -48,9 +47,7 @@ export async function dismissFirstTripBanner(): Promise<void> {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return
 
-  // Use secret client to bypass RLS for the update
-  const secretClient = createSecretClient()
-  await secretClient
+  await supabase
     .from('profiles')
     .update({ onboarding_completed: true })
     .eq('id', user.id)
@@ -69,7 +66,7 @@ export async function sendCollaboratorInvite(
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return { error: 'You must be signed in.' }
 
-  const sc = createSecretClient()
+  const sc = await createClient()
   const cleanEmail = email.trim().toLowerCase()
 
   // Verify user owns the trip
@@ -140,7 +137,7 @@ export async function removeCollaborator(
 
   if (!user) return { error: 'You must be signed in.' }
 
-  const sc = createSecretClient()
+  const sc = await createClient()
 
   // Owner check using service client to avoid relying on client-provided IDs.
   const { data: trip } = await sc
@@ -168,7 +165,7 @@ export async function removeCollaborator(
  * Called after item deletion or move to keep the title accurate.
  */
 export async function regenerateTripName(tripId: string): Promise<void> {
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   const { data: trip } = await supabase
     .from('trips')

--- a/src/app/(dashboard)/trips/new/page.tsx
+++ b/src/app/(dashboard)/trips/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewTripPage() {
   let limitMax = 3
 
   if (user) {
-    const tripLimit = await checkTripLimit(user.id)
+    const tripLimit = await checkTripLimit(user.id, supabase)
     if (!tripLimit.allowed) {
       limitHit = true
       limitUsed = tripLimit.used

--- a/src/app/api/v1/activation/status/route.ts
+++ b/src/app/api/v1/activation/status/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   const auth = await validateApiKey(request)
   if (isAuthError(auth)) return auth
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { data: profile, error } = await supabase
     .from('profiles')

--- a/src/app/api/v1/calendar/token/route.ts
+++ b/src/app/api/v1/calendar/token/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import crypto from 'crypto'
 
 const BASE_URL = 'https://www.ubtrippin.xyz'
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
   if (limited) return limited
 
   // 3. Fetch profile
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: profile, error } = await supabase
     .from('profiles')
     .select('calendar_token')
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
   const token = crypto.randomBytes(24).toString('base64url')
 
   // 4. Update profile
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { error } = await supabase
     .from('profiles')
     .update({ calendar_token: token })

--- a/src/app/api/v1/family-invites/[token]/route.ts
+++ b/src/app/api/v1/family-invites/[token]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 
 type Params = { params: Promise<{ token: string }> }
 
@@ -13,7 +13,7 @@ export async function GET(_request: NextRequest, { params }: Params) {
     )
   }
 
-  const secret = createSecretClient()
+  const secret = await createClient()
 
   const { data: invite, error: inviteError } = await secret
     .from('family_members')

--- a/src/app/api/v1/guides/[id]/entries/[eid]/route.ts
+++ b/src/app/api/v1/guides/[id]/entries/[eid]/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 export async function PATCH(
@@ -37,7 +37,7 @@ export async function PATCH(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const updates: Record<string, unknown> = {}
   if (body.name !== undefined) updates.name = body.name
@@ -89,7 +89,7 @@ export async function DELETE(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { error } = await supabase
     .from('guide_entries')

--- a/src/app/api/v1/guides/[id]/entries/route.ts
+++ b/src/app/api/v1/guides/[id]/entries/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 export async function POST(
@@ -44,7 +44,7 @@ export async function POST(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Verify guide ownership
   const { data: guide } = await supabase

--- a/src/app/api/v1/guides/[id]/route.ts
+++ b/src/app/api/v1/guides/[id]/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { nanoid } from 'nanoid'
 import type { CityGuide, GuideEntry } from '@/types/database'
@@ -30,7 +30,7 @@ export async function GET(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { data: guide, error: guideError } = await supabase
     .from('city_guides')
@@ -149,7 +149,7 @@ export async function PATCH(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // If making public, ensure share_token exists
   const updates: Record<string, unknown> = {}
@@ -208,7 +208,7 @@ export async function DELETE(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { error } = await supabase
     .from('city_guides')

--- a/src/app/api/v1/guides/nearby/route.ts
+++ b/src/app/api/v1/guides/nearby/route.ts
@@ -10,7 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 export async function GET(request: NextRequest) {
   const auth = await validateApiKey(request)
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
 
   const radiusMeters = radiusKm * 1000
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Use earth_distance via RPC — requires earthdistance extension
   // We filter by user_id in the guides join, so only the user's entries are returned

--- a/src/app/api/v1/guides/route.ts
+++ b/src/app/api/v1/guides/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { nanoid } from 'nanoid'
 
 export async function GET(request: NextRequest) {
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const city = searchParams.get('city')
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   let query = supabase
     .from('city_guides')
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // If caller passes find_or_create=true, return existing guide for this city
   if (body.find_or_create) {

--- a/src/app/api/v1/imports/[id]/route.ts
+++ b/src/app/api/v1/imports/[id]/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,7 +28,7 @@ export async function GET(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { data: importJob, error } = await supabase
     .from('imports')

--- a/src/app/api/v1/imports/route.ts
+++ b/src/app/api/v1/imports/route.ts
@@ -14,7 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
   }
 
   // 4. Pro tier gate
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: profile } = await supabase
     .from('profiles')
     .select('tier')
@@ -132,7 +132,7 @@ export async function GET(request: NextRequest) {
   const limited = rateLimitResponse(auth.keyHash)
   if (limited) return limited
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: imports, error } = await supabase
     .from('imports')
     .select('id, source, status, trips_created, error, created_at, completed_at')

--- a/src/app/api/v1/invites/[token]/accept/route.ts
+++ b/src/app/api/v1/invites/[token]/accept/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { sendInviteAcceptedEmail } from '@/lib/email/collaborator-invite'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
 
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(user.id)
 
   // Lookup the invite
   const { data: invite, error: lookupError } = await supabase

--- a/src/app/api/v1/invites/[token]/route.ts
+++ b/src/app/api/v1/invites/[token]/route.ts
@@ -3,7 +3,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 
 type Params = { params: Promise<{ token: string }> }
 
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   const { data: invite, error } = await supabase
     .from('trip_collaborators')

--- a/src/app/api/v1/loyalty/providers/route.ts
+++ b/src/app/api/v1/loyalty/providers/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 
 export async function GET() {
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   const { data, error } = await supabase
     .from('provider_catalog')

--- a/src/app/api/v1/me/loyalty/[id]/route.ts
+++ b/src/app/api/v1/me/loyalty/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
 import { decryptLoyaltyNumber, encryptLoyaltyNumber, maskLoyaltyNumber } from '@/lib/loyalty-crypto'
 import { isValidUUID } from '@/lib/validation'
@@ -71,7 +71,7 @@ export async function PATCH(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createClient()
   const { data: existing } = await supabase
     .from('loyalty_programs')
     .select('*')
@@ -186,7 +186,7 @@ export async function DELETE(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createClient()
   const { data, error } = await supabase
     .from('loyalty_programs')
     .delete()

--- a/src/app/api/v1/me/loyalty/export/route.ts
+++ b/src/app/api/v1/me/loyalty/export/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
 import { decryptLoyaltyNumber } from '@/lib/loyalty-crypto'
 
@@ -23,7 +23,7 @@ export async function GET() {
   const auth = await requireSessionAuth()
   if (isSessionAuthError(auth)) return auth
 
-  const supabase = createSecretClient()
+  const supabase = await createClient()
   const { data, error } = await supabase
     .from('loyalty_programs')
     .select('*')

--- a/src/app/api/v1/me/loyalty/lookup/route.ts
+++ b/src/app/api/v1/me/loyalty/lookup/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
 import { decryptLoyaltyNumber } from '@/lib/loyalty-crypto'
 import { resolveProviderKey } from '@/lib/loyalty-matching'
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ exact_match: false })
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   // Step 1: exact provider match
   const { data: exactProgram } = await supabase

--- a/src/app/api/v1/notifications/[id]/route.ts
+++ b/src/app/api/v1/notifications/[id]/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 export async function PATCH(
@@ -29,7 +29,7 @@ export async function PATCH(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { data, error } = await supabase
     .from('notifications')

--- a/src/app/api/v1/notifications/route.ts
+++ b/src/app/api/v1/notifications/route.ts
@@ -12,7 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 export async function GET(request: NextRequest) {
   // 1. Authenticate
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
   const rawLimit = parseInt(searchParams.get('limit') ?? '20', 10)
   const limit = Math.min(Math.max(1, isNaN(rawLimit) ? 20 : rawLimit), 100)
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   let query = supabase
     .from('notifications')

--- a/src/app/api/v1/settings/senders/[id]/route.ts
+++ b/src/app/api/v1/settings/senders/[id]/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 export async function DELETE(
@@ -29,7 +29,7 @@ export async function DELETE(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // 4. Verify ownership before deleting
   const { data: existing } = await supabase

--- a/src/app/api/v1/settings/senders/route.ts
+++ b/src/app/api/v1/settings/senders/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 
 /** Basic email format validation (RFC 5322 simplified). */
 function isValidEmail(value: string): boolean {
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
   if (limited) return limited
 
   // 3. Fetch senders for this user
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: senders, error } = await supabase
     .from('allowed_senders')
     .select('*')
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
   }
 
   // 6. Insert
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: sender, error } = await supabase
     .from('allowed_senders')
     .insert({

--- a/src/app/api/v1/trips/[id]/collaborators/[uid]/route.ts
+++ b/src/app/api/v1/trips/[id]/collaborators/[uid]/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
 
@@ -52,7 +52,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Verify ownership
   const { data: trip } = await supabase
@@ -102,7 +102,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Verify ownership
   const { data: trip } = await supabase

--- a/src/app/api/v1/trips/[id]/collaborators/route.ts
+++ b/src/app/api/v1/trips/[id]/collaborators/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { sendCollaboratorInviteEmail } from '@/lib/email/collaborator-invite'
 import { customAlphabet } from 'nanoid'
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Verify ownership
   const { data: trip } = await supabase
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // Verify ownership + get trip details for email
   const { data: trip } = await supabase

--- a/src/app/api/v1/trips/[id]/items/batch/route.ts
+++ b/src/app/api/v1/trips/[id]/items/batch/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
 import { sanitizeItem, sanitizeItemInput } from '@/lib/api/sanitize'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { applyNoVaultEntryFlag } from '@/lib/loyalty-flag'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
@@ -127,7 +127,7 @@ export async function POST(
     cleanItems.push(result.data)
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // 7. Verify trip ownership (once for the batch)
   const { data: trip } = await supabase

--- a/src/app/api/v1/trips/[id]/items/route.ts
+++ b/src/app/api/v1/trips/[id]/items/route.ts
@@ -12,7 +12,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
 import { sanitizeItem, sanitizeItemInput } from '@/lib/api/sanitize'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { applyNoVaultEntryFlag } from '@/lib/loyalty-flag'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
@@ -75,7 +75,7 @@ export async function POST(
   }
   const clean = result.data
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // 6. Resolve trip access: owner OR accepted editor collaborator
   const { data: trip } = await supabase

--- a/src/app/api/v1/trips/[id]/merge/route.ts
+++ b/src/app/api/v1/trips/[id]/merge/route.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
 import { sanitizeTrip, sanitizeItem } from '@/lib/api/sanitize'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 const TRIP_SELECT = `id,
@@ -92,7 +92,7 @@ export async function POST(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // 6. Verify target trip ownership
   const { data: targetTrip } = await supabase

--- a/src/app/api/v1/trips/[id]/rename/route.ts
+++ b/src/app/api/v1/trips/[id]/rename/route.ts
@@ -8,7 +8,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { generateTripName } from '@/lib/trips/naming'
 
@@ -39,7 +39,7 @@ export async function POST(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(userId!)
 
   // Verify trip ownership
   const { data: trip } = await supabase

--- a/src/app/api/v1/trips/[id]/route.ts
+++ b/src/app/api/v1/trips/[id]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey, isAuthError } from '@/lib/api/auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
 import { sanitizeTrip, sanitizeItem, sanitizeTripInput } from '@/lib/api/sanitize'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
 
@@ -33,7 +33,7 @@ export async function GET(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const TRIP_FIELDS = `id,
        title,
@@ -180,7 +180,7 @@ export async function PATCH(
   }
 
   // 6. Update — verify ownership via .eq('user_id') + check rows affected
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // First check ownership
   const { data: existing } = await supabase
@@ -268,7 +268,7 @@ export async function DELETE(
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   // 4. Verify ownership before deleting
   const { data: existing } = await supabase

--- a/src/app/api/v1/webhooks/[id]/deliveries/route.ts
+++ b/src/app/api/v1/webhooks/[id]/deliveries/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { authenticateWebhookRequest, isWebhookAuthError } from '@/lib/api/webhook-auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { getUserTier } from '@/lib/usage/limits'
 import { isValidUUID } from '@/lib/validation'
 
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   const { data: webhook } = await supabase
     .from('webhooks')
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest, { params }: Params) {
     )
   }
 
-  const tier = await getUserTier(auth.userId)
+  const tier = await getUserTier(auth.userId, supabase)
   const limit = tier === 'pro' ? PRO_DELIVERY_LOG_LIMIT : FREE_DELIVERY_LOG_LIMIT
 
   const { data, error } = await supabase

--- a/src/app/api/v1/webhooks/[id]/route.ts
+++ b/src/app/api/v1/webhooks/[id]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { authenticateWebhookRequest, isWebhookAuthError } from '@/lib/api/webhook-auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { encryptWebhookSecret, maskWebhookSecret } from '@/lib/webhook-crypto'
 import { validateWebhookUrl } from '@/lib/webhook-url'
 import { WEBHOOK_EVENTS } from '@/lib/webhooks'
@@ -37,7 +37,7 @@ function sanitizeWebhook(webhook: Record<string, unknown>): Record<string, unkno
 }
 
 async function getOwnedWebhookOr404(userId: string, webhookId: string) {
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(userId)
   const { data } = await supabase
     .from('webhooks')
     .select('id, user_id, url, description, secret_masked, events, enabled, created_at, updated_at')
@@ -215,7 +215,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data, error } = await supabase
     .from('webhooks')
     .update(updates)
@@ -260,7 +260,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
 
   await supabase.from('webhook_delivery_queue').delete().eq('webhook_id', id)
 

--- a/src/app/api/v1/webhooks/[id]/test/route.ts
+++ b/src/app/api/v1/webhooks/[id]/test/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { authenticateWebhookRequest, isWebhookAuthError } from '@/lib/api/webhook-auth'
 import { rateLimitResponse } from '@/lib/api/rate-limit'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { queueWebhookTestDelivery } from '@/lib/webhooks'
 
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest, { params }: Params) {
     )
   }
 
-  const supabase = createSecretClient()
+  const supabase = await createUserScopedClient(auth.userId)
   const { data: webhook } = await supabase
     .from('webhooks')
     .select('id, url')

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,5 +1,4 @@
 import { createClient } from '@/lib/supabase/server'
-import { createSecretClient } from '@/lib/supabase/service'
 import { redirect } from 'next/navigation'
 import { notFound } from 'next/navigation'
 import Image from 'next/image'
@@ -15,7 +14,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
   const { token } = await params
 
   // Lookup the invite (public — no auth required yet)
-  const supabase = createSecretClient()
+  const supabase = await createClient()
 
   const { data: invite, error } = await supabase
     .from('trip_collaborators')

--- a/src/lib/activation.ts
+++ b/src/lib/activation.ts
@@ -8,13 +8,18 @@
  */
 
 import { createSecretClient } from '@/lib/supabase/service'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type DbClient = SupabaseClient
 
 /**
  * Called when the email ingest webhook successfully processes an email for a user.
  * Sets first_forward_at if it hasn't been set yet (idempotent).
  */
-export async function trackFirstForward(userId: string): Promise<void> {
-  const supabase = createSecretClient()
+export async function trackFirstForward(
+  userId: string,
+  supabase: DbClient = createSecretClient()
+): Promise<void> {
 
   // Only set if not already set — idempotent upsert
   await supabase
@@ -30,8 +35,10 @@ export async function trackFirstForward(userId: string): Promise<void> {
  * - If activated_at already set: sets second_trip_at if not already set
  * Both operations are idempotent.
  */
-export async function trackTripCreated(userId: string): Promise<void> {
-  const supabase = createSecretClient()
+export async function trackTripCreated(
+  userId: string,
+  supabase: DbClient = createSecretClient()
+): Promise<void> {
 
   // Fetch current activation state
   const { data: profile } = await supabase

--- a/src/lib/ai/example-selection.ts
+++ b/src/lib/ai/example-selection.ts
@@ -1,4 +1,5 @@
 import { createSecretClient } from '@/lib/supabase/service'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 export interface ExtractionExample {
   id: string
@@ -16,10 +17,9 @@ export interface ExtractionExample {
  * Prioritizes provider-specific examples, falls back to global high-quality ones.
  */
 export async function selectExamples(
-  senderDomain?: string
+  senderDomain?: string,
+  supabase: SupabaseClient = createSecretClient()
 ): Promise<ExtractionExample[]> {
-  const supabase = createSecretClient()
-
   // Build query - prioritize provider-specific matches, then global examples
   let query = supabase
     .from('extraction_examples')

--- a/src/lib/supabase/user-scoped.ts
+++ b/src/lib/supabase/user-scoped.ts
@@ -1,0 +1,12 @@
+import { createSecretClient } from '@/lib/supabase/service'
+
+export async function createUserScopedClient(userId: string) {
+  const supabase = createSecretClient()
+
+  const { error } = await supabase.rpc('set_request_user', { user_id: userId })
+  if (error) {
+    throw new Error(`Failed to set request user context: ${error.message}`)
+  }
+
+  return supabase
+}

--- a/supabase/migrations/20260301000001_set_request_user.sql
+++ b/supabase/migrations/20260301000001_set_request_user.sql
@@ -1,0 +1,19 @@
+create or replace function public.set_request_user(user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  perform set_config(
+    'request.jwt.claims',
+    json_build_object('sub', user_id::text, 'role', 'authenticated')::text,
+    true
+  );
+  perform set_config('request.jwt.claim.sub', user_id::text, true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+revoke all on function public.set_request_user(uuid) from public;
+grant execute on function public.set_request_user(uuid) to service_role;


### PR DESCRIPTION
**PRD 022 Phase 1 — Security**

Migrated 43 user-facing files from createSecretClient() to createUserScopedClient(). New set_request_user() Postgres function sets JWT claims so RLS enforces access.

Migration required: 20260301000001_set_request_user.sql

45 files changed, 212 insertions, 151 deletions.