### PR TITLE
feat(024): feedback fixes — guide map, trip edit→inbox, feedback images

### DIFF
--- a/src/app/(dashboard)/feedback/[id]/page.tsx
+++ b/src/app/(dashboard)/feedback/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function FeedbackDetailPage({ params }: FeedbackDetailPageP
 
   const { data: feedbackData } = await supabase
     .from('feedback')
-    .select('id, user_id, type, title, body, status, votes, created_at, updated_at')
+    .select('id, user_id, type, title, body, image_url, status, votes, created_at, updated_at')
     .eq('id', id)
     .maybeSingle()
 
@@ -81,6 +81,7 @@ export default async function FeedbackDetailPage({ params }: FeedbackDetailPageP
       comments={commentItems}
       currentUserId={user.id}
       currentUserName={nameByUserId.get(user.id) ?? null}
+      canManageStatus={user.id === feedback.user_id}
     />
   )
 }

--- a/src/app/(dashboard)/feedback/page.tsx
+++ b/src/app/(dashboard)/feedback/page.tsx
@@ -17,7 +17,7 @@ export default async function FeedbackPage() {
 
   const { data: feedbackData } = await supabase
     .from('feedback')
-    .select('id, user_id, type, title, body, status, votes, created_at, updated_at')
+    .select('id, user_id, type, title, body, image_url, status, votes, created_at, updated_at')
     .order('votes', { ascending: false })
     .order('created_at', { ascending: false })
 

--- a/src/app/(dashboard)/guides/[id]/guide-cover-image-button.tsx
+++ b/src/app/(dashboard)/guides/[id]/guide-cover-image-button.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ImagePlus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { GuideCoverImagePicker } from '@/components/guides/guide-cover-image-picker'
+
+interface GuideCoverImageButtonProps {
+  guideId: string
+  currentImageUrl: string | null
+}
+
+export function GuideCoverImageButton({ guideId, currentImageUrl }: GuideCoverImageButtonProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button size="sm" variant="outline" type="button" onClick={() => setOpen(true)}>
+        <ImagePlus className="mr-1.5 h-3.5 w-3.5" />
+        {currentImageUrl ? 'Change cover' : 'Cover image'}
+      </Button>
+
+      {open && (
+        <GuideCoverImagePicker
+          guideId={guideId}
+          onClose={() => setOpen(false)}
+          onSaved={() => router.refresh()}
+        />
+      )}
+    </>
+  )
+}

--- a/src/app/(dashboard)/inbox/inbox-highlight-scroll.tsx
+++ b/src/app/(dashboard)/inbox/inbox-highlight-scroll.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+export function InboxHighlightScroll() {
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const highlightId = searchParams.get('highlight')
+    if (!highlightId) return
+
+    const el = document.querySelector<HTMLElement>(`[data-email-id="${CSS.escape(highlightId)}"]`)
+    if (!el) return
+
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [searchParams])
+
+  return null
+}

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -5,6 +5,7 @@ import { formatDateTime } from '@/lib/utils'
 import { Mail, AlertCircle, CheckCircle, XCircle, Clock, HelpCircle } from 'lucide-react'
 import Link from 'next/link'
 import type { SourceEmail, EmailParseStatus } from '@/types/database'
