### PR TITLE
feat(022-p3): E2E expansion — 14 spec files, 63 tests

### DIFF
--- a/e2e/helpers/request.ts
+++ b/e2e/helpers/request.ts
@@ -1,0 +1,45 @@
+import type { APIResponse, APIRequestContext } from '@playwright/test'
+
+export async function parseResponseBody(res: APIResponse): Promise<unknown> {
+  const contentType = res.headers()['content-type'] ?? ''
+  if (contentType.includes('application/json')) {
+    try {
+      return await res.json()
+    } catch {
+      return null
+    }
+  }
+
+  try {
+    const text = await res.text()
+    return text || null
+  } catch {
+    return null
+  }
+}
+
+export async function parseResponse(res: APIResponse): Promise<{ status: number; body: unknown }> {
+  return {
+    status: res.status(),
+    body: await parseResponseBody(res),
+  }
+}
+
+export async function requestJson(
+  request: APIRequestContext,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  data?: unknown
+): Promise<{ status: number; body: unknown }> {
+  const res = await request.fetch(path, {
+    method,
+    ...(data === undefined
+      ? {}
+      : {
+          headers: { 'Content-Type': 'application/json' },
+          data,
+        }),
+  })
+
+  return parseResponse(res)
+}

--- a/e2e/tests/billing.spec.ts
+++ b/e2e/tests/billing.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+import { requestJson } from '../helpers/request'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Billing page', () => {
+  test('loads /settings/billing without error', async ({ page }) => {
+    requireSession()
+
+    const response = await page.goto('/settings/billing')
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const body = await page.content()
+    expect(response?.status()).not.toBe(500)
+    expect(body).not.toContain('Application error')
+    await expect(page.getByRole('heading', { name: /billing/i })).toBeVisible()
+  })
+
+  test('shows current plan (free or pro)', async ({ page }) => {
+    requireSession()
+
+    await page.goto('/settings/billing')
+    await expect(page.getByText(/current plan: (free|pro)/i)).toBeVisible()
+  })
+
+  test('shows upgrade actions for free users', async ({ page, request }) => {
+    requireSession()
+
+    const subscription = await requestJson(request, 'GET', '/api/v1/billing/subscription')
+    if (subscription.status !== 200 || !subscription.body || typeof subscription.body !== 'object') {
+      test.skip()
+      return
+    }
+
+    const tier = (subscription.body as { subscription_tier?: string }).subscription_tier
+    test.skip(tier !== 'free', 'Only valid for free users')
+
+    await page.goto('/settings/billing')
+    await expect(page.getByRole('heading', { name: /upgrade to pro/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /go monthly|go annual|get early adopter/i })).toBeVisible()
+  })
+
+  test('GET /api/v1/billing/portal returns URL for pro users', async ({ request }) => {
+    requireSession()
+
+    const subscription = await requestJson(request, 'GET', '/api/v1/billing/subscription')
+    if (subscription.status !== 200 || !subscription.body || typeof subscription.body !== 'object') {
+      test.skip()
+      return
+    }
+
+    const tier = (subscription.body as { subscription_tier?: string }).subscription_tier
+    test.skip(tier !== 'pro', 'Billing portal URL assertion only for pro users')
+
+    const portal = await requestJson(request, 'GET', '/api/v1/billing/portal')
+    expect(portal.status).toBe(200)
+    expect(portal.body).toBeTruthy()
+
+    const url = (portal.body as { url?: string }).url
+    expect(typeof url).toBe('string')
+    expect(url).toMatch(/^https:\/\//)
+  })
+})

--- a/e2e/tests/family.spec.ts
+++ b/e2e/tests/family.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+import { requestJson } from '../helpers/request'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Family', () => {
+  test('GET /api/v1/families returns list', async ({ request }) => {
+    requireSession()
+
+    const result = await requestJson(request, 'GET', '/api/v1/families')
+    expect(result.status).toBe(200)
+
+    const data = (result.body as { data?: unknown[] }).data
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  test('/settings/family loads without error', async ({ page }) => {
+    requireSession()
+
+    const response = await page.goto('/settings/family')
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const body = await page.content()
+    expect(response?.status()).not.toBe(500)
+    expect(body).not.toContain('Application error')
+    await expect(page.getByRole('heading', { name: /family/i })).toBeVisible()
+  })
+})

