### PR TITLE
feat(016-p2): SNCF Train Status

### DIFF
--- a/src/app/api/v1/trains/[trainNumber]/status/route.ts
+++ b/src/app/api/v1/trains/[trainNumber]/status/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { isAuthError, validateApiKey } from '@/lib/api/auth'
+import { rateLimitResponse } from '@/lib/api/rate-limit'
+import { lookupTrainStatus, normalizeTrainNumber } from '@/lib/train/sncf'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ trainNumber: string }> }
+) {
+  const auth = await validateApiKey(request)
+  if (isAuthError(auth)) return auth
+
+  const limited = rateLimitResponse(auth.keyHash)
+  if (limited) return limited
+
+  const { trainNumber: rawTrainNumber } = await params
+  const trainNumber = normalizeTrainNumber(rawTrainNumber)
+  if (!trainNumber) {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: 'trainNumber must include a valid train number.' } },
+      { status: 400 }
+    )
+  }
+
+  const date = request.nextUrl.searchParams.get('date')?.trim() ?? ''
+  if (!ISO_DATE_RE.test(date)) {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: 'Query param "date" must be in YYYY-MM-DD format.' } },
+      { status: 400 }
+    )
+  }
+
+  const supabase = await createUserScopedClient(auth.userId)
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', auth.userId)
+    .maybeSingle()
+
+  if (profileError || !profile) {
+    return NextResponse.json(
+      { error: { code: 'unauthorized', message: 'Authentication required.' } },
+      { status: 401 }
+    )
+  }
+
+  const result = await lookupTrainStatus(trainNumber, date)
+  if (!result) {
+    return NextResponse.json(
+      { error: { code: 'upstream_error', message: 'SNCF status lookup failed.' } },
+      { status: 502 }
+    )
+  }
+
+  return NextResponse.json({
+    status: result.status,
+    delay_minutes: result.delayMinutes,
+    platform: result.platform,
+    departure_station: result.departureStation,
+    arrival_station: result.arrivalStation,
+    scheduled_departure: result.scheduledDeparture,
+    scheduled_arrival: result.scheduledArrival,
+    actual_departure: result.actualDeparture,
+    actual_arrival: result.actualArrival,
+    monthly_regularity: result.monthlyRegularity,
+    source: 'sncf',
+    train_number: trainNumber,
+    date,
+  })
+}

--- a/src/components/trips/item-details/index.ts
+++ b/src/components/trips/item-details/index.ts
@@ -1,5 +1,6 @@
 export { FlightDetailsView } from './flight-details'
 export { HotelDetailsView } from './hotel-details'
 export { TrainDetailsView } from './train-details'
+export { TrainStatusBadge } from './train-status'
 export { CarDetailsView } from './car-details'
 export { GenericDetailsView } from './generic-details'

