### PR TITLE
PRD-033: Supabase Health — RLS perf, policy consolidation, indexes, code refactor

### DIFF
--- a/scripts/backfill-local-times.ts
+++ b/scripts/backfill-local-times.ts
@@ -1,0 +1,149 @@
+import { createSecretClient } from '@/lib/supabase/service'
+import { extractLocalTime } from '@/lib/utils'
+
+type ExtractedEmailItem = {
+  kind?: string | null
+  provider?: string | null
+  confirmation_code?: string | null
+  start_date?: string | null
+  end_date?: string | null
+  start_ts?: string | null
+  end_ts?: string | null
+}
+
+type TripItemRow = {
+  id: string
+  kind: string
+  provider: string | null
+  confirmation_code: string | null
+  start_date: string | null
+  end_date: string | null
+  start_ts: string | null
+  end_ts: string | null
+  details_json: Record<string, unknown> | null
+  source_email_id: string | null
+  source_emails: { extracted_json?: { items?: ExtractedEmailItem[] } | null } | null
+}
+
+function same(a: string | null | undefined, b: string | null | undefined): boolean {
+  return (a || null) === (b || null)
+}
+
+function findSourceItem(row: TripItemRow): ExtractedEmailItem | null {
+  const items = row.source_emails?.extracted_json?.items
+  if (!Array.isArray(items)) return null
+
+  const exact = items.find((item) =>
+    same(item.kind, row.kind) &&
+    same(item.provider, row.provider) &&
+    same(item.confirmation_code, row.confirmation_code) &&
+    same(item.start_ts, row.start_ts) &&
+    same(item.end_ts, row.end_ts)
+  )
+  if (exact) return exact
+
+  const byTime = items.find((item) =>
+    same(item.kind, row.kind) &&
+    same(item.start_ts, row.start_ts) &&
+    same(item.end_ts, row.end_ts)
+  )
+  if (byTime) return byTime
+
+  const byDate = items.find((item) =>
+    same(item.kind, row.kind) &&
+    same(item.start_date, row.start_date) &&
+    same(item.end_date, row.end_date)
+  )
+  return byDate || null
+}
+
+async function main() {
+  const supabase = createSecretClient()
+
+  const { data, error } = await supabase
+    .from('trip_items')
+    .select(`
+      id,
+      kind,
+      provider,
+      confirmation_code,
+      start_date,
+      end_date,
+      start_ts,
+      end_ts,
+      details_json,
+      source_email_id,
+      source_emails!inner(extracted_json)
+    `)
+    .in('kind', ['flight', 'train'])
+    .not('source_email_id', 'is', null)
+
+  if (error) {
+    throw new Error(`Failed to fetch items: ${error.message}`)
+  }
+
+  const rows = (data ?? []) as TripItemRow[]
+  let scanned = 0
+  let updated = 0
+  let skipped = 0
+
+  for (const row of rows) {
+    scanned++
+
+    const details = { ...(row.details_json || {}) }
+    const hasDeparture = typeof details.departure_local_time === 'string' && details.departure_local_time.length > 0
+    const hasArrival = typeof details.arrival_local_time === 'string' && details.arrival_local_time.length > 0
+
+    if (hasDeparture && hasArrival) {
+      skipped++
+      continue
+    }
+
+    const sourceItem = findSourceItem(row)
+    if (!sourceItem) {
+      skipped++
+      continue
+    }
+
+    let changed = false
+
+    if (!hasDeparture) {
+      const departureLocal = extractLocalTime(sourceItem.start_ts ?? row.start_ts)
+      if (departureLocal) {
+        details.departure_local_time = departureLocal
+        changed = true
+      }
+    }
+
+    if (!hasArrival) {
+      const arrivalLocal = extractLocalTime(sourceItem.end_ts ?? row.end_ts)
+      if (arrivalLocal) {
+        details.arrival_local_time = arrivalLocal
+        changed = true
+      }
+    }
+
+    if (!changed) {
+      skipped++
+      continue
+    }
+
+    const { error: updateError } = await supabase
+      .from('trip_items')
+      .update({ details_json: details })
+      .eq('id', row.id)
+
+    if (updateError) {
+      throw new Error(`Failed to update item ${row.id}: ${updateError.message}`)
+    }
+
+    updated++
+  }
+
+  console.log(JSON.stringify({ scanned, updated, skipped }, null, 2))
+}
+
+main().catch((error) => {
+  console.error('[backfill-local-times] failed:', error)
+  process.exit(1)
+})

--- a/src/app/api/emails/[id]/corrections/route.ts
+++ b/src/app/api/emails/[id]/corrections/route.ts
@@ -4,6 +4,7 @@ import { createSecretClient } from '@/lib/supabase/service'
 import { createEmailSnippet } from '@/lib/ai/example-selection'
 import type { ExtractedItem } from '@/lib/ai/extract-travel-data'
 import type { Json } from '@/types/database'
