### PR TITLE
fix: derive primary_location from hotels, not raw frequency

### DIFF
--- a/src/lib/trips/assignment.test.ts
+++ b/src/lib/trips/assignment.test.ts
@@ -91,4 +91,30 @@ describe('getPrimaryLocation', () => {
     ]
     expect(getPrimaryLocation(items)).toBe('New York')
   })
+
+  it('strips parenthesized airport codes — "New York (JFK)" → "New York"', () => {
+    const items = [
+      makeItem({ kind: 'flight', end_location: 'New York (JFK)' }),
+    ]
+    expect(getPrimaryLocation(items)).toBe('New York')
+  })
+
+  it('does not mangle multi-word city names — "New York City, NY" stays "New York City, NY"', () => {
+    const items = [
+      makeItem({ kind: 'hotel', start_location: 'New York City, NY' }),
+    ]
+    const result = getPrimaryLocation(items)
+    // Must not silently collapse to "NY"
+    expect(result).not.toBe('NY')
+    expect(result).toContain('New York City')
+  })
+
+  it('does not mangle "Salt Lake City, UT" to "UT"', () => {
+    const items = [
+      makeItem({ kind: 'hotel', start_location: 'Salt Lake City, UT' }),
+    ]
+    const result = getPrimaryLocation(items)
+    expect(result).not.toBe('UT')
+    expect(result).toContain('Salt Lake City')
+  })
 })

--- a/src/lib/trips/assignment.test.ts
+++ b/src/lib/trips/assignment.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { getPrimaryLocation } from './assignment'
+import type { ExtractedItem } from '@/lib/ai/extract-travel-data'
+
+function makeItem(overrides: Partial<ExtractedItem>): ExtractedItem {
+  return {
+    kind: 'flight',
+    provider: null,
+    confirmation_code: null,
+    traveler_names: [],
+    start_date: '2026-04-01',
+    end_date: null,
+    start_ts: null,
+    end_ts: null,
+    start_location: null,
+    end_location: null,
+    summary: null,
+    status: 'confirmed',
+    confidence: 1,
+    needs_review: false,
+    details: {},
+    ...overrides,
+  }
+}
+
+describe('getPrimaryLocation', () => {
+  it('returns null for empty items', () => {
+    expect(getPrimaryLocation([])).toBeNull()
+  })
+
+  it('prefers hotel location over flights', () => {
+    const items = [
+      makeItem({ kind: 'flight', start_location: 'Paris CDG', end_location: 'Tokyo NRT' }),
+      makeItem({ kind: 'hotel', start_location: 'Tokyo, Japan' }),
+      makeItem({ kind: 'flight', start_location: 'Tokyo NRT', end_location: 'Paris CDG' }),
+    ]
+    expect(getPrimaryLocation(items)).toBe('Tokyo, Japan')
+  })
+
+  it('does not use hotel name as city ("The Vendue, Charleston, SC")', () => {
+    const items = [
+      makeItem({ kind: 'flight', start_location: 'Paris CDG', end_location: 'Charleston' }),
+      makeItem({ kind: 'hotel', start_location: 'The Vendue, Charleston, SC' }),
+      makeItem({ kind: 'activity', start_location: 'Charleston' }),
+    ]
+    const result = getPrimaryLocation(items)
+    expect(result).not.toContain('Vendue')
+    expect(result).toContain('Charleston')
+  })
+
+  it('handles multi-city trip — picks most common hotel city', () => {
+    const items = [
+      makeItem({ kind: 'hotel', start_location: 'Austin, TX' }),
+      makeItem({ kind: 'hotel', start_location: 'Austin, TX' }),
+      makeItem({ kind: 'hotel', start_location: 'Milan, Italy' }),
+    ]
+    expect(getPrimaryLocation(items)).toBe('Austin, TX')
+  })
+
+  it('uses activities/restaurants when no hotels', () => {
+    const items = [
+      makeItem({ kind: 'flight', start_location: 'JFK', end_location: 'LAX' }),
+      makeItem({ kind: 'restaurant', start_location: 'Los Angeles' }),
+      makeItem({ kind: 'activity', start_location: 'Los Angeles' }),
+    ]
+    const result = getPrimaryLocation(items)
+    expect(result).toContain('Los Angeles')
+  })
+
+  it('falls back to flight destinations when nothing else', () => {
+    const items = [
+      makeItem({ kind: 'flight', start_location: 'CDG', end_location: 'Tokyo NRT' }),
+    ]
+    expect(getPrimaryLocation(items)).toBe('Tokyo')
+  })
+
+  it('ignores layover cities in favor of destination', () => {
+    // NYC → Atlanta (connection) → SF: hotel is in SF
+    const items = [
+      makeItem({ kind: 'flight', start_location: 'New York JFK', end_location: 'Atlanta' }),
+      makeItem({ kind: 'flight', start_location: 'Atlanta', end_location: 'San Francisco SFO' }),
+      makeItem({ kind: 'hotel', start_location: 'San Francisco, CA' }),
+    ]
+    const result = getPrimaryLocation(items)
+    expect(result).toContain('San Francisco')
+  })
+
+  it('strips airport codes from locations', () => {
+    const items = [
+      makeItem({ kind: 'flight', end_location: 'New York JFK' }),
+    ]
+    expect(getPrimaryLocation(items)).toBe('New York')
+  })
+})