--- a/src/components/trips/item-details/train-status.tsx
+++ b/src/components/trips/item-details/train-status.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+
+import { cn } from '@/lib/utils'
+
+type LiveStatus =
+  | 'on_time'
+  | 'delayed'
+  | 'cancelled'
+  | 'diverted'
+  | 'en_route'
+  | 'boarding'
+  | 'landed'
+  | 'arrived'
+  | 'unknown'
+
+interface StatusPayload {
+  status: LiveStatus
+  delay_minutes: number | null
+  platform: string | null
+  last_checked_at: string | null
+}
+
+interface TrainStatusBadgeProps {
+  itemId: string
+}
+
+const STATUS_META: Record<LiveStatus, { label: string; toneClass: string }> = {
+  on_time: { label: 'On time', toneClass: 'text-emerald-700 bg-emerald-50 border-emerald-200' },
+  delayed: { label: 'Delayed', toneClass: 'text-amber-700 bg-amber-50 border-amber-200' },
+  cancelled: { label: 'Cancelled', toneClass: 'text-red-700 bg-red-50 border-red-200' },
+  diverted: { label: 'Diverted', toneClass: 'text-red-700 bg-red-50 border-red-200' },
+  en_route: { label: 'En route', toneClass: 'text-blue-700 bg-blue-50 border-blue-200' },
+  boarding: { label: 'Boarding', toneClass: 'text-blue-700 bg-blue-50 border-blue-200' },
+  landed: { label: 'Arrived', toneClass: 'text-emerald-700 bg-emerald-50 border-emerald-200' },
+  arrived: { label: 'Arrived', toneClass: 'text-emerald-700 bg-emerald-50 border-emerald-200' },
+  unknown: { label: 'Status unavailable', toneClass: 'text-gray-700 bg-gray-50 border-gray-200' },
+}
+
+function statusDotColor(status: LiveStatus): string {
+  if (status === 'on_time' || status === 'arrived' || status === 'landed') return 'bg-emerald-500'
+  if (status === 'delayed') return 'bg-amber-500'
+  if (status === 'cancelled' || status === 'diverted') return 'bg-red-500'
+  if (status === 'en_route' || status === 'boarding') return 'bg-blue-500'
+  return 'bg-gray-400'
+}
+
+function asStatusPayload(value: unknown): StatusPayload | null {
+  if (!value || typeof value !== 'object') return null
+  const row = value as Record<string, unknown>
+  const status = row.status
+  if (typeof status !== 'string') return null
+  if (!(status in STATUS_META)) return null
+
+  const delayMinutes =
+    typeof row.delay_minutes === 'number' && Number.isFinite(row.delay_minutes)
+      ? row.delay_minutes
+      : null
+
+  return {
+    status: status as LiveStatus,
+    delay_minutes: delayMinutes,
+    platform: typeof row.platform === 'string' ? row.platform : null,
+    last_checked_at: typeof row.last_checked_at === 'string' ? row.last_checked_at : null,
+  }
+}
+
+function renderLastChecked(iso: string | null): string {
+  if (!iso) return 'Last checked unknown'
+  const checked = new Date(iso)
+  if (Number.isNaN(checked.getTime())) return 'Last checked unknown'
+
+  const ageMs = Date.now() - checked.getTime()
+  if (ageMs < 30_000) return 'Last checked just now'
+  return `Last checked ${formatDistanceToNow(checked, { addSuffix: true })}`
+}
+
+export function TrainStatusBadge({ itemId }: TrainStatusBadgeProps) {
+  const [status, setStatus] = useState<StatusPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/v1/items/${itemId}/status`, { cache: 'no-store' })
+      if (!response.ok) return
+      const payload = await response.json()
+      setStatus(asStatusPayload(payload?.data?.status))
+    } finally {
+      setLoading(false)
+    }
+  }, [itemId])
+
+  useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        void loadStatus()
+      }
+    }, 2 * 60 * 1000)
+
+    return () => clearInterval(timer)
+  }, [loadStatus])
+
+  if (!status) return null
+
+  const heading = useMemo(() => {
+    const base = STATUS_META[status.status].label
+    if (status.status === 'delayed' && (status.delay_minutes ?? 0) > 0) {
+      return `${base} ${status.delay_minutes} min`
+    }
+    return base
+  }, [status.delay_minutes, status.status])
+
+  return (
+    <div
+      className={cn(
+        'mt-3 rounded-md border px-3 py-2',
+        STATUS_META[status.status].toneClass
+      )}
+    >
+      <p className="text-sm font-medium">
+        <span className={cn('mr-2 inline-block h-2.5 w-2.5 rounded-full', statusDotColor(status.status))} />
+        {heading}
+        {status.platform ? ` · Platform ${status.platform}` : ''}
+      </p>
+      <p className="mt-0.5 text-xs opacity-90">
+        {loading ? 'Checking live status…' : renderLastChecked(status.last_checked_at)}
+      </p>
+    </div>
+  )
+}

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -41,6 +41,7 @@ import {
   FlightDetailsView,
   HotelDetailsView,
   TrainDetailsView,
+  TrainStatusBadge,
   CarDetailsView,
   GenericDetailsView,
 } from './item-details'
@@ -253,6 +254,10 @@ export function TripItemCard({ item, allTrips }: TripItemCardProps) {
 
               {item.kind === 'flight' && (
                 <ItemStatusBadge itemId={item.id} />
+              )}
+
+              {item.kind === 'train' && (
+                <TrainStatusBadge itemId={item.id} />
               )}
             </div>
 

--- a/src/lib/train/sncf.ts
+++ b/src/lib/train/sncf.ts
@@ -1,0 +1,377 @@
+import type { ExistingTripItemStatus, FlightItemLiveStatus } from '@/lib/flight-status'
+
+const SNCF_API_BASE_URL = 'https://data.sncf.com/api/explore/v2.1'
+const SCHEDULE_DATASET = 'tgvmax'
+const REGULARITY_DATASETS = ['reglarite-mensuelle-tgv-nationale', 'regularite-mensuelle-tgv-aqst'] as const
+const CACHE_TTL_MS = 5 * 60_000
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const MONTH_RE = /^\d{4}-\d{2}$/
+const TIME_RE = /^\d{2}:\d{2}$/
+
+const TRAIN_PROVIDER_KEYWORDS = [
+  'sncf',
+  'tgv',
+  'ouigo',
+  'eurostar',
+  'thalys',
+  'ter',
+  'intercites',
+  'trenitalia',
+  'deutsche bahn',
+]
+
+const SNCF_FAMILY_PROVIDER_KEYWORDS = [
+  'sncf',
+  'tgv',
+  'ouigo',
+  'ter',
+  'intercites',
+]
+
+interface CacheEntry {
+  expiresAt: number
+  value: SncfTrainStatusResult | null
+}
+
+const cache = new Map<string, CacheEntry>()
+
+interface SncfScheduleRecord {
+  date?: string
+  train_no?: string
+  origine?: string
+  destination?: string
+  heure_depart?: string
+  heure_arrivee?: string
+  [key: string]: unknown
+}
+
+interface SncfRegularityRecord {
+  date?: string
+  regularite_composite?: number
+  ponctualite_origine?: number
+}
+
+export interface SncfTrainStatusResult {
+  status: FlightItemLiveStatus
+  delayMinutes: number | null
+  platform: string | null
+  departureStation: string | null
+  arrivalStation: string | null
+  scheduledDeparture: string | null
+  scheduledArrival: string | null
+  actualDeparture: string | null
+  actualArrival: string | null
+  monthlyRegularity: number | null
+  raw: Record<string, unknown>
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return null
+}
+
+function normalizeText(value: string | null | undefined): string {
+  if (!value) return ''
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+}
+
+function hasKeyword(value: string | null | undefined, keywords: readonly string[]): boolean {
+  const normalized = normalizeText(value)
+  if (!normalized) return false
+  return keywords.some((keyword) => normalized.includes(keyword))
+}
+
+function extractTrainNumberFromText(value: string | null | undefined): string | null {
+  if (!value) return null
+
+  const upper = value.toUpperCase()
+  const withSpaceMatch = upper.match(/\b(?:[A-Z]{1,4}\s+)?(\d{2,6})\b/)
+  if (withSpaceMatch?.[1]) return withSpaceMatch[1]
+
+  const compact = upper.replace(/[^A-Z0-9]/g, '')
+  const compactDigits = compact.match(/(\d{2,6})/)
+  if (compactDigits?.[1]) return compactDigits[1]
+
+  return null
+}
+
+function toScheduledDateTime(date: string, hhmm: string | null): string | null {
+  if (!hhmm || !TIME_RE.test(hhmm)) return null
+  return `${date}T${hhmm}:00`
+}
+
+function compareTime(a: string | null, b: string | null): number {
+  if (!a && !b) return 0
+  if (!a) return 1
+  if (!b) return -1
+  return a.localeCompare(b)
+}
+
+function diffMinutes(startIso: string, endIso: string): number | null {
+  const startMs = Date.parse(startIso)
+  const endMs = Date.parse(endIso)
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null
+  return Math.max(0, Math.round((endMs - startMs) / 60_000))
+}
+
+async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(url, { cache: 'no-store' })
+    if (!response.ok) return null
+    const payload = await response.json()
+    return asRecord(payload)
+  } catch {
+    return null
+  }
+}
+
+async function loadSchedule(trainNumber: string, date: string): Promise<SncfScheduleRecord[]> {
+  const where = `train_no="${trainNumber}" AND date=date'${date}'`
+  const url = `${SNCF_API_BASE_URL}/catalog/datasets/${SCHEDULE_DATASET}/records?where=${encodeURIComponent(where)}&limit=50`
+  const payload = await fetchJson(url)
+  if (!payload) return []
+
+  const rows = Array.isArray(payload.results) ? payload.results : []
+  return rows
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is SncfScheduleRecord => entry !== null)
+}
+
+async function loadMonthlyRegularity(date: string): Promise<number | null> {
+  const month = date.slice(0, 7)
+  if (!MONTH_RE.test(month)) return null
+
+  for (const datasetId of REGULARITY_DATASETS) {
+    const where = `date<="${month}"`
+    const url = `${SNCF_API_BASE_URL}/catalog/datasets/${datasetId}/records?where=${encodeURIComponent(where)}&order_by=${encodeURIComponent('date desc')}&limit=1`
+    const payload = await fetchJson(url)
+    if (!payload) continue
+
+    const rows = Array.isArray(payload.results) ? payload.results : []
+    const first = asRecord(rows[0])
+    if (!first) continue
+
+    const regularity = asNumber(first.regularite_composite)
+    if (regularity !== null) return regularity
+  }
+
+  return null
+}
+
+function parseScheduleStatus(rows: SncfScheduleRecord[], date: string, monthlyRegularity: number | null): SncfTrainStatusResult {
+  if (rows.length === 0) {
+    return {
+      status: 'unknown',
+      delayMinutes: null,
+      platform: null,
+      departureStation: null,
+      arrivalStation: null,
+      scheduledDeparture: null,
+      scheduledArrival: null,
+      actualDeparture: null,
+      actualArrival: null,
+      monthlyRegularity,
+      raw: {
+        source_dataset: SCHEDULE_DATASET,
+        matched_records: 0,
+      },
+    }
+  }
+
+  const byDeparture = [...rows].sort((a, b) => compareTime(asString(a.heure_depart), asString(b.heure_depart)))
+  const byArrival = [...rows].sort((a, b) => compareTime(asString(b.heure_arrivee), asString(a.heure_arrivee)))
+
+  const firstDeparture = byDeparture[0]
+  const lastArrival = byArrival[0]
+
+  const departureStation = asString(firstDeparture.origine)
+  const arrivalStation = asString(lastArrival.destination)
+  const scheduledDeparture = toScheduledDateTime(date, asString(firstDeparture.heure_depart))
+  const scheduledArrival = toScheduledDateTime(date, asString(lastArrival.heure_arrivee))
+
+  const actualDeparture =
+    asString(firstDeparture.actual_departure) ??
+    asString(firstDeparture.departure_time_actual) ??
+    null
+  const actualArrival =
+    asString(lastArrival.actual_arrival) ??
+    asString(lastArrival.arrival_time_actual) ??
+    null
+
+  const platform =
+    asString(firstDeparture.platform) ??
+    asString(firstDeparture.departure_platform) ??
+    asString(firstDeparture.quai) ??
+    null
+
+  const cancellationHint = normalizeText(
+    asString(firstDeparture.status) ??
+    asString(firstDeparture.etat_train) ??
+    asString(firstDeparture.state)
+  )
+  const cancelled = cancellationHint.includes('annule') || cancellationHint.includes('cancel')
+
+  const computedDelay = scheduledDeparture && actualDeparture
+    ? diffMinutes(scheduledDeparture, actualDeparture)
+    : null
+
+  const status: FlightItemLiveStatus = cancelled
+    ? 'cancelled'
+    : (computedDelay ?? 0) > 0
+    ? 'delayed'
+    : 'on_time'
+
+  return {
+    status,
+    delayMinutes: status === 'delayed' ? computedDelay ?? null : computedDelay ?? 0,
+    platform,
+    departureStation,
+    arrivalStation,
+    scheduledDeparture,
+    scheduledArrival,
+    actualDeparture,
+    actualArrival,
+    monthlyRegularity,
+    raw: {
+      source_dataset: SCHEDULE_DATASET,
+      matched_records: rows.length,
+      first_record: firstDeparture,
+      last_record: lastArrival,
+      monthly_regularity: monthlyRegularity,
+      inferred_status: !cancelled && computedDelay === null,
+    },
+  }
+}
+
+function asLiveStatus(value: string | null | undefined): FlightItemLiveStatus | null {
+  if (!value) return null
+  if (
+    value === 'on_time' ||
+    value === 'delayed' ||
+    value === 'cancelled' ||
+    value === 'diverted' ||
+    value === 'en_route' ||
+    value === 'boarding' ||
+    value === 'landed' ||
+    value === 'arrived' ||
+    value === 'unknown'
+  ) {
+    return value
+  }
+  return null
+}
+
+function toIsoOrNull(value: string | null | undefined): string | null {
+  if (!value) return null
+  return Number.isNaN(Date.parse(value)) ? null : value
+}
+
+export function isTrainOperator(provider: string | null | undefined): boolean {
+  return hasKeyword(provider, TRAIN_PROVIDER_KEYWORDS)
+}
+
+export function isSncfFamilyProvider(provider: string | null | undefined): boolean {
+  return hasKeyword(provider, SNCF_FAMILY_PROVIDER_KEYWORDS)
+}
+
+export function isTrainLikeItem(item: { kind: string | null | undefined; provider: string | null | undefined }): boolean {
+  return item.kind === 'train' || isTrainOperator(item.provider)
+}
+
+export function extractTrainNumberFromItem(item: {
+  details_json: unknown
+  summary: string | null | undefined
+  provider: string | null | undefined
+}): string | null {
+  const details = asRecord(item.details_json)
+  const fromDetails =
+    extractTrainNumberFromText(asString(details?.train_number)) ??
+    extractTrainNumberFromText(asString(details?.flight_number))
+
+  return fromDetails
+    ?? extractTrainNumberFromText(item.summary)
+    ?? extractTrainNumberFromText(item.provider)
+}
+
+export function normalizeTrainNumber(value: string): string | null {
+  const raw = value.trim()
+  if (!raw) return null
+  return extractTrainNumberFromText(raw)
+}
+
+export async function lookupTrainStatus(trainNumber: string, date: string): Promise<SncfTrainStatusResult | null> {
+  const normalizedTrainNumber = normalizeTrainNumber(trainNumber)
+  if (!normalizedTrainNumber || !ISO_DATE_RE.test(date)) return null
+
+  const cacheKey = `${normalizedTrainNumber}:${date}`
+  const now = Date.now()
+  const cached = cache.get(cacheKey)
+  if (cached && cached.expiresAt > now) return cached.value
+
+  try {
+    const [scheduleRows, monthlyRegularity] = await Promise.all([
+      loadSchedule(normalizedTrainNumber, date),
+      loadMonthlyRegularity(date),
+    ])
+    const result = parseScheduleStatus(scheduleRows, date, monthlyRegularity)
+    cache.set(cacheKey, {
+      expiresAt: now + CACHE_TTL_MS,
+      value: result,
+    })
+    return result
+  } catch {
+    cache.set(cacheKey, {
+      expiresAt: now + CACHE_TTL_MS,
+      value: null,
+    })
+    return null
+  }
+}
+
+export function buildTrainStatusUpsertValues(params: {
+  itemId: string
+  result: SncfTrainStatusResult
+  existing: ExistingTripItemStatus | null
+}) {
+  const nowIso = new Date().toISOString()
+  const previous = asLiveStatus(params.existing?.status)
+  const changed = previous !== null && previous !== params.result.status
+
+  return {
+    values: {
+      item_id: params.itemId,
+      status: params.result.status,
+      delay_minutes: params.result.delayMinutes,
+      gate: null,
+      terminal: null,
+      platform: params.result.platform,
+      estimated_departure: toIsoOrNull(params.result.actualDeparture ?? params.result.scheduledDeparture),
+      estimated_arrival: toIsoOrNull(params.result.actualArrival ?? params.result.scheduledArrival),
+      actual_departure: toIsoOrNull(params.result.actualDeparture),
+      actual_arrival: toIsoOrNull(params.result.actualArrival),
+      raw_response: params.result.raw,
+      source: 'sncf',
+      last_checked_at: nowIso,
+      status_changed_at: changed ? nowIso : params.existing?.status_changed_at ?? null,
+      previous_status: changed ? previous : params.existing?.previous_status ?? null,
+      updated_at: nowIso,
+    },
+    statusChanged: changed,
+    previousStatus: changed ? previous : null,
+  }
+}


### PR DESCRIPTION
**PRD 016 Phase 2**

- SNCF Open Data integration (free, no API key)
- Train status lookup with 5-min cache
- Status badge on trip items (On Time / Delayed / Cancelled)
- API endpoint: GET /api/v1/trains/:number/status
- Integrated with status-check cron
- 8 files, 718 insertions