### PR TITLE
fix: dashboard footer links + inbox mobile layout

### DIFF
--- a/src/app/(dashboard)/inbox/[id]/page.tsx
+++ b/src/app/(dashboard)/inbox/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function EmailDetailPage({ params }: EmailDetailPageProps) 
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
+    <div className="mx-auto max-w-4xl min-w-0 space-y-4 sm:space-y-6">
       {/* Back link */}
       <Link
         href="/inbox"

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import Link from 'next/link'
 import { DashboardNav } from '@/components/dashboard-nav'
 import { UpgradeBanner } from '@/components/billing/upgrade-banner'
 
@@ -33,6 +34,17 @@ export default async function DashboardLayout({
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </main>
+      <footer className="mx-auto w-full max-w-7xl px-4 pb-6 text-xs text-gray-500 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-3 border-t border-gray-200 pt-4">
+          <Link href="/privacy" className="hover:text-gray-700 transition-colors">
+            Privacy Policy
+          </Link>
+          <span aria-hidden="true">•</span>
+          <Link href="/terms" className="hover:text-gray-700 transition-colors">
+            Terms of Service
+          </Link>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/components/email/attachment-viewer.tsx
+++ b/src/components/email/attachment-viewer.tsx
@@ -18,8 +18,8 @@ export function AttachmentViewer({ attachmentText, attachments }: AttachmentView
 
   return (
     <div className="mt-4 pt-4 border-t">
-      <div className="flex items-center justify-between mb-2">
-        <h4 className="text-sm font-medium text-gray-700 flex items-center gap-2">
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h4 className="flex items-center gap-2 text-sm font-medium text-gray-700">
           <FileText className="h-4 w-4" />
           Attachments ({attachments.length})
         </h4>
@@ -28,7 +28,7 @@ export function AttachmentViewer({ attachmentText, attachments }: AttachmentView
             variant="ghost"
             size="sm"
             onClick={() => setIsExpanded(!isExpanded)}
-            className="text-xs"
+            className="h-auto justify-start px-0 py-1 text-xs sm:h-8 sm:px-3 sm:justify-center"
           >
             {isExpanded ? (
               <>
@@ -50,11 +50,13 @@ export function AttachmentViewer({ attachmentText, attachments }: AttachmentView
         {attachments.map((att, index) => (
           <div
             key={index}
-            className="text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded flex items-center gap-2"
+            className="flex items-start gap-2 rounded bg-gray-50 px-2 py-1 text-xs text-gray-600"
           >
-            <FileText className="h-3 w-3" />
-            {att.filename}
-            <span className="text-gray-400">({att.content_type})</span>
+            <FileText className="h-3 w-3 shrink-0" />
+            <span className="min-w-0 break-all">
+              {att.filename}{' '}
+              <span className="text-gray-400">({att.content_type})</span>
+            </span>
           </div>
         ))}
       </div>

--- a/src/components/email/email-correction-view.tsx
+++ b/src/components/email/email-correction-view.tsx
@@ -82,18 +82,18 @@ export function EmailCorrectionView({ email }: EmailCorrectionViewProps) {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0">
           <h1 className="text-xl font-bold text-gray-900">
             {email.subject || '(no subject)'}
           </h1>
-          <div className="mt-1 flex items-center gap-3 text-sm text-gray-600">
-            <span>From: {email.from_email}</span>
-            <span>•</span>
+          <div className="mt-1 flex flex-col gap-1 text-sm text-gray-600 sm:flex-row sm:items-center sm:gap-3">
+            <span className="break-all">From: {email.from_email}</span>
+            <span className="hidden sm:inline">•</span>
             <span>{formatDateTime(email.received_at)}</span>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 self-start">
           {saveSuccess && (
             <span className="text-sm text-green-600">Saved!</span>
           )}
@@ -115,26 +115,28 @@ export function EmailCorrectionView({ email }: EmailCorrectionViewProps) {
 
       {/* Actions */}
       {email.parse_status !== 'processing' && (
-        <ReparseButton emailId={email.id} />
+        <div className="w-full sm:w-auto">
+          <ReparseButton emailId={email.id} />
+        </div>
       )}
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Email content */}
         <Card>
-          <CardHeader>
+          <CardHeader className="p-4 sm:p-6">
             <CardTitle className="flex items-center gap-2">
               <Mail className="h-5 w-5" />
               Email Content
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
             {email.body_text ? (
-              <div className="max-h-96 overflow-y-auto rounded-lg bg-gray-50 p-4 text-sm font-mono whitespace-pre-wrap">
+              <div className="max-h-96 overflow-x-auto overflow-y-auto rounded-lg bg-gray-50 p-3 text-sm font-mono whitespace-pre-wrap break-words sm:p-4">
                 {email.body_text}
               </div>
             ) : email.body_html ? (
               <div
-                className="max-h-96 overflow-y-auto rounded-lg bg-gray-50 p-4 text-sm prose prose-sm"
+                className="prose prose-sm max-h-96 overflow-x-auto overflow-y-auto rounded-lg bg-gray-50 p-3 text-sm break-words sm:p-4"
                 dangerouslySetInnerHTML={{ __html: sanitizeHtml(email.body_html) }}
               />
             ) : (
@@ -150,18 +152,18 @@ export function EmailCorrectionView({ email }: EmailCorrectionViewProps) {
 
         {/* Extracted data - Editable */}
         <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+          <CardHeader className="p-4 sm:p-6">
+            <CardTitle className="flex flex-wrap items-center gap-2">
               <FileText className="h-5 w-5" />
               Extracted Data
               {email.extracted_json?.overall_confidence !== undefined && (
-                <span className="ml-auto text-sm font-normal text-gray-500">
+                <span className="text-sm font-normal text-gray-500 sm:ml-auto">
                   {Math.round(email.extracted_json.overall_confidence * 100)}% confidence
                 </span>
               )}
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
             {email.parse_error && (
               <div className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-600">
                 <p>{email.parse_error}</p>
@@ -192,14 +194,14 @@ export function EmailCorrectionView({ email }: EmailCorrectionViewProps) {
       {/* Auth results */}
       {email.auth_results && (
         <Card>
-          <CardHeader>
+          <CardHeader className="p-4 sm:p-6">
             <CardTitle className="flex items-center gap-2">
               <Shield className="h-5 w-5" />
               Email Authentication
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="flex gap-4 text-sm">
+          <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
+            <div className="flex flex-wrap gap-4 text-sm">
               <div className="flex items-center gap-2">
                 <span className="text-gray-500">SPF:</span>
                 <Badge variant={email.auth_results.spf === 'pass' ? 'success' : 'secondary'}>

--- a/src/components/email/extraction-editor.tsx
+++ b/src/components/email/extraction-editor.tsx
@@ -105,9 +105,9 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
     <div className="space-y-4">
       {items.map((item, index) => (
         <Card key={index} className="relative">
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-base flex items-center gap-2">
+          <CardHeader className="p-4 pb-3 sm:p-6 sm:pb-3">
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle className="flex items-center gap-2 text-base">
                 <span className="font-medium">Item {index + 1}</span>
                 {item.confidence < 0.65 && (
                   <span className="text-xs text-[#4f46e5] bg-[#ffffff] px-2 py-0.5 rounded">
@@ -125,9 +125,9 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
               </Button>
             </div>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-4 p-4 pt-0 sm:p-6 sm:pt-0">
             {/* Row 1: Kind and Status */}
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className="text-xs text-gray-500 mb-1 block">Type</label>
                 <Select
@@ -157,7 +157,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             </div>
 
             {/* Row 2: Provider and Confirmation */}
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className="text-xs text-gray-500 mb-1 block">Provider</label>
                 <Input
@@ -178,7 +178,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             </div>
 
             {/* Row 3: Dates */}
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className="text-xs text-gray-500 mb-1 block">Start Date</label>
                 <Input
@@ -198,7 +198,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             </div>
 
             {/* Row 4: Times */}
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className="text-xs text-gray-500 mb-1 block">Departure Time</label>
                 <Input
@@ -218,7 +218,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             </div>
 
             {/* Row 5: Locations */}
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className="text-xs text-gray-500 mb-1 block">
                   {item.kind === 'flight' ? 'Departure' : 'Location'}
@@ -253,7 +253,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
 
             {/* Kind-specific details */}
             {item.kind === 'flight' && (
-              <div className="grid grid-cols-3 gap-3 pt-2 border-t">
+              <div className="grid grid-cols-1 gap-3 border-t pt-2 sm:grid-cols-3">
                 <div>
                   <label className="text-xs text-gray-500 mb-1 block">Flight Number</label>
                   <Input
@@ -283,7 +283,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             )}
 
             {item.kind === 'hotel' && (
-              <div className="grid grid-cols-2 gap-3 pt-2 border-t">
+              <div className="grid grid-cols-1 gap-3 border-t pt-2 sm:grid-cols-2">
                 <div>
                   <label className="text-xs text-gray-500 mb-1 block">Room Type</label>
                   <Input
@@ -304,7 +304,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
             )}
 
             {item.kind === 'train' && (
-              <div className="grid grid-cols-2 gap-3 pt-2 border-t">
+              <div className="grid grid-cols-1 gap-3 border-t pt-2 sm:grid-cols-2">
                 <div>
                   <label className="text-xs text-gray-500 mb-1 block">Train Number</label>
                   <Input
@@ -345,8 +345,8 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
       </Button>
 
       {/* Save section */}
-      <div className="flex items-center justify-between pt-4 border-t">
-        <label className="flex items-center gap-2 text-sm">
+      <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <label className="flex items-start gap-2 text-sm sm:items-center">
           <input
             type="checkbox"
             checked={createExample}
@@ -356,7 +356,7 @@ export function ExtractionEditor({ items, onChange, onSave, isSaving }: Extracti
           <Sparkles className="h-4 w-4 text-[#4f46e5]" />
           Save as learning example
         </label>
-        <Button onClick={() => onSave(createExample)} disabled={isSaving}>
+        <Button onClick={() => onSave(createExample)} disabled={isSaving} className="w-full sm:w-auto">
           <Save className="h-4 w-4 mr-2" />
           {isSaving ? 'Saving...' : 'Save Corrections'}
         </Button>

--- a/src/components/email/reparse-button.tsx
+++ b/src/components/email/reparse-button.tsx
@@ -37,6 +37,7 @@ export function ReparseButton({ emailId }: ReparseButtonProps) {
       size="sm"
       onClick={handleReparse}
       disabled={loading}
+      className="w-full justify-center sm:w-auto"
     >
       <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
       {loading ? 'Re-parsing...' : 'Re-parse email'}


### PR DESCRIPTION
Addresses 2 user feedback items from /feedback:

**1. Privacy/ToS links (9b77e0cc)**
Logged-in users couldn't find Privacy Policy or Terms of Service. Added a minimal footer to the dashboard layout with links.

**2. Inbox detail mobile (a40e8634)**
Inbox detail/edit page wasn't mobile-friendly. Added responsive Tailwind classes for proper stacking, full-width inputs, and better spacing on small screens.