--- a/e2e/tests/feedback.spec.ts
+++ b/e2e/tests/feedback.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Feedback page', () => {
+  test('/feedback loads without error', async ({ page }) => {
+    requireSession()
+
+    const response = await page.goto('/feedback')
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const body = await page.content()
+    expect(response?.status()).not.toBe(500)
+    expect(body).not.toContain('Application error')
+    await expect(page.getByRole('heading', { name: /feedback/i })).toBeVisible()
+  })
+
+  test('submit form is visible', async ({ page }) => {
+    requireSession()
+
+    await page.goto('/feedback')
+
+    await page.getByRole('button', { name: /new idea/i }).click()
+
+    await expect(page.getByText('Share feedback')).toBeVisible()
+    await expect(page.locator('#feedback-title')).toBeVisible()
+    await expect(page.locator('#feedback-type')).toBeVisible()
+    await expect(page.locator('#feedback-body')).toBeVisible()
+  })
+})

--- a/e2e/tests/help.spec.ts
+++ b/e2e/tests/help.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Help center', () => {
+  test('/help loads core sections', async ({ page }) => {
+    requireSession()
+
+    const response = await page.goto('/help')
+    await expect(page).not.toHaveURL(/\/login/)
+
+    expect(response?.status()).not.toBe(500)
+    await expect(page.getByRole('heading', { name: /help center/i })).toBeVisible()
+    await expect(page.locator('#getting-started')).toBeVisible()
+    await expect(page.locator('#calendar')).toBeVisible()
+    await expect(page.locator('#faq')).toBeVisible()
+  })
+
+  test('search filters help content', async ({ page }) => {
+    requireSession()
+
+    await page.goto('/help')
+
+    await page.getByLabel('Search help articles').fill('calendar')
+
+    await expect(page.getByText('1 section found')).toBeVisible()
+    await expect(page.locator('#calendar')).toBeVisible()
+    await expect(page.locator('#getting-started')).toBeHidden()
+  })
+
+  test('deep link /help#calendar resolves to calendar section', async ({ page }) => {
+    requireSession()
+
+    await page.goto('/help#calendar')
+    await expect(page).toHaveURL(/\/help#calendar$/)
+
+    const section = page.locator('#calendar')
+    await expect(section).toBeVisible()
+
+    const open = await section.evaluate((el) => (el as HTMLDetailsElement).open)
+    expect(open).toBe(true)
+  })
+})

--- a/e2e/tests/loyalty.spec.ts
+++ b/e2e/tests/loyalty.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+import { requestJson } from '../helpers/request'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Loyalty', () => {
+  let createdId = ''
+
+  test.afterAll(async ({ request }) => {
+    if (!createdId) return
+    await requestJson(request, 'DELETE', `/api/v1/me/loyalty/${createdId}`)
+  })
+
+  test('loads /loyalty without error', async ({ page }) => {
+    requireSession()
+
+    const response = await page.goto('/loyalty')
+    await expect(page).not.toHaveURL(/\/login/)
+    const body = await page.content()
+
+    expect(response?.status()).not.toBe(500)
+    expect(body).not.toContain('Application error')
+    await expect(page.getByText(/loyalty/i)).toBeVisible()
+  })
+
+  test('GET /api/v1/loyalty/providers returns provider list', async ({ request }) => {
+    const providers = await requestJson(request, 'GET', '/api/v1/loyalty/providers')
+
+    expect(providers.status).toBe(200)
+    expect(providers.body).toBeTruthy()
+
+    const data = (providers.body as { data?: unknown[] }).data
+    expect(Array.isArray(data)).toBe(true)
+    expect((data ?? []).length).toBeGreaterThan(0)
+  })
+
+  test('POST /api/v1/me/loyalty creates program', async ({ request }) => {
+    requireSession()
+
+    const created = await requestJson(request, 'POST', '/api/v1/me/loyalty', {
+      traveler_name: 'E2E Traveler',
+      provider_type: 'airline',
+      provider_name: 'Delta SkyMiles',
+      provider_key: 'delta',
+      program_number: '1234561234',
+      preferred: false,
+    })
+
+    expect(created.status).toBe(201)
+    expect(created.body).toBeTruthy()
+
+    const data = (created.body as { data?: { id?: string } }).data
+    expect(data?.id).toBeTruthy()
+
+    createdId = data?.id ?? ''
+  })
+
+  test('GET /api/v1/me/loyalty lists created program', async ({ request }) => {
+    requireSession()
+    if (!createdId) test.skip()
+
+    const list = await requestJson(request, 'GET', '/api/v1/me/loyalty')
+
+    expect(list.status).toBe(200)
+    const data = (list.body as { data?: Array<{ id: string; provider_name?: string }> }).data ?? []
+    const created = data.find((entry) => entry.id === createdId)
+
+    expect(created).toBeDefined()
+    expect(created?.provider_name).toMatch(/delta/i)
+  })
+
+  test('masked number format is present', async ({ request }) => {
+    requireSession()
+    if (!createdId) test.skip()
+
+    const list = await requestJson(request, 'GET', '/api/v1/me/loyalty')
+    expect(list.status).toBe(200)
+
+    const data =
+      (list.body as { data?: Array<{ id: string; program_number_masked?: string }> }).data ?? []
+    const created = data.find((entry) => entry.id === createdId)
+
+    expect(created?.program_number_masked).toBeTruthy()
+    expect(created?.program_number_masked).toMatch(/[•*].*1234$/)
+  })
+
+  test('DELETE /api/v1/me/loyalty/:id removes program', async ({ request }) => {
+    requireSession()
+    if (!createdId) test.skip()
+
+    const deleted = await requestJson(request, 'DELETE', `/api/v1/me/loyalty/${createdId}`)
+    expect([200, 204]).toContain(deleted.status)
+
+    createdId = ''
+  })
+})