+import { extractLocalTime } from '@/lib/utils'
 import { isValidUUID } from '@/lib/validation'
 
 interface CorrectionRequest {
@@ -237,6 +238,19 @@ async function syncTripItems(
   emailId: string,
   items: ExtractedItem[]
 ) {
+  const buildDetails = (item: ExtractedItem): Record<string, unknown> => {
+    const details = { ...((item.details as Record<string, unknown>) || {}) }
+    if (item.kind === 'flight' || item.kind === 'train') {
+      if (!details.departure_local_time && item.start_ts) {
+        details.departure_local_time = extractLocalTime(item.start_ts)
+      }
+      if (!details.arrival_local_time && item.end_ts) {
+        details.arrival_local_time = extractLocalTime(item.end_ts)
+      }
+    }
+    return details
+  }
+
   // Get existing trip items for this email
   const { data: existingItems } = await supabase
     .from('trip_items')
@@ -266,7 +280,7 @@ async function syncTripItems(
           start_location: item.start_location,
           end_location: item.end_location,
           summary: item.summary,
-          details_json: item.details || {},
+          details_json: buildDetails(item),
           status: item.status,
           confidence: 1.0, // User-corrected = high confidence
           needs_review: false,
@@ -316,7 +330,7 @@ async function syncTripItems(
           start_location: item.start_location,
           end_location: item.end_location,
           summary: item.summary,
-          details_json: item.details || {},
+          details_json: buildDetails(item),
           status: item.status,
           confidence: 1.0,
           needs_review: false,

--- a/src/app/api/emails/[id]/corrections/route.ts
+++ b/src/app/api/emails/[id]/corrections/route.ts
@@ -4,7 +4,7 @@ import { createSecretClient } from '@/lib/supabase/service'
 import { createEmailSnippet } from '@/lib/ai/example-selection'
 import type { ExtractedItem } from '@/lib/ai/extract-travel-data'
 import type { Json } from '@/types/database'
-import { extractLocalTime } from '@/lib/utils'
+import { buildTripItemDetails } from '@/lib/utils'
 import { isValidUUID } from '@/lib/validation'
 
 interface CorrectionRequest {
@@ -238,19 +238,6 @@ async function syncTripItems(
   emailId: string,
   items: ExtractedItem[]
 ) {
-  const buildDetails = (item: ExtractedItem): Record<string, unknown> => {
-    const details = { ...((item.details as Record<string, unknown>) || {}) }
-    if (item.kind === 'flight' || item.kind === 'train') {
-      if (!details.departure_local_time && item.start_ts) {
-        details.departure_local_time = extractLocalTime(item.start_ts)
-      }
-      if (!details.arrival_local_time && item.end_ts) {
-        details.arrival_local_time = extractLocalTime(item.end_ts)
-      }
-    }
-    return details
-  }
-
   // Get existing trip items for this email
   const { data: existingItems } = await supabase
     .from('trip_items')
@@ -280,7 +267,7 @@ async function syncTripItems(
           start_location: item.start_location,
           end_location: item.end_location,
           summary: item.summary,
-          details_json: buildDetails(item),
+          details_json: buildTripItemDetails(item),
           status: item.status,
           confidence: 1.0, // User-corrected = high confidence
           needs_review: false,
@@ -330,7 +317,7 @@ async function syncTripItems(
           start_location: item.start_location,
           end_location: item.end_location,
           summary: item.summary,
-          details_json: buildDetails(item),
+          details_json: buildTripItemDetails(item),
           status: item.status,
           confidence: 1.0,
           needs_review: false,

--- a/src/app/api/emails/[id]/reparse/route.ts
+++ b/src/app/api/emails/[id]/reparse/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createSecretClient } from '@/lib/supabase/service'
 import { extractTravelData } from '@/lib/ai/extract-travel-data'
 import { assignToTrip, updateTripDates, collectTravelerNames } from '@/lib/trips/assignment'
+import { extractLocalTime } from '@/lib/utils'
 import { isValidUUID } from '@/lib/validation'
 
 export async function POST(
@@ -112,6 +113,16 @@ export async function POST(
       }
 
       // Create trip item
+      const details = { ...((item.details as Record<string, unknown>) || {}) }
+      if (item.kind === 'flight' || item.kind === 'train') {
+        if (!details.departure_local_time && item.start_ts) {
+          details.departure_local_time = extractLocalTime(item.start_ts)
+        }
+        if (!details.arrival_local_time && item.end_ts) {
+          details.arrival_local_time = extractLocalTime(item.end_ts)
+        }
+      }
+
       const { error: itemError } = await secretClient.from('trip_items').insert({
         user_id: user.id,
         trip_id: tripId,
@@ -126,7 +137,7 @@ export async function POST(
         start_location: item.start_location,
         end_location: item.end_location,
         summary: item.summary,
-        details_json: item.details || {},
+        details_json: details,
         status: item.status,
         confidence: item.confidence,
         needs_review: item.needs_review,

--- a/src/app/api/emails/[id]/reparse/route.ts
+++ b/src/app/api/emails/[id]/reparse/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createSecretClient } from '@/lib/supabase/service'
 import { extractTravelData } from '@/lib/ai/extract-travel-data'
 import { assignToTrip, updateTripDates, collectTravelerNames } from '@/lib/trips/assignment'
-import { extractLocalTime } from '@/lib/utils'
+import { buildTripItemDetails } from '@/lib/utils'
 import { isValidUUID } from '@/lib/validation'
 
 export async function POST(
@@ -113,15 +113,7 @@ export async function POST(
       }
 
       // Create trip item
-      const details = { ...((item.details as Record<string, unknown>) || {}) }
-      if (item.kind === 'flight' || item.kind === 'train') {
-        if (!details.departure_local_time && item.start_ts) {
-          details.departure_local_time = extractLocalTime(item.start_ts)
-        }
-        if (!details.arrival_local_time && item.end_ts) {
-          details.arrival_local_time = extractLocalTime(item.end_ts)
-        }
-      }
+      const details = buildTripItemDetails(item)
 
       const { error: itemError } = await secretClient.from('trip_items').insert({
         user_id: user.id,

--- a/src/app/api/v1/families/[id]/guides/route.ts
+++ b/src/app/api/v1/families/[id]/guides/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { requireFamilyAccess } from '../_lib'
 
 type Params = { params: Promise<{ id: string }> }
@@ -70,9 +70,9 @@ export async function GET(_request: NextRequest, { params }: Params) {
     )
   }
 
-  const secret = createSecretClient()
+  const scoped = await createUserScopedClient(access.ctx.viewerId)
   const { data: profileRows } = memberUserIds.length
-    ? await secret
+    ? await scoped
         .from('profiles')
         .select('id, full_name, email')
         .in('id', memberUserIds)

--- a/src/app/api/v1/families/[id]/loyalty/route.ts
+++ b/src/app/api/v1/families/[id]/loyalty/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { decryptLoyaltyNumber } from '@/lib/loyalty-crypto'
 import { requireFamilyAccess } from '../_lib'
 
@@ -31,11 +31,8 @@ export async function GET(_request: NextRequest, { params }: Params) {
 
   const memberUserIds = Array.from(new Set(access.ctx.members.map((member) => member.user_id)))
 
-  // Use service client for cross-user family loyalty lookup.
-  // Auth is already verified: requireFamilyAccess confirms the viewer
-  // is an accepted member of this family before we reach this point.
-  const service = createSecretClient()
-  const { data: loyaltyRows, error: loyaltyError } = await service
+  const scoped = await createUserScopedClient(access.ctx.viewerId)
+  const { data: loyaltyRows, error: loyaltyError } = await scoped
     .from('loyalty_programs')
     .select('id, user_id, traveler_name, provider_name, provider_key, program_number_encrypted, program_number_masked, preferred, updated_at, created_at')
     .in('user_id', memberUserIds)
@@ -51,7 +48,7 @@ export async function GET(_request: NextRequest, { params }: Params) {
   }
 
   const { data: profileRows } = memberUserIds.length
-    ? await service
+    ? await scoped
         .from('profiles')
         .select('id, full_name, email')
         .in('id', memberUserIds)

--- a/src/app/api/v1/families/[id]/profiles/route.ts
+++ b/src/app/api/v1/families/[id]/profiles/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { requireFamilyAccess } from '../_lib'
 
 type Params = { params: Promise<{ id: string }> }
@@ -28,18 +28,18 @@ export async function GET(_request: NextRequest, { params }: Params) {
   if ('response' in access) return access.response
 
   const memberUserIds = Array.from(new Set(access.ctx.members.map((member) => member.user_id)))
-  const secret = createSecretClient()
+  const scoped = await createUserScopedClient(access.ctx.viewerId)
 
   const [{ data: profileRows, error: profilesError }, { data: userProfileRows, error: userProfilesError }] =
     await Promise.all([
       memberUserIds.length
-        ? secret
+        ? scoped
             .from('profiles')
             .select('id, full_name, email, avatar_url')
             .in('id', memberUserIds)
         : Promise.resolve({ data: [], error: null }),
       memberUserIds.length
-        ? secret
+        ? scoped
             .from('user_profiles')
             .select('id, seat_preference, meal_preference, airline_alliance, hotel_brand_preference, home_airport, currency_preference, notes')
             .in('id', memberUserIds)

--- a/src/app/api/v1/families/[id]/route.ts
+++ b/src/app/api/v1/families/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 
 function normalizeFamilyName(value: unknown): string | null {
@@ -83,9 +83,9 @@ export async function GET(_request: NextRequest, { params }: Params) {
     profileIds.add(member.invited_by)
   }
 
-  const secret = createSecretClient()
+  const scoped = await createUserScopedClient(auth.userId)
   const { data: profileRows } = profileIds.size
-    ? await secret
+    ? await scoped
         .from('profiles')
         .select('id, full_name, email, avatar_url')
         .in('id', Array.from(profileIds))

--- a/src/app/api/v1/families/[id]/trips/route.ts
+++ b/src/app/api/v1/families/[id]/trips/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSecretClient } from '@/lib/supabase/service'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { requireFamilyAccess } from '../_lib'
 
 type Params = { params: Promise<{ id: string }> }
@@ -99,9 +99,9 @@ export async function GET(request: NextRequest, { params }: Params) {
     )
   }
 
-  const secret = createSecretClient()
+  const scoped = await createUserScopedClient(access.ctx.viewerId)
   const { data: profileRows } = memberUserIds.length
-    ? await secret
+    ? await scoped
         .from('profiles')
         .select('id, full_name, email')
         .in('id', memberUserIds)

--- a/src/app/api/v1/inbox/[emailId]/attachments/[index]/route.ts
+++ b/src/app/api/v1/inbox/[emailId]/attachments/[index]/route.ts
@@ -7,11 +7,8 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createClient as createServiceClient } from '@supabase/supabase-js'
+import { createSecretClient } from '@/lib/supabase/service'
 import { isValidUUID } from '@/lib/validation'
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY!
 
 interface StoredAttachment {
   filename: string
@@ -62,7 +59,7 @@ export async function GET(
     )
   }
 
-  const service = createServiceClient(SUPABASE_URL, SUPABASE_SECRET_KEY)
+  const service = createSecretClient()
   const { data, error } = await service.storage
     .from('email-attachments')
     .createSignedUrl(attachment.storage_path, 3600)

--- a/src/app/api/v1/trips/[id]/items/[itemId]/ticket-pdf/route.ts
+++ b/src/app/api/v1/trips/[id]/items/[itemId]/ticket-pdf/route.ts
@@ -8,11 +8,8 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createClient as createServiceClient } from '@supabase/supabase-js'
+import { createSecretClient } from '@/lib/supabase/service'
 import { isValidUUID } from '@/lib/validation'
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const SUPABASE_SECRET_KEY = process.env.SUPABASE_SECRET_KEY!
 
 export async function GET(
   _request: NextRequest,
@@ -58,7 +55,7 @@ export async function GET(
   const bucket = (details?.ticket_pdf_bucket as string) || 'ticket-attachments'
 
   // Generate a 1-hour signed URL using service client
-  const service = createServiceClient(SUPABASE_URL, SUPABASE_SECRET_KEY)
+  const service = createSecretClient()
   const { data, error } = await service.storage
     .from(bucket)
     .createSignedUrl(pdfPath, 3600) // 1 hour

--- a/src/app/api/v1/trips/[id]/items/batch/route.ts
+++ b/src/app/api/v1/trips/[id]/items/batch/route.ts
@@ -180,6 +180,7 @@ export async function POST(
 
   for (const item of items ?? []) {
     void applyNoVaultEntryFlag({
+      supabase,
       userId: auth.userId,
       tripItemId: item.id as string,
       providerName: (item.provider as string | null) ?? null,

--- a/src/app/api/v1/trips/[id]/items/route.ts
+++ b/src/app/api/v1/trips/[id]/items/route.ts
@@ -159,6 +159,7 @@ export async function POST(
 
   if (item) {
     void applyNoVaultEntryFlag({
+      supabase,
       userId: trip.user_id,
       tripItemId: item.id,
       providerName: item.provider,

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -16,7 +16,7 @@ import { searchBraveImages } from '@/lib/images/brave-image-search'
 import { storeCoverImage } from '@/lib/images/store-cover-image'
 import { locationToCityAsync } from '@/lib/images/airport-cities'
 import { generateTripName, isDefaultTitle } from '@/lib/trips/naming'
-import { sanitizeHtml } from '@/lib/utils'
+import { extractLocalTime, sanitizeHtml } from '@/lib/utils'
 import { TripConfirmationEmail } from '@/components/email/trip-confirmation'
 import { render } from '@react-email/components'
 import { checkExtractionLimit, incrementExtractionCount } from '@/lib/usage/limits'
@@ -178,7 +178,7 @@ export async function POST(request: NextRequest) {
       : profilesData as { email: string; full_name: string | null } | null
 
     // ── Soft usage gate: check monthly extraction limit ───────────────────────
-    const extractionCheck = await checkExtractionLimit(userId)
+    const extractionCheck = await checkExtractionLimit(userId, supabase)
     if (!extractionCheck.allowed) {
       console.log(`Extraction limit reached for user ${userId}: ${extractionCheck.used}/${extractionCheck.limit}`)
       await supabase
@@ -303,10 +303,10 @@ export async function POST(request: NextRequest) {
       }
 
       // Count this extraction against the user's monthly limit
-      await incrementExtractionCount(userId)
+      await incrementExtractionCount(userId, supabase)
 
       // Track that this user forwarded their first email (idempotent)
-      trackFirstForward(userId).catch((err) =>
+      trackFirstForward(userId, supabase).catch((err) =>
         console.error('[activation] trackFirstForward failed:', err)
       )
 
@@ -501,7 +501,7 @@ export async function POST(request: NextRequest) {
             tripOwnerId = userId
 
             // Track activation milestone (idempotent)
-            trackTripCreated(userId).catch((err) =>
+            trackTripCreated(userId, supabase).catch((err) =>
               console.error('[activation] trackTripCreated failed:', err)
             )
 
@@ -586,6 +586,16 @@ export async function POST(request: NextRequest) {
         }
         tripsToUpdate.get(confirmedTripId)!.items.push(item)
 
+        const details = { ...((item.details as Record<string, unknown>) || {}) }
+        if (item.kind === 'flight' || item.kind === 'train') {
+          if (!details.departure_local_time && item.start_ts) {
+            details.departure_local_time = extractLocalTime(item.start_ts)
+          }
+          if (!details.arrival_local_time && item.end_ts) {
+            details.arrival_local_time = extractLocalTime(item.end_ts)
+          }
+        }
+
         // Create trip item
         const { data: tripItem, error: itemError } = await supabase
           .from('trip_items')
@@ -603,7 +613,7 @@ export async function POST(request: NextRequest) {
             start_location: item.start_location,
             end_location: item.end_location,
             summary: item.summary,
-            details_json: item.details || {},
+            details_json: details,
             status: item.status,
             confidence: item.confidence,
             needs_review: item.needs_review,
@@ -618,6 +628,7 @@ export async function POST(request: NextRequest) {
         }
 
         await applyEmailLoyaltyFlag({
+          supabase,
           userId: confirmedTripOwnerId,
           tripItemId: tripItem.id,
           providerName: item.provider,

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -16,7 +16,7 @@ import { searchBraveImages } from '@/lib/images/brave-image-search'
 import { storeCoverImage } from '@/lib/images/store-cover-image'
 import { locationToCityAsync } from '@/lib/images/airport-cities'
 import { generateTripName, isDefaultTitle } from '@/lib/trips/naming'
-import { extractLocalTime, sanitizeHtml } from '@/lib/utils'
+import { buildTripItemDetails, sanitizeHtml } from '@/lib/utils'
 import { TripConfirmationEmail } from '@/components/email/trip-confirmation'
 import { render } from '@react-email/components'
 import { checkExtractionLimit, incrementExtractionCount } from '@/lib/usage/limits'
@@ -318,7 +318,7 @@ export async function POST(request: NextRequest) {
         fullEmail.subject || '',
         fullEmail.text || fullEmail.html || '',
         attachmentText || undefined,
-        { senderDomain }
+        { senderDomain, supabase }
       )
 
       // Update source email with extraction result and attachment text
@@ -586,15 +586,7 @@ export async function POST(request: NextRequest) {
         }
         tripsToUpdate.get(confirmedTripId)!.items.push(item)
 
-        const details = { ...((item.details as Record<string, unknown>) || {}) }
-        if (item.kind === 'flight' || item.kind === 'train') {
-          if (!details.departure_local_time && item.start_ts) {
-            details.departure_local_time = extractLocalTime(item.start_ts)
-          }
-          if (!details.arrival_local_time && item.end_ts) {
-            details.arrival_local_time = extractLocalTime(item.end_ts)
-          }
-        }
+        const details = buildTripItemDetails(item)
 
         // Create trip item
         const { data: tripItem, error: itemError } = await supabase

--- a/src/lib/activation.ts
+++ b/src/lib/activation.ts
@@ -7,7 +7,6 @@
  *   second_trip_at    — second trip created
  */
 
-import { createSecretClient } from '@/lib/supabase/service'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 type DbClient = SupabaseClient
@@ -18,7 +17,7 @@ type DbClient = SupabaseClient
  */
 export async function trackFirstForward(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<void> {
 
   // Only set if not already set — idempotent upsert
@@ -37,7 +36,7 @@ export async function trackFirstForward(
  */
 export async function trackTripCreated(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<void> {
 
   // Fetch current activation state

--- a/src/lib/ai/example-selection.ts
+++ b/src/lib/ai/example-selection.ts
@@ -1,4 +1,3 @@
-import { createSecretClient } from '@/lib/supabase/service'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 export interface ExtractionExample {
@@ -17,8 +16,8 @@ export interface ExtractionExample {
  * Prioritizes provider-specific examples, falls back to global high-quality ones.
  */
 export async function selectExamples(
-  senderDomain?: string,
-  supabase: SupabaseClient = createSecretClient()
+  senderDomain: string | undefined,
+  supabase: SupabaseClient
 ): Promise<ExtractionExample[]> {
   // Build query - prioritize provider-specific matches, then global examples
   let query = supabase

--- a/src/lib/ai/extract-travel-data.ts
+++ b/src/lib/ai/extract-travel-data.ts
@@ -5,6 +5,7 @@ import {
   buildSystemPromptWithExamples,
 } from './prompts'
 import { selectExamples } from './example-selection'
+import { createSecretClient } from '@/lib/supabase/service'
 import type { TripItemKind, TripItemStatus } from '@/types/database'
 
 export interface ExtractedItem {
@@ -94,8 +95,9 @@ export async function extractTravelData(
   attachmentText?: string,
   options?: ExtractTravelDataOptions
 ): Promise<ExtractionResult> {
+  const supabase = createSecretClient()
   // Select relevant few-shot examples based on sender domain
-  const examples = await selectExamples(options?.senderDomain)
+  const examples = await selectExamples(options?.senderDomain, supabase)
 
   if (examples.length > 0) {
     console.log(`Using ${examples.length} extraction examples for ${options?.senderDomain || 'unknown domain'}`)

--- a/src/lib/ai/extract-travel-data.ts
+++ b/src/lib/ai/extract-travel-data.ts
@@ -34,6 +34,7 @@ export interface ExtractionResult {
 
 export interface ExtractTravelDataOptions {
   senderDomain?: string
+  supabase?: import('@supabase/supabase-js').SupabaseClient
 }
 
 interface DateNormalizationContext {
@@ -95,9 +96,9 @@ export async function extractTravelData(
   attachmentText?: string,
   options?: ExtractTravelDataOptions
 ): Promise<ExtractionResult> {
-  const supabase = createSecretClient()
   // Select relevant few-shot examples based on sender domain
-  const examples = await selectExamples(options?.senderDomain, supabase)
+  const dbClient = options?.supabase ?? createSecretClient()
+  const examples = await selectExamples(options?.senderDomain, dbClient)
 
   if (examples.length > 0) {
     console.log(`Using ${examples.length} extraction examples for ${options?.senderDomain || 'unknown domain'}`)

--- a/src/lib/loyalty-flag.ts
+++ b/src/lib/loyalty-flag.ts
@@ -1,6 +1,5 @@
 import { decryptLoyaltyNumber } from '@/lib/loyalty-crypto'
 import { resolveProviderKey } from '@/lib/loyalty-matching'
-import { createSecretClient } from '@/lib/supabase/service'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 type DbClient = SupabaseClient
@@ -109,7 +108,7 @@ async function setTripItemFlag(
 }
 
 export async function applyEmailLoyaltyFlag(params: {
-  supabase?: DbClient
+  supabase: DbClient
   userId: string
   tripItemId: string
   providerName: string | null
@@ -118,7 +117,7 @@ export async function applyEmailLoyaltyFlag(params: {
   const providerName = params.providerName?.trim()
   if (!providerName) return
 
-  const supabase = params.supabase ?? createSecretClient()
+  const { supabase } = params
   const match = await matchProviderForUser(supabase, params.userId, providerName)
   if (!match) return
 
@@ -164,7 +163,7 @@ export async function applyEmailLoyaltyFlag(params: {
 }
 
 export async function applyNoVaultEntryFlag(params: {
-  supabase?: DbClient
+  supabase: DbClient
   userId: string
   tripItemId: string
   providerName: string | null
@@ -172,7 +171,7 @@ export async function applyNoVaultEntryFlag(params: {
   const providerName = params.providerName?.trim()
   if (!providerName) return
 
-  const supabase = params.supabase ?? createSecretClient()
+  const { supabase } = params
   const match = await matchProviderForUser(supabase, params.userId, providerName)
   if (!match) return
 

--- a/src/lib/trips/access.ts
+++ b/src/lib/trips/access.ts
@@ -1,4 +1,4 @@
-import { createSecretClient } from '@/lib/supabase/service'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 export type TripWriteAccessRole = 'owner' | 'editor' | 'family_member'
 export type TripWriteDeniedReason = 'not_found' | 'forbidden' | 'viewer' | 'internal_error'
@@ -7,8 +7,6 @@ interface TripOwnerRow {
   id: string
   user_id: string
 }
-
-type SupabaseSecretClient = ReturnType<typeof createSecretClient>
 
 export type TripWriteAccessResult =
   | {
@@ -23,7 +21,7 @@ export type TripWriteAccessResult =
     }
 
 interface ResolveTripWriteAccessParams {
-  supabase: SupabaseSecretClient
+  supabase: SupabaseClient
   tripId: string
   userId: string
 }

--- a/src/lib/usage/limits.ts
+++ b/src/lib/usage/limits.ts
@@ -1,4 +1,3 @@
-import { createSecretClient } from '@/lib/supabase/service'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 export type SubscriptionTier = 'free' | 'pro'
@@ -16,7 +15,7 @@ export interface LimitResult {
 
 export async function getUserTier(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<SubscriptionTier> {
   const { data } = await supabase
     .from('profiles')
@@ -32,7 +31,7 @@ export async function getUserTier(
  */
 export async function checkExtractionLimit(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<LimitResult> {
   const tier = await getUserTier(userId, supabase)
 
@@ -63,7 +62,7 @@ export async function checkExtractionLimit(
  */
 export async function incrementExtractionCount(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<void> {
   const month = new Date().toISOString().slice(0, 7) // YYYY-MM
 
@@ -92,7 +91,7 @@ export async function incrementExtractionCount(
  */
 export async function checkTripLimit(
   userId: string,
-  supabase: DbClient = createSecretClient()
+  supabase: DbClient
 ): Promise<LimitResult> {
   const tier = await getUserTier(userId, supabase)
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,6 +70,25 @@ export function extractLocalTime(isoString: string | null | undefined): string |
 }
 
 /**
+ * Build details_json for a trip item, ensuring local times are populated
+ * from the ISO timestamps before Postgres normalizes them to UTC.
+ */
+export function buildTripItemDetails(
+  item: { kind: string; start_ts?: string | null; end_ts?: string | null; details?: Record<string, unknown> | null }
+): Record<string, unknown> {
+  const details = { ...(item.details || {}) }
+  if (item.kind === 'flight' || item.kind === 'train') {
+    if (!details.departure_local_time && item.start_ts) {
+      details.departure_local_time = extractLocalTime(item.start_ts)
+    }
+    if (!details.arrival_local_time && item.end_ts) {
+      details.arrival_local_time = extractLocalTime(item.end_ts)
+    }
+  }
+  return details
+}
+
+/**
  * Get the best display time for a trip item, preferring local times from details.
  * Returns [startTime, endTime] as formatted strings.
  */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -59,6 +59,17 @@ export function formatTime(date: string | Date | null | undefined): string {
 }
 
 /**
+ * Extract local time (HH:MM) from an ISO 8601 timestamp.
+ * The time portion of the ISO string represents local time when an offset is present.
+ * e.g., "2026-03-10T12:52:00-05:00" -> "12:52"
+ */
+export function extractLocalTime(isoString: string | null | undefined): string | null {
+  if (!isoString) return null
+  const match = isoString.match(/T(\d{2}:\d{2})/)
+  return match ? match[1] : null
+}
+
+/**
  * Get the best display time for a trip item, preferring local times from details.
  * Returns [startTime, endTime] as formatted strings.
  */

--- a/supabase/migrations/20260304000002_rls_initplan_fix.sql
+++ b/supabase/migrations/20260304000002_rls_initplan_fix.sql
@@ -1,0 +1,217 @@
+-- PRD-033 P2A: Wrap auth functions in initplan subselects for RLS performance.
+
+-- Update helper functions to avoid per-row auth.uid() evaluation.
+CREATE OR REPLACE FUNCTION public.is_trip_owner(p_trip_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.trips
+    WHERE id = p_trip_id
+      AND user_id = (SELECT auth.uid())
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_family_member(target_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.family_members fm1
+    JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+    WHERE fm1.user_id = (SELECT auth.uid())
+      AND fm2.user_id = target_user_id
+      AND fm1.accepted_at IS NOT NULL
+      AND fm2.accepted_at IS NOT NULL
+      AND fm1.user_id <> fm2.user_id
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_family_member_of(target_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM public.family_members
+      WHERE family_id = target_id
+        AND user_id = (SELECT auth.uid())
+        AND accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.family_members fm1
+      JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+      WHERE fm1.user_id = (SELECT auth.uid())
+        AND fm2.user_id = target_id
+        AND fm1.accepted_at IS NOT NULL
+        AND fm2.accepted_at IS NOT NULL
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_family_admin(target_family_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.family_members
+    WHERE family_id = target_family_id
+      AND user_id = (SELECT auth.uid())
+      AND role = 'admin'
+      AND accepted_at IS NOT NULL
+  );
+$$;
+
+DO $$
+DECLARE
+  pol RECORD;
+  cmd_sql text;
+  mode_sql text;
+  role_name text;
+  role_list text;
+  role_clause text;
+  using_expr_original text;
+  check_expr_original text;
+  using_expr_rewritten text;
+  check_expr_rewritten text;
+  create_sql text;
+BEGIN
+  FOR pol IN
+    SELECT
+      n.nspname AS schema_name,
+      c.relname AS table_name,
+      pol.polname,
+      pol.polcmd,
+      pol.polpermissive,
+      pol.polroles,
+      pg_get_expr(pol.polqual, pol.polrelid) AS using_expr,
+      pg_get_expr(pol.polwithcheck, pol.polrelid) AS check_expr
+    FROM pg_policy pol
+    JOIN pg_class c ON c.oid = pol.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+    ORDER BY c.relname, pol.polname
+  LOOP
+    using_expr_original := pol.using_expr;
+    check_expr_original := pol.check_expr;
+
+    using_expr_rewritten := using_expr_original;
+    check_expr_rewritten := check_expr_original;
+
+    IF using_expr_rewritten IS NOT NULL THEN
+      using_expr_rewritten := replace(using_expr_rewritten, '(SELECT auth.uid())', '__PRD033_AUTH_UID__');
+      using_expr_rewritten := replace(using_expr_rewritten, '(select auth.uid())', '__PRD033_AUTH_UID__');
+      using_expr_rewritten := replace(using_expr_rewritten, '(SELECT auth.jwt())', '__PRD033_AUTH_JWT__');
+      using_expr_rewritten := replace(using_expr_rewritten, '(select auth.jwt())', '__PRD033_AUTH_JWT__');
+      using_expr_rewritten := replace(using_expr_rewritten, 'auth.uid()', '(SELECT auth.uid())');
+      using_expr_rewritten := replace(using_expr_rewritten, 'auth.jwt()', '(SELECT auth.jwt())');
+      using_expr_rewritten := replace(using_expr_rewritten, '__PRD033_AUTH_UID__', '(SELECT auth.uid())');
+      using_expr_rewritten := replace(using_expr_rewritten, '__PRD033_AUTH_JWT__', '(SELECT auth.jwt())');
+    END IF;
+
+    IF check_expr_rewritten IS NOT NULL THEN
+      check_expr_rewritten := replace(check_expr_rewritten, '(SELECT auth.uid())', '__PRD033_AUTH_UID__');
+      check_expr_rewritten := replace(check_expr_rewritten, '(select auth.uid())', '__PRD033_AUTH_UID__');
+      check_expr_rewritten := replace(check_expr_rewritten, '(SELECT auth.jwt())', '__PRD033_AUTH_JWT__');
+      check_expr_rewritten := replace(check_expr_rewritten, '(select auth.jwt())', '__PRD033_AUTH_JWT__');
+      check_expr_rewritten := replace(check_expr_rewritten, 'auth.uid()', '(SELECT auth.uid())');
+      check_expr_rewritten := replace(check_expr_rewritten, 'auth.jwt()', '(SELECT auth.jwt())');
+      check_expr_rewritten := replace(check_expr_rewritten, '__PRD033_AUTH_UID__', '(SELECT auth.uid())');
+      check_expr_rewritten := replace(check_expr_rewritten, '__PRD033_AUTH_JWT__', '(SELECT auth.jwt())');
+    END IF;
+
+    IF coalesce(using_expr_original, '') = coalesce(using_expr_rewritten, '')
+       AND coalesce(check_expr_original, '') = coalesce(check_expr_rewritten, '') THEN
+      CONTINUE;
+    END IF;
+
+    cmd_sql := CASE pol.polcmd
+      WHEN 'r' THEN 'SELECT'
+      WHEN 'a' THEN 'INSERT'
+      WHEN 'w' THEN 'UPDATE'
+      WHEN 'd' THEN 'DELETE'
+      ELSE 'ALL'
+    END;
+
+    mode_sql := CASE WHEN pol.polpermissive THEN 'PERMISSIVE' ELSE 'RESTRICTIVE' END;
+
+    role_list := NULL;
+    IF pol.polroles IS NOT NULL AND array_length(pol.polroles, 1) IS NOT NULL THEN
+      IF 0 = ANY(pol.polroles) THEN
+        role_list := 'PUBLIC';
+      END IF;
+
+      FOR role_name IN
+        SELECT quote_ident(r.rolname)
+        FROM pg_roles r
+        WHERE r.oid = ANY(pol.polroles)
+          AND r.oid <> 0
+        ORDER BY r.rolname
+      LOOP
+        role_list := CASE
+          WHEN role_list IS NULL THEN role_name
+          ELSE role_list || ', ' || role_name
+        END;
+      END LOOP;
+    END IF;
+
+    role_clause := CASE
+      WHEN role_list IS NULL THEN ''
+      ELSE ' TO ' || role_list
+    END;
+
+    EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I', pol.polname, pol.schema_name, pol.table_name);
+
+    create_sql := format(
+      'CREATE POLICY %I ON %I.%I AS %s FOR %s%s',
+      pol.polname,
+      pol.schema_name,
+      pol.table_name,
+      mode_sql,
+      cmd_sql,
+      role_clause
+    );
+
+    IF using_expr_rewritten IS NOT NULL THEN
+      create_sql := create_sql || format(' USING (%s)', using_expr_rewritten);
+    END IF;
+
+    IF check_expr_rewritten IS NOT NULL THEN
+      create_sql := create_sql || format(' WITH CHECK (%s)', check_expr_rewritten);
+    END IF;
+
+    EXECUTE create_sql;
+  END LOOP;
+END $$;
+
+DROP POLICY IF EXISTS "profiles_family_read" ON public.profiles;
+CREATE POLICY "profiles_family_read" ON public.profiles
+  FOR SELECT
+  USING (
+    (SELECT auth.uid()) = id
+    OR public.is_family_member_of(id)
+  );
+
+DROP POLICY IF EXISTS "user_profiles_family_read" ON public.user_profiles;
+CREATE POLICY "user_profiles_family_read" ON public.user_profiles
+  FOR SELECT
+  USING (
+    (SELECT auth.uid()) = id
+    OR public.is_family_member(id)
+  );

--- a/supabase/migrations/20260304000002_rls_initplan_fix.sql
+++ b/supabase/migrations/20260304000002_rls_initplan_fix.sql
@@ -35,30 +35,26 @@ AS $$
   );
 $$;
 
-CREATE OR REPLACE FUNCTION public.is_family_member_of(target_id uuid)
+-- is_family_member_of: checks if the current user shares a family with target_user_id.
+-- Previously this function also accepted a family_id, but all family_id usage has been
+-- inlined into the consolidated policies (P2B). Now it only handles user_id lookups.
+CREATE OR REPLACE FUNCTION public.is_family_member_of(target_user_id uuid)
 RETURNS boolean
 LANGUAGE sql
 SECURITY DEFINER
 STABLE
 SET search_path = ''
 AS $$
-  SELECT
-    EXISTS (
-      SELECT 1
-      FROM public.family_members
-      WHERE family_id = target_id
-        AND user_id = (SELECT auth.uid())
-        AND accepted_at IS NOT NULL
-    )
-    OR EXISTS (
-      SELECT 1
-      FROM public.family_members fm1
-      JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
-      WHERE fm1.user_id = (SELECT auth.uid())
-        AND fm2.user_id = target_id
-        AND fm1.accepted_at IS NOT NULL
-        AND fm2.accepted_at IS NOT NULL
-    );
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.family_members fm1
+    JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+    WHERE fm1.user_id = (SELECT auth.uid())
+      AND fm2.user_id = target_user_id
+      AND fm1.accepted_at IS NOT NULL
+      AND fm2.accepted_at IS NOT NULL
+      AND fm1.user_id <> fm2.user_id
+  );
 $$;
 
 CREATE OR REPLACE FUNCTION public.is_family_admin(target_family_id uuid)

--- a/supabase/migrations/20260304000003_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260304000003_consolidate_rls_policies.sql
@@ -1,0 +1,345 @@
+-- PRD-033 P2B: Consolidate overlapping permissive RLS policies.
+
+-- trips
+DROP POLICY IF EXISTS "Users can manage own trips" ON public.trips;
+DROP POLICY IF EXISTS "trips_select" ON public.trips;
+DROP POLICY IF EXISTS "trips_family_read" ON public.trips;
+DROP POLICY IF EXISTS "trips_collaborators_update" ON public.trips;
+DROP POLICY IF EXISTS "trips_family_update" ON public.trips;
+
+CREATE POLICY "trips_select" ON public.trips
+  FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trips.id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR public.is_family_member(user_id)
+  );
+
+CREATE POLICY "trips_insert" ON public.trips
+  FOR INSERT
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+  );
+
+CREATE POLICY "trips_update" ON public.trips
+  FOR UPDATE
+  USING (
+    user_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trips.id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.role = 'editor'
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR public.is_family_member(user_id)
+  )
+  WITH CHECK (
+    user_id = public.trip_owner_user_id(id)
+    AND (
+      user_id = (SELECT auth.uid())
+      OR EXISTS (
+        SELECT 1
+        FROM public.trip_collaborators tc
+        WHERE tc.trip_id = trips.id
+          AND tc.user_id = (SELECT auth.uid())
+          AND tc.role = 'editor'
+          AND tc.accepted_at IS NOT NULL
+      )
+      OR public.is_family_member(user_id)
+    )
+  );
+
+CREATE POLICY "trips_delete" ON public.trips
+  FOR DELETE
+  USING (
+    user_id = (SELECT auth.uid())
+  );
+
+-- trip_items
+DROP POLICY IF EXISTS "Users can manage own trip items" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_select" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_collab_insert" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_collab_update" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_family_read" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_family_insert" ON public.trip_items;
+DROP POLICY IF EXISTS "trip_items_family_update" ON public.trip_items;
+
+CREATE POLICY "trip_items_select" ON public.trip_items
+  FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_items.trip_id
+        AND t.user_id = (SELECT auth.uid())
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trip_items.trip_id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_items.trip_id
+        AND public.is_family_member(t.user_id)
+    )
+  );
+
+CREATE POLICY "trip_items_insert" ON public.trip_items
+  FOR INSERT
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    OR public.is_trip_owner(trip_id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trip_items.trip_id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.role = 'editor'
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_items.trip_id
+        AND public.is_family_member(t.user_id)
+    )
+  );
+
+CREATE POLICY "trip_items_update" ON public.trip_items
+  FOR UPDATE
+  USING (
+    user_id = (SELECT auth.uid())
+    OR public.is_trip_owner(trip_id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trip_items.trip_id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.role = 'editor'
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_items.trip_id
+        AND public.is_family_member(t.user_id)
+    )
+  )
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    OR public.is_trip_owner(trip_id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.trip_collaborators tc
+      WHERE tc.trip_id = trip_items.trip_id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.role = 'editor'
+        AND tc.accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_items.trip_id
+        AND public.is_family_member(t.user_id)
+    )
+  );
+
+-- Keep dedicated delete policy added in PRD-030.
+
+-- trip_collaborators
+DROP POLICY IF EXISTS "collab_owner_select" ON public.trip_collaborators;
+DROP POLICY IF EXISTS "collab_self_select" ON public.trip_collaborators;
+DROP POLICY IF EXISTS "collab_owner_insert" ON public.trip_collaborators;
+DROP POLICY IF EXISTS "collab_owner_update" ON public.trip_collaborators;
+DROP POLICY IF EXISTS "collab_self_accept" ON public.trip_collaborators;
+DROP POLICY IF EXISTS "collab_owner_delete" ON public.trip_collaborators;
+
+CREATE POLICY "trip_collaborators_select" ON public.trip_collaborators
+  FOR SELECT
+  USING (
+    public.is_trip_owner(trip_id)
+    OR user_id = (SELECT auth.uid())
+  );
+
+CREATE POLICY "trip_collaborators_insert" ON public.trip_collaborators
+  FOR INSERT
+  WITH CHECK (
+    public.is_trip_owner(trip_id)
+  );
+
+CREATE POLICY "trip_collaborators_update" ON public.trip_collaborators
+  FOR UPDATE
+  USING (
+    public.is_trip_owner(trip_id)
+    OR invited_email = (
+      SELECT email
+      FROM public.profiles
+      WHERE id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "trip_collaborators_delete" ON public.trip_collaborators
+  FOR DELETE
+  USING (
+    public.is_trip_owner(trip_id)
+  );
+
+-- trip_item_status
+DROP POLICY IF EXISTS "status_select_owner" ON public.trip_item_status;
+DROP POLICY IF EXISTS "status_select_collaborator" ON public.trip_item_status;
+DROP POLICY IF EXISTS "status_select_family" ON public.trip_item_status;
+
+CREATE POLICY "status_select" ON public.trip_item_status
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.trip_items ti
+      JOIN public.trips t ON t.id = ti.trip_id
+      WHERE ti.id = trip_item_status.item_id
+        AND (
+          public.is_trip_owner(ti.trip_id)
+          OR EXISTS (
+            SELECT 1
+            FROM public.trip_collaborators tc
+            WHERE tc.trip_id = ti.trip_id
+              AND tc.user_id = (SELECT auth.uid())
+              AND tc.accepted_at IS NOT NULL
+          )
+          OR public.is_family_member(t.user_id)
+        )
+    )
+  );
+
+-- city_guides
+DROP POLICY IF EXISTS "guides_owner_all" ON public.city_guides;
+DROP POLICY IF EXISTS "guides_public_read" ON public.city_guides;
+DROP POLICY IF EXISTS "guides_family_read" ON public.city_guides;
+
+CREATE POLICY "guides_select" ON public.city_guides
+  FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())
+    OR is_public = true
+    OR public.is_family_member(user_id)
+  );
+
+CREATE POLICY "guides_insert" ON public.city_guides
+  FOR INSERT
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "guides_update" ON public.city_guides
+  FOR UPDATE
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "guides_delete" ON public.city_guides
+  FOR DELETE
+  USING (user_id = (SELECT auth.uid()));
+
+-- guide_entries
+DROP POLICY IF EXISTS "entries_owner_all" ON public.guide_entries;
+DROP POLICY IF EXISTS "entries_public_read" ON public.guide_entries;
+DROP POLICY IF EXISTS "guide_entries_family_read" ON public.guide_entries;
+
+CREATE POLICY "guide_entries_select" ON public.guide_entries
+  FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.city_guides cg
+      WHERE cg.id = guide_entries.guide_id
+        AND cg.is_public = true
+    )
+    OR public.is_family_member(user_id)
+  );
+
+CREATE POLICY "guide_entries_insert" ON public.guide_entries
+  FOR INSERT
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "guide_entries_update" ON public.guide_entries
+  FOR UPDATE
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "guide_entries_delete" ON public.guide_entries
+  FOR DELETE
+  USING (user_id = (SELECT auth.uid()));
+
+-- families
+DROP POLICY IF EXISTS "families_member_select" ON public.families;
+DROP POLICY IF EXISTS "families_creator_select" ON public.families;
+
+CREATE POLICY "families_select" ON public.families
+  FOR SELECT
+  USING (
+    created_by = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM public.family_members fm
+      WHERE fm.family_id = families.id
+        AND fm.user_id = (SELECT auth.uid())
+        AND fm.accepted_at IS NOT NULL
+    )
+  );
+
+-- loyalty_programs
+DROP POLICY IF EXISTS "loyalty_programs_self" ON public.loyalty_programs;
+DROP POLICY IF EXISTS "loyalty_family_read" ON public.loyalty_programs;
+
+CREATE POLICY "loyalty_programs_select" ON public.loyalty_programs
+  FOR SELECT
+  USING (
+    user_id = (SELECT auth.uid())
+    OR public.is_family_member(user_id)
+  );
+
+CREATE POLICY "loyalty_programs_insert" ON public.loyalty_programs
+  FOR INSERT
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "loyalty_programs_update" ON public.loyalty_programs
+  FOR UPDATE
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "loyalty_programs_delete" ON public.loyalty_programs
+  FOR DELETE
+  USING (user_id = (SELECT auth.uid()));
+
+-- profiles
+DROP POLICY IF EXISTS "Users can view own profile" ON public.profiles;
+DROP POLICY IF EXISTS "profiles_collab_read" ON public.profiles;
+DROP POLICY IF EXISTS "profiles_family_read" ON public.profiles;
+
+CREATE POLICY "profiles_select" ON public.profiles
+  FOR SELECT
+  USING (
+    id = (SELECT auth.uid())
+    OR public.is_family_member(id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.trips t
+      JOIN public.trip_collaborators tc ON tc.trip_id = t.id
+      WHERE t.user_id = profiles.id
+        AND tc.user_id = (SELECT auth.uid())
+        AND tc.accepted_at IS NOT NULL
+    )
+  );
+
+-- Keep existing profiles insert/update policies unchanged.

--- a/supabase/migrations/20260304000004_index_foreign_keys.sql
+++ b/supabase/migrations/20260304000004_index_foreign_keys.sql
@@ -1,0 +1,18 @@
+-- PRD-033 P3A: Add missing indexes for foreign keys.
+
+CREATE INDEX IF NOT EXISTS idx_trip_items_source_email ON public.trip_items(source_email_id);
+CREATE INDEX IF NOT EXISTS idx_trip_pdfs_trip ON public.trip_pdfs(trip_id);
+CREATE INDEX IF NOT EXISTS idx_trip_pdfs_user ON public.trip_pdfs(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_trip ON public.notifications(trip_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_actor ON public.notifications(actor_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_comments_feedback ON public.feedback_comments(feedback_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_comments_user ON public.feedback_comments(user_id);
+CREATE INDEX IF NOT EXISTS idx_families_created_by ON public.families(created_by);
+CREATE INDEX IF NOT EXISTS idx_family_members_invited_by ON public.family_members(invited_by);
+CREATE INDEX IF NOT EXISTS idx_trip_collaborators_invited_by ON public.trip_collaborators(invited_by);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user ON public.audit_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_extraction_examples_source_email ON public.extraction_examples(source_email_id);
+CREATE INDEX IF NOT EXISTS idx_extraction_examples_user ON public.extraction_examples(user_id);
+CREATE INDEX IF NOT EXISTS idx_guide_entries_recommended_by ON public.guide_entries(recommended_by_user_id);
+CREATE INDEX IF NOT EXISTS idx_imports_user ON public.imports(user_id);
+CREATE INDEX IF NOT EXISTS idx_trip_item_status_refresh_logs_item ON public.trip_item_status_refresh_logs(item_id);

--- a/supabase/migrations/20260304000005_drop_duplicate_indexes.sql
+++ b/supabase/migrations/20260304000005_drop_duplicate_indexes.sql
@@ -1,0 +1,5 @@
+-- PRD-033 P3B: Drop duplicate indexes shadowed by unique constraints.
+
+DROP INDEX IF EXISTS public.idx_trip_item_status_item;
+DROP INDEX IF EXISTS public.idx_profiles_stripe_customer;
+DROP INDEX IF EXISTS public.idx_api_keys_hash;

--- a/supabase/migrations/20260304000006_move_extensions.sql
+++ b/supabase/migrations/20260304000006_move_extensions.sql
@@ -1,0 +1,5 @@
+-- PRD-033 P4: Move extensions out of public schema.
+
+ALTER EXTENSION citext SET SCHEMA extensions;
+ALTER EXTENSION cube SET SCHEMA extensions;
+ALTER EXTENSION earthdistance SET SCHEMA extensions;


### PR DESCRIPTION
## PRD-033 — Supabase Health Monthly Audit

### Phase 2: RLS Performance
- **P2A:** Wrapped all `auth.uid()` calls in `(SELECT ...)` subselects across 55 RLS policies — prevents per-row function re-evaluation
- **P2B:** Consolidated 70 multiple permissive policies into clean per-action policies (trips, trip_items, city_guides, guide_entries, families, loyalty_programs, profiles, trip_collaborators, trip_item_status)
- Added `profiles_family_read` and `user_profiles_family_read` policies

### Phase 3: Index Hygiene
- **P3A:** Added 16 indexes for unindexed foreign keys
- **P3B:** Dropped 3 duplicate indexes (non-unique duplicating unique constraints)

### Phase 4: Schema Hygiene
- Moved `citext`, `cube`, `earthdistance` extensions to `extensions` schema

### Phase 5: Code Refactoring
- **P5A:** Fixed local time loss — `extractLocalTime()` utility + patched all 3 insertion paths (webhook, reparse, corrections) + backfill script
- **P5C:** Switched 5 family routes from `createSecretClient()` to `createUserScopedClient()` — authorization now goes through RLS
- **P5D:** Made supabase client param required (not optional) in limits.ts, activation.ts, example-selection.ts, loyalty-flag.ts, trips/access.ts. Consolidated inline storage clients.

### Validation
- ✅ `npx tsc --noEmit` — clean
- ✅ `pnpm test` — 88/88 passing  
- ✅ `bash scripts/check-rls.sh` — all tables have RLS
- ✅ `pnpm lint` — 0 errors