### PR TITLE
fix: fallback to trip title for cover image when location too obscure

### DIFF
--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -437,7 +437,7 @@ export async function POST(request: NextRequest) {
 
               console.log('Cleaned location:', cleanLocation)
               if (cleanLocation) {
-                const coverImageUrl = await getDestinationImageUrl(cleanLocation)
+                const coverImageUrl = await getDestinationImageUrl(cleanLocation, smartTitle)
                 console.log('Cover image URL:', coverImageUrl)
                 if (coverImageUrl) {
                   await supabase

--- a/src/lib/images/unsplash.ts
+++ b/src/lib/images/unsplash.ts
@@ -179,6 +179,7 @@ export async function getDestinationImageUrl(location: string, tripTitle?: strin
           .replace(/trip to /i, '')
           .replace(/\s*-\s*\w{3}\s+\d{4}$/i, '') // Remove " - Apr 2026" suffix
           .trim()
+          .slice(0, 100) // Cap length — don't leak long AI titles to third-party API
         console.log('Trying fallback with trip title:', titleQuery)
         const fallbackParams = new URLSearchParams({
           query: `${titleQuery} travel`,


### PR DESCRIPTION
## Problem

When a hotel booking with an obscure location name was forwarded, the auto-created trip got no cover image. Unsplash returns zero results for niche venue names.

## Fix

`getDestinationImageUrl` now accepts an optional `tripTitle` parameter. When the location-based search returns no results, it falls back to searching with the AI-generated trip title (e.g. 'Japan Hot Springs Getaway travel'). Trip titles typically contain country/region context that yields good cover images.

**Tested:** Obscure venue name → 0 Unsplash results. AI trip title → 40 results ✅