--- a/e2e/tests/mobile.spec.ts
+++ b/e2e/tests/mobile.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, type Page } from '@playwright/test'
+
+function requireSession() {
+  if (!process.env.TEST_USER_EMAIL) test.skip()
+}
+
+test.describe('Mobile viewport', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  async function assertNoHorizontalOverflow(pagePath: string, page: Page) {
+    await page.goto(pagePath)
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const hasOverflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth + 1
+    })
+
+    expect(hasOverflow).toBe(false)
+  }
+
+  test('/trips has no horizontal overflow', async ({ page }) => {
+    requireSession()
+    await assertNoHorizontalOverflow('/trips', page)
+  })
+
+  test('/loyalty has no horizontal overflow', async ({ page }) => {
+    requireSession()
+    await assertNoHorizontalOverflow('/loyalty', page)
+  })
+
+  test('/help has no horizontal overflow', async ({ page }) => {
+    requireSession()
+    await assertNoHorizontalOverflow('/help', page)
+  })
+
+  test('/settings has no horizontal overflow', async ({ page }) => {
+    requireSession()
+    await assertNoHorizontalOverflow('/settings', page)
+  })
+
+  test('/feedback has no horizontal overflow', async ({ page }) => {
+    requireSession()
+    await assertNoHorizontalOverflow('/feedback', page)
+  })
+
+  test('mobile nav hamburger is accessible', async ({ page }) => {
+    requireSession()
+
+    await page.goto('/trips')
+
+    const toggle = page.locator('button').filter({ has: page.locator('svg') }).first()
+    await expect(toggle).toBeVisible()
+
+    await toggle.click()
+
+    await expect(page.getByRole('link', { name: /settings/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /trips/i })).toBeVisible()
+  })
+})

--- a/e2e/tests/sharing.spec.ts
+++ b/e2e/tests/sharing.spec.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'node:crypto'
+import { test, expect } from '@playwright/test'
+import { apiDelete, apiPost } from '../helpers/api'
+import { adminClient } from '../helpers/supabase-admin'
+
+function hasApiKey() {
+  return Boolean(process.env.TEST_API_KEY)
+}
+
+function hasAdminEnv() {
+  return Boolean(
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.SUPABASE_SECRET_KEY
+  )
+}
+
+test.describe('Trip sharing', () => {
+  let tripId = ''
+  let shareToken = ''
+
+  test.beforeAll(async () => {
+    if (!hasApiKey() || !hasAdminEnv()) return
+
+    const created = await apiPost('/api/v1/trips', {
+      title: 'E2E Sharing Trip',
+      start_date: '2027-01-11',
+      end_date: '2027-01-14',
+      primary_location: 'Seattle, USA',
+    })
+
+    if (created.status !== 201 || !created.body || typeof created.body !== 'object') return
+
+    const id = (created.body as { data?: { id?: string } }).data?.id
+    if (!id) return
+
+    tripId = id
+    shareToken = `e2e_${Date.now()}_${randomUUID().replace(/-/g, '').slice(0, 10)}`
+
+    const supabase = adminClient()
+    await supabase
+      .from('trips')
+      .update({ share_enabled: true, share_token: shareToken })
+      .eq('id', tripId)
+  })
+
+  test.afterAll(async () => {
+    if (!tripId || !hasApiKey()) return
+    await apiDelete(`/api/v1/trips/${tripId}`)
+  })
+
+  test('API creates trip and sharing is enabled', async () => {
+    if (!hasApiKey() || !hasAdminEnv() || !tripId || !shareToken) test.skip()
+
+    const supabase = adminClient()
+    const { data } = await supabase
+      .from('trips')
+      .select('id, share_enabled, share_token')
+      .eq('id', tripId)
+      .single()
+
+    expect(data?.id).toBe(tripId)
+    expect(data?.share_enabled).toBe(true)
+    expect(data?.share_token).toBe(shareToken)
+  })
+
+  test('public share URL loads without auth and shows trip info', async ({ browser }) => {
+    if (!tripId || !shareToken) test.skip()
+
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+
+    await page.goto(`/share/${shareToken}`)
+    await expect(page).not.toHaveURL(/\/login/)
+    await expect(page.getByText('E2E Sharing Trip')).toBeVisible()
+
+    const body = await page.content()
+    expect(body).not.toContain('Application error')
+
+    await ctx.close()
+  })
+
+  test('share page is read-only (no edit controls)', async ({ browser }) => {
+    if (!shareToken) test.skip()
+
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+
+    await page.goto(`/share/${shareToken}`)
+
+    const body = await page.textContent('body')
+    expect(body).not.toMatch(/add item|edit trip|delete trip|sharing enabled/i)
+
+    await ctx.close()
+  })
+})

