### PR TITLE
feat(026): agent onboarding — skill upgrade, API docs, parity CI

### DIFF
--- a/.github/workflows/api-parity.yml
+++ b/.github/workflows/api-parity.yml
@@ -24,7 +24,7 @@ jobs:
           
           while IFS= read -r file; do
             # Convert file path to API path
-            api_path=$(echo "$file" | sed 's|src/app/api/v1/||' | sed 's|/route\.ts$||' | sed 's|\[([^]]*)\]|:\1|g')
+            api_path=$(echo "$file" | sed 's|src/app/api/v1/||' | sed 's|/route\.ts$||' | sed -E 's/\[([^]]+)\]/:\1/g')
             api_path="/api/v1/$api_path"
             
             # Extract HTTP methods

--- a/.github/workflows/api-parity.yml
+++ b/.github/workflows/api-parity.yml
@@ -1,0 +1,84 @@
+name: API Parity Check
+
+on:
+  push:
+    branches: [main, feat/**]
+  pull_request:
+    branches: [main]
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract API surface
+        id: extract
+        run: |
+          # Find all route files and extract HTTP methods + paths
+          REPORT=""
+          MISSING_SKILL=""
+          MISSING_MCP=""
+          
+          while IFS= read -r file; do
+            # Convert file path to API path
+            api_path=$(echo "$file" | sed 's|src/app/api/v1/||' | sed 's|/route\.ts$||' | sed 's|\[([^]]*)\]|:\1|g')
+            api_path="/api/v1/$api_path"
+            
+            # Extract HTTP methods
+            methods=$(grep -oP 'export async function (GET|POST|PUT|PATCH|DELETE)' "$file" | awk '{print $4}' | sort | tr '\n' ',' | sed 's/,$//')
+            
+            if [ -n "$methods" ]; then
+              REPORT="$REPORT\n$methods $api_path"
+              
+              # Check skill coverage
+              # Normalize path for matching: replace :param patterns with generic markers
+              skill_path=$(echo "$api_path" | sed 's|/:[^/]*||g')
+              if ! grep -q "$skill_path" skill/SKILL.md 2>/dev/null; then
+                MISSING_SKILL="$MISSING_SKILL\n- $methods $api_path"
+              fi
+              
+              # Check MCP coverage (best effort)
+              if [ -d "mcp/src" ]; then
+                if ! grep -rq "$(echo "$api_path" | sed 's|/:.*||')" mcp/src/ 2>/dev/null; then
+                  MISSING_MCP="$MISSING_MCP\n- $methods $api_path"
+                fi
+              fi
+            fi
+          done < <(find src/app/api/v1 -name 'route.ts' | sort)
+          
+          # Build comment body
+          COMMENT="## 🔍 API Parity Report\n\n"
+          
+          if [ -n "$MISSING_SKILL" ]; then
+            COMMENT="$COMMENT### ⚠️ Missing from skill/SKILL.md\n$MISSING_SKILL\n\n"
+          else
+            COMMENT="$COMMENT### ✅ skill/SKILL.md covers all endpoints\n\n"
+          fi
+          
+          if [ -n "$MISSING_MCP" ]; then
+            COMMENT="$COMMENT### ⚠️ Possibly missing from mcp/src/\n$MISSING_MCP\n\n"
+          else
+            COMMENT="$COMMENT### ✅ mcp/src/ appears to cover all endpoints\n\n"
+          fi
+          
+          COMMENT="$COMMENT<details><summary>Full API surface</summary>\n\n\`\`\`\n$(echo -e "$REPORT")\n\`\`\`\n</details>"
+          
+          # Save for PR comment
+          echo -e "$COMMENT" > /tmp/parity-report.md
+          
+          # Check if there are issues
+          if [ -n "$MISSING_SKILL" ] || [ -n "$MISSING_MCP" ]; then
+            echo "has_drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && steps.extract.outputs.has_drift == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: api-parity
+          path: /tmp/parity-report.md

--- a/.github/workflows/api-surface-check.yml
+++ b/.github/workflows/api-surface-check.yml
@@ -1,0 +1,29 @@
+name: API Surface Change Reminder
+
+on:
+  pull_request:
+    paths:
+      - 'src/app/api/v1/**'
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remind to update agent tooling
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: api-surface-reminder
+          message: |
+            ## 📡 API Surface Changed
+
+            This PR modifies files under `src/app/api/v1/`. Please ensure the following are updated:
+
+            - [ ] **skill/SKILL.md** — OpenClaw skill documentation
+            - [ ] **mcp/src/** — MCP tool definitions
+            - [ ] **src/app/api/v1/docs/route.ts** — API docs endpoint
+
+            Run the API Parity Check workflow for a detailed report.

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -1,0 +1,293 @@
+import { NextResponse } from 'next/server'
+
+const DOCS = `# UB Trippin API Reference (v1)
+
+Base URL: \`https://www.ubtrippin.xyz\`
+
+## Authentication
+
+All endpoints (unless noted) require a Bearer token:
+
+\`\`\`
+Authorization: Bearer ubt_k1_<your_key>
+\`\`\`
+
+Generate keys at [ubtrippin.xyz/settings](https://www.ubtrippin.xyz/settings).
+
+Rate limit: 100 req/min per key. HTTP 429 → back off 60s.
+
+---
+
+## Trips
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/trips | List all trips (query: ?status=upcoming) |
+| POST | /api/v1/trips | Create a trip |
+| GET | /api/v1/trips/:id | Get trip with all items |
+| PATCH | /api/v1/trips/:id | Update trip |
+| DELETE | /api/v1/trips/:id | Delete trip |
+| POST | /api/v1/trips/:id/rename | Rename trip |
+| POST | /api/v1/trips/:id/merge | Merge another trip into this one |
+| GET | /api/v1/trips/:id/status | Trip processing status |
+| GET | /api/v1/trips/demo | Demo trip (no auth) |
+
+### Example: List Trips
+
+\`\`\`
+GET /api/v1/trips
+Authorization: Bearer ubt_k1_abc123...
+
+200 OK
+{
+  "data": [
+    { "id": "uuid", "title": "Tokyo Spring 2026", "start_date": "2026-04-01", "end_date": "2026-04-14", "primary_location": "Tokyo, Japan" }
+  ],
+  "meta": { "count": 1 }
+}
+\`\`\`
+
+### Example: Create Trip
+
+\`\`\`
+POST /api/v1/trips
+Content-Type: application/json
+Authorization: Bearer ubt_k1_abc123...
+
+{ "title": "Summer in Provence", "start_date": "2026-07-01", "end_date": "2026-07-14" }
+
+201 Created
+{ "data": { "id": "new-uuid", "title": "Summer in Provence", ... } }
+\`\`\`
+
+---
+
+## Items
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/items/:id | Get single item |
+| PATCH | /api/v1/items/:id | Update item |
+| DELETE | /api/v1/items/:id | Delete item |
+| GET | /api/v1/items/:id/status | Item status |
+| POST | /api/v1/items/:id/status/refresh | Refresh live status |
+| POST | /api/v1/trips/:id/items | Add item to trip |
+| POST | /api/v1/trips/:id/items/batch | Batch add items |
+
+Item kinds: flight, hotel, train, car, ferry, activity, other
+
+---
+
+## Loyalty Vault
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/me/loyalty | List my loyalty programs |
+| POST | /api/v1/me/loyalty | Add loyalty program |
+| GET | /api/v1/me/loyalty/lookup?provider_key=X | Lookup by provider |
+| GET | /api/v1/me/loyalty/export | Export all loyalty data |
+| PATCH | /api/v1/me/loyalty/:id | Update loyalty program |
+| DELETE | /api/v1/me/loyalty/:id | Delete loyalty program |
+| GET | /api/v1/loyalty/providers | List known providers (no auth) |
+
+### Example: Lookup Loyalty Number
+
+\`\`\`
+GET /api/v1/me/loyalty/lookup?provider_key=delta_skymiles
+Authorization: Bearer ubt_k1_abc123...
+
+200 OK
+{ "data": { "provider_key": "delta_skymiles", "member_number": "1234567890", "tier": "Gold" } }
+\`\`\`
+
+---
+
+## Profile
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/me/profile | Get my profile |
+| PUT | /api/v1/me/profile | Update my profile |
+| POST | /api/v1/me/profile | Update my profile (alias) |
+
+---
+
+## Family
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/families | List my families |
+| POST | /api/v1/families | Create family |
+| GET | /api/v1/families/:id | Get family |
+| PATCH | /api/v1/families/:id | Update family |
+| DELETE | /api/v1/families/:id | Delete family |
+| POST | /api/v1/families/:id/members | Invite member |
+| DELETE | /api/v1/families/:id/members/:uid | Remove member |
+| GET | /api/v1/families/:id/profiles | Member profiles |
+| GET | /api/v1/families/:id/trips | Family trips |
+| GET | /api/v1/families/:id/loyalty | Family loyalty programs |
+| GET | /api/v1/families/:id/loyalty/lookup?provider_key=X | Family loyalty lookup |
+| GET | /api/v1/families/:id/guides | Family city guides |
+| GET | /api/v1/family-invites/:token | View family invite |
+| POST | /api/v1/family-invites/:token/accept | Accept family invite |
+
+---
+
+## Collaborators (Trip Sharing)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/trips/:id/collaborators | List collaborators |
+| POST | /api/v1/trips/:id/collaborators | Invite collaborator |
+| PATCH | /api/v1/trips/:id/collaborators/:uid | Update role |
+| DELETE | /api/v1/trips/:id/collaborators/:uid | Remove collaborator |
+| GET | /api/v1/invites/:token | View trip invite |
+| POST | /api/v1/invites/:token/accept | Accept trip invite |
+
+---
+
+## City Guides
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/guides | List guides |
+| POST | /api/v1/guides | Create guide |
+| GET | /api/v1/guides/:id | Get guide |
+| PATCH | /api/v1/guides/:id | Update guide |
+| DELETE | /api/v1/guides/:id | Delete guide |
+| GET | /api/v1/guides/:id/entries | List entries |
+| POST | /api/v1/guides/:id/entries | Add entry |
+| PATCH | /api/v1/guides/:id/entries/:eid | Update entry |
+| DELETE | /api/v1/guides/:id/entries/:eid | Delete entry |
+| GET | /api/v1/guides/nearby?lat=X&lng=Y | Nearby guides |
+
+---
+
+## Senders
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/settings/senders | List allowed senders |
+| POST | /api/v1/settings/senders | Add sender |
+| DELETE | /api/v1/settings/senders/:id | Remove sender |
+
+---
+
+## Calendar
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/calendar/token | Get iCal subscription URL |
+| POST | /api/v1/calendar/token | Regenerate token |
+
+---
+
+## Notifications
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/notifications | List notifications (?unread=true) |
+| PATCH | /api/v1/notifications/:id | Mark read |
+
+---
+
+## Webhooks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/webhooks | List webhooks |
+| POST | /api/v1/webhooks | Create webhook |
+| GET | /api/v1/webhooks/:id | Get webhook |
+| PATCH | /api/v1/webhooks/:id | Update webhook |
+| DELETE | /api/v1/webhooks/:id | Delete webhook |
+| POST | /api/v1/webhooks/:id/test | Test webhook |
+| GET | /api/v1/webhooks/:id/deliveries | List deliveries |
+
+---
+
+## Trains
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/trains/:trainNumber/status | Real-time train status |
+
+---
+
+## Images
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/images/search?q=X | Search destination images |
+
+---
+
+## Imports
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/imports | List imports |
+| POST | /api/v1/imports | Create import |
+| GET | /api/v1/imports/:id | Get import |
+
+---
+
+## Billing
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/billing/subscription | Current subscription |
+| GET | /api/v1/billing/portal | Stripe billing portal URL |
+| GET | /api/v1/billing/prices | Available plans/pricing |
+| POST | /api/v1/checkout | Create checkout session |
+
+---
+
+## Activation
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/v1/activation/status | Account activation status |
+
+---
+
+## Common Agent Workflows
+
+1. **Get upcoming trips:** \`GET /api/v1/trips\` → filter by start_date >= today
+2. **Full itinerary:** \`GET /api/v1/trips/:id\` → items sorted by start_ts
+3. **Loyalty lookup:** \`GET /api/v1/me/loyalty/lookup?provider_key=delta_skymiles\`
+4. **Add booking:** Forward confirmation email to trips@ubtrippin.xyz from registered sender
+5. **Family loyalty:** \`GET /api/v1/families/:id/loyalty/lookup?provider_key=X\`
+6. **Share trip:** \`POST /api/v1/trips/:id/collaborators\` with email + role
+7. **Train status:** \`GET /api/v1/trains/:number/status\`
+8. **Calendar sync:** \`GET /api/v1/calendar/token\` → iCal URL
+
+---
+
+## Error Codes
+
+| Status | Code | Meaning |
+|--------|------|---------|
+| 400 | invalid_param | Bad input or missing field |
+| 401 | unauthorized | Missing/invalid API key |
+| 404 | not_found | Resource not found or access denied |
+| 429 | — | Rate limited (wait 60s) |
+| 500 | internal_error | Server error (retry once) |
+
+All errors: \`{ "error": { "code": "...", "message": "..." } }\`
+
+---
+
+## Notes
+
+- All IDs are UUIDs
+- Dates: ISO 8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ)
+- \`details_json\` on items contains parsed booking data (confirmation #, seats, etc.)
+- \`confidence\` (0-1) indicates parser confidence; \`needs_review: true\` = may have errors
+`
+
+export async function GET() {
+  return new NextResponse(DOCS, {
+    status: 200,
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
## PRD 026 — Agent Onboarding (Phases 1, 4, 5)

### Phase 1: Skill Upgrade (v1.0.0 → v2.0.0)
- Updated `skill/SKILL.md` to cover ALL API endpoints (was only trips/items/email forwarding)
- Added: loyalty vault, profile, family, collaborators, city guides, senders, calendar, notifications, webhooks, trains, images, imports, billing, activation
- Added agent workflow examples for new capabilities
- Bumped version to 2.0.0

### Phase 4: API Docs Endpoint
- Created `GET /api/v1/docs` — public, no auth, returns complete API reference as markdown
- Static content, read-only, Content-Type: text/markdown

### Phase 5: Parity Enforcement
- `api-parity.yml` — scans route files, checks skill + MCP coverage, posts warning comment on PRs if drift detected
- `api-surface-check.yml` — on PRs touching `src/app/api/v1/**`, adds reminder to update skill/MCP/docs