--- a/src/lib/trips/assignment.ts
+++ b/src/lib/trips/assignment.ts
@@ -132,41 +132,35 @@ export function updateTripDates(
  * Normalises city names so "Paris CDG", "Paris, France", and "Paris" all count as "Paris".
  */
 export function getPrimaryLocation(items: ExtractedItem[]): string | null {
-  // 1. Prefer hotel locations — where you sleep is where you are
+  // Single pass to categorise locations
   const hotelLocations: string[] = []
+  const groundLocations: string[] = []
+  const flightDests: string[] = []
+
   for (const item of items) {
     if (item.kind === 'hotel') {
-      const loc = item.start_location
-      if (loc) hotelLocations.push(loc)
+      if (item.start_location) hotelLocations.push(item.start_location)
+    } else if (item.kind !== 'flight') {
+      const loc = item.end_location || item.start_location
+      if (loc) groundLocations.push(loc)
+    } else {
+      if (item.end_location) flightDests.push(item.end_location)
     }
   }
+
+  // 1. Prefer hotel locations — where you sleep is where you are
   if (hotelLocations.length > 0) {
     const best = mostFrequentCity(hotelLocations)
     if (best) return best
-    // Single hotel — normalise to city (strip hotel names)
-    return normaliseToCity(hotelLocations[0]) || hotelLocations[0]
   }
 
   // 2. Non-flight items: activities, restaurants, trains, etc.
-  const groundLocations: string[] = []
-  for (const item of items) {
-    if (item.kind !== 'flight') {
-      const loc = item.end_location || item.start_location
-      if (loc) groundLocations.push(loc)
-    }
-  }
   if (groundLocations.length > 0) {
     const best = mostFrequentCity(groundLocations)
     if (best) return best
   }
 
   // 3. Flight destinations as last resort
-  const flightDests: string[] = []
-  for (const item of items) {
-    if (item.kind === 'flight' && item.end_location) {
-      flightDests.push(item.end_location)
-    }
-  }
   if (flightDests.length > 0) {
     const best = mostFrequentCity(flightDests)
     if (best) return best
@@ -176,24 +170,38 @@ export function getPrimaryLocation(items: ExtractedItem[]): string | null {
 }
 
 /**
+ * Returns true if the string looks like a venue/hotel name rather than a city.
+ *
+ * Uses leading articles and hospitality keywords — NOT word count, which incorrectly
+ * flags multi-word city names like "New York City", "Salt Lake City", "Mexico City".
+ */
+function looksLikeVenueName(name: string): boolean {
+  return (
+    /^(The|A|An)\s/i.test(name) ||
+    /\b(Hotel|Inn|Hostel|Resort|Suites?|Lodge|Motel|Apartments?|Villas?|Palace|House|Gardens|Manor|Hall|Centre|Center|Venue|Club)\b/i.test(name)
+  )
+}
+
+/**
  * Normalise a location string to just the city name.
  * "Paris CDG" → "Paris", "The Vendue, Charleston, SC" → "Charleston",
- * "New York JFK" → "New York", "Tokyo, Japan" → "Tokyo"
+ * "New York JFK" → "New York", "New York (JFK)" → "New York",
+ * "New York City, NY" → "New York City", "Tokyo, Japan" → "Tokyo"
  */
 function normaliseToCity(location: string): string {
   let city = location.trim()
 
-  // Strip known airport codes (3-letter suffix after a space)
-  city = city.replace(/\s+[A-Z]{3}$/, '')
+  // Strip airport codes: parenthesized "(JFK)" style and trailing " JFK" style
+  city = city.replace(/\s*\([A-Z]{3}\)/g, '') // Remove (JFK) style
+  city = city.replace(/\s+[A-Z]{3}$/, '')     // Remove trailing " JFK" style
 
   // If it contains a comma, figure out which segment is the city
   if (city.includes(',')) {
     const segments = city.split(',').map(s => s.trim())
     const first = segments[0]
-    // If first segment looks like a venue/hotel name (starts with "The", or has 3+ words),
-    // the city is likely the second segment
-    const looksLikeVenue = /^The\s/i.test(first) || first.split(/\s+/).length >= 3
-    if (looksLikeVenue && segments.length >= 2 && segments[1].length > 1) {
+    // Venue detection uses article/keyword signals — not word count, which would
+    // incorrectly mangle multi-word cities like "New York City" or "Salt Lake City"
+    if (looksLikeVenueName(first) && segments.length >= 2 && segments[1].length > 1) {
       city = segments[1]
     } else {
       city = first
@@ -225,10 +233,10 @@ function mostFrequentCity(locations: string[]): string | null {
   const orig = best.original
   const normalised = normaliseToCity(orig)
 
-  // If original is a clean "City, Country" or "City, State" (2 segments, no venue name),
+  // If original is a clean "City, Country" or "City, State" (2 segments, not a venue),
   // prefer it for display. Otherwise use the normalised city.
   const segments = orig.split(',').map((s: string) => s.trim())
-  const firstIsCity = segments.length === 2 && !(/^The\s/i.test(segments[0])) && segments[0].split(/\s+/).length <= 2
+  const firstIsCity = segments.length === 2 && !looksLikeVenueName(segments[0])
   if (firstIsCity) {
     return orig
   }

--- a/src/lib/trips/assignment.ts
+++ b/src/lib/trips/assignment.ts
@@ -121,22 +121,118 @@ export function updateTripDates(
   }
 }
 
+/**
+ * Derive the primary location for a trip from its items.
+ *
+ * Priority:
+ * 1. Hotel/accommodation start_location (where you sleep = where you are)
+ * 2. Most-repeated city across all non-flight items (activities, restaurants, trains)
+ * 3. Most-repeated flight destination as fallback
+ *
+ * Normalises city names so "Paris CDG", "Paris, France", and "Paris" all count as "Paris".
+ */
 export function getPrimaryLocation(items: ExtractedItem[]): string | null {
-  // Find the most common destination location
-  const locations: Record<string, number> = {}
-
+  // 1. Prefer hotel locations — where you sleep is where you are
+  const hotelLocations: string[] = []
   for (const item of items) {
-    const loc = item.end_location || item.start_location
-    if (loc) {
-      locations[loc] = (locations[loc] || 0) + 1
+    if (item.kind === 'hotel') {
+      const loc = item.start_location
+      if (loc) hotelLocations.push(loc)
+    }
+  }
+  if (hotelLocations.length > 0) {
+    const best = mostFrequentCity(hotelLocations)
+    if (best) return best
+    // Single hotel — normalise to city (strip hotel names)
+    return normaliseToCity(hotelLocations[0]) || hotelLocations[0]
+  }
+
+  // 2. Non-flight items: activities, restaurants, trains, etc.
+  const groundLocations: string[] = []
+  for (const item of items) {
+    if (item.kind !== 'flight') {
+      const loc = item.end_location || item.start_location
+      if (loc) groundLocations.push(loc)
+    }
+  }
+  if (groundLocations.length > 0) {
+    const best = mostFrequentCity(groundLocations)
+    if (best) return best
+  }
+
+  // 3. Flight destinations as last resort
+  const flightDests: string[] = []
+  for (const item of items) {
+    if (item.kind === 'flight' && item.end_location) {
+      flightDests.push(item.end_location)
+    }
+  }
+  if (flightDests.length > 0) {
+    const best = mostFrequentCity(flightDests)
+    if (best) return best
+  }
+
+  return null
+}
+
+/**
+ * Normalise a location string to just the city name.
+ * "Paris CDG" → "Paris", "The Vendue, Charleston, SC" → "Charleston",
+ * "New York JFK" → "New York", "Tokyo, Japan" → "Tokyo"
+ */
+function normaliseToCity(location: string): string {
+  let city = location.trim()
+
+  // Strip known airport codes (3-letter suffix after a space)
+  city = city.replace(/\s+[A-Z]{3}$/, '')
+
+  // If it contains a comma, figure out which segment is the city
+  if (city.includes(',')) {
+    const segments = city.split(',').map(s => s.trim())
+    const first = segments[0]
+    // If first segment looks like a venue/hotel name (starts with "The", or has 3+ words),
+    // the city is likely the second segment
+    const looksLikeVenue = /^The\s/i.test(first) || first.split(/\s+/).length >= 3
+    if (looksLikeVenue && segments.length >= 2 && segments[1].length > 1) {
+      city = segments[1]
+    } else {
+      city = first
     }
   }
 
-  if (Object.keys(locations).length === 0) return null
+  return city
+}
 
-  // Return the most frequent location
-  const sorted = Object.entries(locations).sort((a, b) => b[1] - a[1])
-  return sorted[0][0]
+/** Return the most frequent city from a list of location strings. */
+function mostFrequentCity(locations: string[]): string | null {
+  const counts: Record<string, { count: number; original: string }> = {}
+
+  for (const loc of locations) {
+    const city = normaliseToCity(loc)
+    if (!city) continue
+    if (!counts[city]) {
+      counts[city] = { count: 0, original: loc }
+    }
+    counts[city].count++
+  }
+
+  const entries = Object.values(counts)
+  if (entries.length === 0) return null
+
+  entries.sort((a, b) => b.count - a.count)
+
+  const best = entries[0]
+  const orig = best.original
+  const normalised = normaliseToCity(orig)
+
+  // If original is a clean "City, Country" or "City, State" (2 segments, no venue name),
+  // prefer it for display. Otherwise use the normalised city.
+  const segments = orig.split(',').map((s: string) => s.trim())
+  const firstIsCity = segments.length === 2 && !(/^The\s/i.test(segments[0])) && segments[0].split(/\s+/).length <= 2
+  if (firstIsCity) {
+    return orig
+  }
+  return normalised
 }
 
 export function collectTravelerNames(items: ExtractedItem[]): string[] {


### PR DESCRIPTION
## Bug

Trips were showing layover cities ('Atlanta' for a NYC→SF trip), hotel names ('The Vendue, Charleston, SC'), and airport locations instead of actual destinations.

## Fix

Rewrote `getPrimaryLocation()` with priority order:
1. **Hotel locations** — where you sleep = where you are
2. **Ground activities** — restaurants, activities, trains
3. **Flight destinations** — last resort

Also normalises:
- Venue names: 'The Vendue, Charleston, SC' → 'Charleston'
- Airport codes: 'Tokyo NRT' → 'Tokyo'
- Multi-word hotel names detected and skipped in favor of city

## Tests

8 new tests covering: hotel priority, venue name stripping, multi-city trips, layover filtering, airport code stripping.

108 total tests passing. Build clean.