--- a/e2e/tests/webhooks.spec.ts
+++ b/e2e/tests/webhooks.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test'
+import { apiDelete, apiGet, apiPost } from '../helpers/api'
+
+function requireApiKey() {
+  if (!process.env.TEST_API_KEY) test.skip()
+}
+
+test.describe('Webhooks API', () => {
+  let webhookId = ''
+
+  test.afterAll(async () => {
+    if (!webhookId || !process.env.TEST_API_KEY) return
+    await apiDelete(`/api/v1/webhooks/${webhookId}`)
+  })
+
+  test('POST /api/v1/webhooks registers a webhook', async () => {
+    requireApiKey()
+
+    const created = await apiPost('/api/v1/webhooks', {
+      url: `https://webhook.site/${Date.now()}-ubtrippin-e2e`,
+      secret: 'ubtrippin_e2e_secret_12345',
+      description: 'E2E webhook',
+      events: ['trip.created'],
+    })
+
+    test.skip(
+      created.status === 403,
+      'Webhook registration is pro-only for this test user'
+    )
+
+    expect(created.status).toBe(201)
+    expect(created.body).toBeTruthy()
+
+    const id = (created.body as { data?: { id?: string } }).data?.id
+    expect(id).toBeTruthy()
+    webhookId = id ?? ''
+  })
+
+  test('GET /api/v1/webhooks list includes webhook', async () => {
+    requireApiKey()
+    if (!webhookId) test.skip()
+
+    const list = await apiGet('/api/v1/webhooks')
+    expect(list.status).toBe(200)
+
+    const rows = (list.body as { data?: Array<{ id: string }> }).data ?? []
+    expect(rows.some((row) => row.id === webhookId)).toBe(true)
+  })
+
+  test('POST /api/v1/webhooks/:id/test queues a delivery', async () => {
+    requireApiKey()
+    if (!webhookId) test.skip()
+
+    const triggered = await apiPost(`/api/v1/webhooks/${webhookId}/test`, {})
+    expect(triggered.status).toBe(200)
+
+    const queued = (triggered.body as { data?: { queued?: boolean } }).data?.queued
+    expect(queued).toBe(true)
+  })
+
+  test('GET /api/v1/webhooks/:id/deliveries returns delivery log', async () => {
+    requireApiKey()
+    if (!webhookId) test.skip()
+
+    let found = false
+
+    for (let i = 0; i < 8; i += 1) {
+      const deliveries = await apiGet(`/api/v1/webhooks/${webhookId}/deliveries`)
+      expect(deliveries.status).toBe(200)
+
+      const rows = (deliveries.body as { data?: Array<{ event?: string }> }).data ?? []
+      if (rows.length > 0) {
+        found = true
+        expect(rows[0].event).toBeTruthy()
+        break
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 750))
+    }
+
+    expect(found).toBe(true)
+  })
+
+  test('DELETE /api/v1/webhooks/:id removes webhook', async () => {
+    requireApiKey()
+    if (!webhookId) test.skip()
+
+    const deleted = await apiDelete(`/api/v1/webhooks/${webhookId}`)
+    expect([200, 204]).toContain(deleted.status)
+
+    webhookId = ''
+  })
+})


### PR DESCRIPTION
Adds 8 new E2E spec files: billing, loyalty, sharing, family, help, webhooks, feedback, mobile viewport. TSC clean, tests pass (skip when env vars missing).