+import { InboxHighlightScroll } from './inbox-highlight-scroll'
 
 const statusConfig: Record<EmailParseStatus, { label: string; icon: typeof Clock; variant: 'secondary' | 'default' | 'success' | 'error' | 'warning' }> = {
   pending: {
@@ -34,7 +35,12 @@ const statusConfig: Record<EmailParseStatus, { label: string; icon: typeof Clock
   },
 }
 
-export default async function InboxPage() {
+interface InboxPageProps {
+  searchParams: Promise<{ highlight?: string }>
+}
+
+export default async function InboxPage({ searchParams }: InboxPageProps) {
+  const { highlight } = await searchParams
   const supabase = await createClient()
 
   const { data: emailsData } = await supabase
@@ -48,6 +54,7 @@ export default async function InboxPage() {
 
   return (
     <div className="space-y-6">
+      <InboxHighlightScroll />
       {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Inbox</h1>
@@ -70,10 +77,18 @@ export default async function InboxPage() {
           {emails.map((email) => {
             const status = statusConfig[email.parse_status]
             const StatusIcon = status.icon
+            const isHighlighted = highlight === email.id
 
             return (
               <Link key={email.id} href={`/inbox/${email.id}`}>
-                <Card className="group cursor-pointer transition-all hover:shadow-md hover:border-[#cbd5e1]">
+                <Card
+                  data-email-id={email.id}
+                  className={`group cursor-pointer transition-all hover:shadow-md hover:border-[#cbd5e1] ${
+                    isHighlighted
+                      ? 'border-indigo-500 ring-2 ring-indigo-200 shadow-md'
+                      : ''
+                  }`}
+                >
                   <CardContent className="p-4">
                     <div className="flex items-start gap-4">
                       {/* Status indicator */}

--- a/src/app/api/feedback/[id]/status/route.ts
+++ b/src/app/api/feedback/[id]/status/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { isValidUUID } from '@/lib/validation'
+
+const FEEDBACK_STATUSES = new Set([
+  'new',
+  'under_review',
+  'planned',
+  'in_progress',
+  'shipped',
+  'declined',
+])
+
+function feedbackImagePathFromPublicUrl(imageUrl: string): string | null {
+  try {
+    const parsed = new URL(imageUrl)
+    const marker = '/storage/v1/object/public/feedback-images/'
+    const index = parsed.pathname.indexOf(marker)
+    if (index === -1) return null
+
+    const path = parsed.pathname.slice(index + marker.length)
+    return path ? decodeURIComponent(path) : null
+  } catch {
+    return null
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  if (!isValidUUID(id)) {
+    return NextResponse.json({ error: 'Invalid feedback ID' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const payload = (await request.json().catch(() => null)) as { status?: unknown } | null
+  const status = typeof payload?.status === 'string' ? payload.status : ''
+  if (!FEEDBACK_STATUSES.has(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+  }
+
+  const { data: existing } = await supabase
+    .from('feedback')
+    .select('id, user_id, status, image_url')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (existing.user_id !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let nextImageUrl = existing.image_url
+
+  if (existing.status !== 'shipped' && status === 'shipped' && existing.image_url) {
+    const imagePath = feedbackImagePathFromPublicUrl(existing.image_url)
+    if (imagePath) {
+      await supabase.storage.from('feedback-images').remove([imagePath])
+      nextImageUrl = null
+    }
+  }
+
+  const { data: updated, error } = await supabase
+    .from('feedback')
+    .update({ status, image_url: nextImageUrl })
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select('id, user_id, type, title, body, image_url, status, votes, created_at, updated_at')
+    .single()
+
+  if (error || !updated) {
+    return NextResponse.json({ error: 'Could not update status' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: updated })
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+const ALLOWED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+
+function normalizeFeedbackType(value: unknown): 'bug' | 'feature' | 'general' {
+  if (value === 'bug' || value === 'feature' || value === 'general') return value
+  return 'general'
+}
+
+function extensionFromMimeType(type: string): string {
+  if (type === 'image/jpeg') return 'jpg'
+  if (type === 'image/png') return 'png'
+  if (type === 'image/webp') return 'webp'
+  return 'bin'
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+
+  const title = (formData.get('title') as string | null)?.trim() ?? ''
+  const body = (formData.get('body') as string | null)?.trim() ?? ''
+  const type = normalizeFeedbackType(formData.get('type'))
+  const pageUrl = (formData.get('page_url') as string | null)?.trim() || null
+  const maybeImage = formData.get('image')
+
+  if (!title || !body) {
+    return NextResponse.json({ error: 'Title and details are required.' }, { status: 400 })
+  }
+
+  let imageUrl: string | null = null
+  let imagePath: string | null = null
+
+  if (maybeImage instanceof File && maybeImage.size > 0) {
+    if (maybeImage.size > MAX_IMAGE_BYTES) {
+      return NextResponse.json({ error: 'Image must be 5MB or smaller.' }, { status: 400 })
+    }
+
+    if (!ALLOWED_IMAGE_TYPES.has(maybeImage.type)) {
+      return NextResponse.json({ error: 'Image must be JPG, PNG, or WebP.' }, { status: 400 })
+    }
+
+    const ext = extensionFromMimeType(maybeImage.type)
+    imagePath = `${user.id}/${crypto.randomUUID()}.${ext}`
+
+    const { error: uploadError } = await supabase.storage
+      .from('feedback-images')
+      .upload(imagePath, maybeImage, {
+        contentType: maybeImage.type,
+        upsert: false,
+      })
+
+    if (uploadError) {
+      return NextResponse.json({ error: 'Could not upload image.' }, { status: 500 })
+    }
+
+    const { data: publicUrlData } = supabase.storage
+      .from('feedback-images')
+      .getPublicUrl(imagePath)
+
+    imageUrl = publicUrlData.publicUrl
+  }
+
+  const { data, error: insertError } = await supabase
+    .from('feedback')
+    .insert({
+      user_id: user.id,
+      type,
+      title,
+      body,
+      image_url: imageUrl,
+      page_url: pageUrl,
+    })
+    .select('id, user_id, type, title, body, image_url, status, votes, created_at, updated_at')
+    .single()
+
+  if (insertError || !data) {
+    if (imagePath) {
+      await supabase.storage.from('feedback-images').remove([imagePath])
+    }
+    return NextResponse.json({ error: 'Unable to submit feedback right now.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data })
+}

--- a/src/app/api/guides/[id]/cover-image/route.ts
+++ b/src/app/api/guides/[id]/cover-image/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { isValidUUID } from '@/lib/validation'
+
+const ALLOWED_IMAGE_HOSTNAMES = ['images.unsplash.com', 'plus.unsplash.com']
+
+function isAllowedUnsplashUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:') return false
+
+    return ALLOWED_IMAGE_HOSTNAMES.some(
+      (host) => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`)
+    )
+  } catch {
+    return false
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: guideId } = await params
+
+  if (!isValidUUID(guideId)) {
+    return NextResponse.json({ error: 'Invalid guide ID' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: guide } = await supabase
+    .from('city_guides')
+    .select('id, user_id')
+    .eq('id', guideId)
+    .single()
+
+  if (!guide || guide.user_id !== user.id) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const payload = (await request.json().catch(() => null)) as { unsplash_url?: unknown } | null
+  const unsplashUrl = typeof payload?.unsplash_url === 'string' ? payload.unsplash_url.trim() : ''
+
+  if (!unsplashUrl) {
+    return NextResponse.json({ error: 'Missing unsplash_url' }, { status: 400 })
+  }
+
+  if (!isAllowedUnsplashUrl(unsplashUrl)) {
+    return NextResponse.json({ error: 'Only Unsplash URLs are allowed' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('city_guides')
+    .update({ cover_image_url: unsplashUrl })
+    .eq('id', guideId)
+    .eq('user_id', user.id)
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to update guide cover image' }, { status: 500 })
+  }
+
+  return NextResponse.json({ cover_image_url: unsplashUrl })
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -134,3 +134,8 @@ body > * {
   position: relative;
   z-index: 2;
 }
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+}

--- a/src/app/guide/[token]/page.tsx
+++ b/src/app/guide/[token]/page.tsx
@@ -15,6 +15,15 @@ type GuideEntryWithAuthor = GuideEntry & {
   author_name?: string | null
 }
 
+function toCoordinate(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
 const CATEGORY_ICONS: Record<string, string> = {
   Coffee: '☕',
   Restaurants: '🍽️',
@@ -98,14 +107,19 @@ export default async function PublicGuidePage({ params, searchParams }: Props) {
   const hasMultipleAuthors =
     new Set(entries.map((entry) => entry.author_id || entry.user_id)).size > 1
   const mapEntries = entries
-    .filter((entry) => typeof entry.latitude === 'number' && typeof entry.longitude === 'number')
-    .map((entry) => ({
-      id: entry.id,
-      name: entry.name,
-      category: entry.category,
-      latitude: entry.latitude as number,
-      longitude: entry.longitude as number,
-    }))
+    .map((entry) => {
+      const latitude = toCoordinate(entry.latitude)
+      const longitude = toCoordinate(entry.longitude)
+      if (latitude === null || longitude === null) return null
+      return {
+        id: entry.id,
+        name: entry.name,
+        category: entry.category,
+        latitude,
+        longitude,
+      }
+    })
+    .filter((entry): entry is { id: string; name: string; category: string; latitude: number; longitude: number } => entry !== null)
   const hasMapEntries = mapEntries.length > 0
   const showMapView = hasMapEntries && view === 'map'
 

--- a/src/components/feedback/feedback-utils.ts
+++ b/src/components/feedback/feedback-utils.ts
@@ -7,6 +7,7 @@ export interface FeedbackBoardItem {
   type: FeedbackType
   title: string
   body: string
+  image_url: string | null
   status: FeedbackStatus
   votes: number
   created_at: string

--- a/src/components/guides/guide-cover-image-picker.tsx
+++ b/src/components/guides/guide-cover-image-picker.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { Loader2, Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface UnsplashResult {
+  urls: {
+    regular: string
+    small: string
+  }
+  alt_description: string | null
+  user: {
+    name: string
+  }
+}
+
+interface GuideCoverImagePickerProps {
+  guideId: string
+  onClose: () => void
+  onSaved: () => void
+}
+
+export function GuideCoverImagePicker({ guideId, onClose, onSaved }: GuideCoverImagePickerProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<UnsplashResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [savingUrl, setSavingUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSearch = async () => {
+    const query = searchQuery.trim()
+    if (!query) return
+
+    setSearching(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/unsplash/search?q=${encodeURIComponent(query)}`)
+      if (!response.ok) {
+        setError('Unable to search photos right now.')
+        setSearchResults([])
+        setSearching(false)
+        return
+      }
+
+      const payload = (await response.json()) as { results?: UnsplashResult[] }
+      setSearchResults(payload.results ?? [])
+    } catch {
+      setError('Unable to search photos right now.')
+      setSearchResults([])
+    }
+
+    setSearching(false)
+  }
+
+  const handlePick = async (url: string) => {
+    if (savingUrl) return
+
+    setSavingUrl(url)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/guides/${guideId}/cover-image`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ unsplash_url: url }),
+      })
+
+      if (!response.ok) {
+        setError('Unable to save cover image.')
+        setSavingUrl(null)
+        return
+      }
+
+      onSaved()
+      onClose()
+    } catch {
+      setError('Unable to save cover image.')
+      setSavingUrl(null)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-3xl rounded-xl bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b p-4">
+          <h3 className="text-lg font-semibold text-gray-900">Pick a cover image</h3>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <div className="flex gap-2">
+            <Input
+              value={searchQuery}
+              placeholder="Search Unsplash photos..."
+              onChange={(event) => setSearchQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  void handleSearch()
+                }
+              }}
+            />
+            <Button onClick={() => void handleSearch()} disabled={searching}>
+              {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+            </Button>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+            {searchResults.map((result) => {
+              const isSaving = savingUrl === result.urls.regular
+              return (
+                <button
+                  key={`${result.urls.regular}-${result.user.name}`}
+                  type="button"
+                  onClick={() => void handlePick(result.urls.regular)}
+                  disabled={Boolean(savingUrl)}
+                  className="group relative aspect-video overflow-hidden rounded-lg border border-gray-200 text-left disabled:opacity-60"
+                >
+                  <Image
+                    src={result.urls.small}
+                    alt={result.alt_description || 'Unsplash photo'}
+                    fill
+                    className="object-cover transition-transform group-hover:scale-105"
+                    sizes="(max-width: 768px) 50vw, 33vw"
+                    unoptimized
+                  />
+                  <div className="absolute inset-x-0 bottom-0 bg-black/55 px-2 py-1 text-xs text-white">
+                    {isSaving ? 'Saving...' : `Photo by ${result.user.name}`}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+
+          {!searching && searchResults.length === 0 && (
+            <p className="py-8 text-center text-sm text-gray-500">Search to see photo options.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/maps/guide-map-section.tsx
+++ b/src/components/maps/guide-map-section.tsx
@@ -20,5 +20,6 @@ const GuideMap = dynamic(
 )
 
 export function GuideMapSection({ entries }: GuideMapSectionProps) {
+  if (entries.length === 0) return null
   return <GuideMap entries={entries} />
 }

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import Image from 'next/image'
 import { createClient } from '@/lib/supabase/client'
 import { Card, CardContent } from '@/components/ui/card'
@@ -34,6 +35,7 @@ import {
   MapPin,
   Clock,
   Hash,
+  Pencil,
 } from 'lucide-react'
 import type { TripItem, Trip, FlightDetails, HotelDetails, TrainDetails, CarRentalDetails, Json } from '@/types/database'
 import { getProviderLogoUrl } from '@/lib/images/provider-logo'
@@ -151,6 +153,9 @@ export function TripItemCard({ item, allTrips }: TripItemCardProps) {
 
   const safeAllTrips = Array.isArray(allTrips) ? allTrips : []
   const otherTrips = safeAllTrips.filter((t) => t.id !== item.trip_id)
+  const sourceEmailId = typeof item.source_email_id === 'string' && item.source_email_id.length > 0
+    ? item.source_email_id
+    : null
 
   return (
     <>
@@ -266,7 +271,30 @@ export function TripItemCard({ item, allTrips }: TripItemCardProps) {
             </div>
 
             {/* Actions */}
-            <div className="relative">
+            <div className="relative flex items-center gap-1">
+              {sourceEmailId ? (
+                <Link href={`/inbox?highlight=${encodeURIComponent(sourceEmailId)}`}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    title="Edit extraction in Inbox"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </Link>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0 text-gray-300"
+                  disabled
+                  title="No source email for this item"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+              )}
+
               <Button
                 variant="ghost"
                 size="sm"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -371,6 +371,7 @@ export interface Database {
           title: string
           body: string
           page_url: string | null
+          image_url: string | null
           status: 'new' | 'under_review' | 'planned' | 'in_progress' | 'shipped' | 'declined'
           votes: number
           admin_notes: string | null
@@ -384,6 +385,7 @@ export interface Database {
           title: string
           body: string
           page_url?: string | null
+          image_url?: string | null
           status?: 'new' | 'under_review' | 'planned' | 'in_progress' | 'shipped' | 'declined'
           votes?: number
           admin_notes?: string | null
@@ -397,6 +399,7 @@ export interface Database {
           title?: string
           body?: string
           page_url?: string | null
+          image_url?: string | null
           status?: 'new' | 'under_review' | 'planned' | 'in_progress' | 'shipped' | 'declined'
           votes?: number
           admin_notes?: string | null

--- a/supabase/migrations/20260301000004_feedback_images.sql
+++ b/supabase/migrations/20260301000004_feedback_images.sql
@@ -1,0 +1,58 @@
+-- PRD 024: Feedback images + storage policies
+
+alter table public.feedback
+  add column if not exists image_url text;
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'feedback-images',
+  'feedback-images',
+  true,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp']::text[]
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- Users can upload images into their own folder: {auth.uid()}/...
+drop policy if exists "feedback_images_insert_own" on storage.objects;
+create policy "feedback_images_insert_own"
+  on storage.objects
+  for insert
+  to authenticated
+  with check (
+    bucket_id = 'feedback-images'
+    and auth.uid() is not null
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+-- Users can update/delete only images in their own folder
+drop policy if exists "feedback_images_update_own" on storage.objects;
+create policy "feedback_images_update_own"
+  on storage.objects
+  for update
+  to authenticated
+  using (
+    bucket_id = 'feedback-images'
+    and auth.uid() is not null
+    and split_part(name, '/', 1) = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'feedback-images'
+    and auth.uid() is not null
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+drop policy if exists "feedback_images_delete_own" on storage.objects;
+create policy "feedback_images_delete_own"
+  on storage.objects
+  for delete
+  to authenticated
+  using (
+    bucket_id = 'feedback-images'
+    and auth.uid() is not null
+    and split_part(name, '/', 1) = auth.uid()::text
+  );


### PR DESCRIPTION
All 3 feedback items from Chris Carlson:

1. **City guide map fix** — hardened coordinate parsing, added map section to guide pages, added cover image picker (Unsplash)
2. **Trip item Edit → Inbox** — pencil icon on trip items links to `/inbox?highlight=<email_id>`, scrolls to and highlights the source email
3. **Feedback image upload** — optional screenshot on submit (5MB, jpg/png/webp), Supabase Storage bucket, auto-cleanup on ship

Migration: `20260301000004_feedback_images.sql` (adds `image_url` to feedback, creates storage bucket + policies)

TSC clean, 88/88 tests pass, lint 0 errors.