### PR TITLE
fix: normalise hotel names in weather city extraction

### DIFF
--- a/src/lib/weather/cities.test.ts
+++ b/src/lib/weather/cities.test.ts
@@ -93,4 +93,33 @@ describe('extractTripCities', () => {
 
     expect(cities.map((city) => city.city)).toEqual(['Austin, TX', 'Chicago, IL', 'New York, NY'])
   })
+
+  it('strips full hotel address to city name', () => {
+    const cities = extractTripCities([
+      makeItem({
+        id: 'hotel-1',
+        kind: 'hotel',
+        start_date: '2026-03-09',
+        end_date: '2026-03-10',
+        start_location: 'Grand Beach Hotel Surfside, 9449 Collins Avenue, Surfside, Florida 33154',
+      }),
+    ])
+    expect(cities[0].city).toContain('Surfside')
+    expect(cities[0].city).not.toContain('Collins Avenue')
+    expect(cities[0].city).not.toContain('9449')
+  })
+
+  it('extracts city from branded hotel name without address', () => {
+    const cities = extractTripCities([
+      makeItem({
+        id: 'hotel-1',
+        kind: 'hotel',
+        start_date: '2026-03-13',
+        end_date: '2026-03-14',
+        start_location: 'Park Hyatt Tokyo',
+      }),
+    ])
+    expect(cities[0].city).toContain('Tokyo')
+    expect(cities[0].city).not.toContain('Hyatt')
+  })
 })

--- a/src/lib/weather/cities.ts
+++ b/src/lib/weather/cities.ts
@@ -31,6 +31,20 @@ function cleanCityPart(value: string) {
       .replace(/\([^)]*\)/g, ' ')
       .replace(/[-/]/g, ',')
       .replace(/\s+,/g, ',')
+      .replace(/\b\d{5}(-\d{4})?\b/g, '')  // strip US zip codes
+  )
+}
+
+/**
+ * Detect venue/hotel names that aren't city names.
+ * "The Vendue" → true, "Grand Beach Hotel Surfside" → true, "Park Hyatt Tokyo" → true
+ * "Salt Lake City" → false, "New York" → false
+ */
+function looksLikeVenueName(name: string): boolean {
+  return (
+    /^(The|A|An)\s/i.test(name) ||
+    /\b(Hotel|Inn|Hostel|Resort|Suites?|Lodge|Motel|Apartments?|Villas?|Palace|House|Gardens?|Manor|Hall|Centre|Center|Venue|Club|Hyatt|Marriott|Hilton|Sheraton|Westin|Radisson|Novotel|Ibis|Sofitel|Intercontinental|Holiday Inn|Best Western|Hampton|Courtyard)\b/i.test(name) ||
+    /\d{3,}/.test(name) // street addresses contain 3+ digit numbers
   )
 }
 
@@ -46,17 +60,37 @@ export function toCityQuery(location: string | null | undefined): string | null 
 
   if (segments.length === 0) return null
 
+  // Strip leading airport codes (e.g. "CDG, Paris" → start from "Paris")
   const usableSegments =
     segments[0] && /^[A-Z]{3,4}$/.test(segments[0]) && segments.length > 1
       ? segments.slice(1)
       : segments
 
-  const city = usableSegments[0]
-  const region = usableSegments[1]
-  const country = usableSegments[2]
+  // If the first segment looks like a venue/hotel name, skip to the next segment
+  // "Grand Beach Hotel Surfside, 9449 Collins Avenue, Surfside, Florida" → skip to find "Surfside"
+  let cityIndex = 0
+  while (cityIndex < usableSegments.length && looksLikeVenueName(usableSegments[cityIndex])) {
+    cityIndex++
+  }
+  // If we skipped everything (single venue name with no commas), try to extract a city
+  // from the venue name itself by stripping known hotel keywords
+  if (cityIndex >= usableSegments.length) {
+    const stripped = usableSegments[0]
+      .replace(/\b(The|A|An|Hotel|Inn|Hostel|Resort|Suites?|Lodge|Motel|Grand|Royal|Palace|House|Manor|Hall|Park|Hyatt|Marriott|Hilton|Sheraton|Westin|Radisson|Novotel|Ibis|Sofitel|Sonesta|Intercontinental|Hampton|Courtyard|Best|Western)\b/gi, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (stripped && stripped.length > 2) {
+      return stripped
+    }
+    cityIndex = 0
+  }
+
+  const city = usableSegments[cityIndex]
+  // Look for a region/country after the city
+  const regionIndex = cityIndex + 1
+  const region = regionIndex < usableSegments.length ? usableSegments[regionIndex] : null
   const parts = [city]
-  if (region) parts.push(region)
-  else if (country) parts.push(country)
+  if (region && !/^\d/.test(region)) parts.push(region)
   return parts.join(', ')
 }
 


### PR DESCRIPTION
Weather section was blank on trips because hotel locations like full street addresses were being passed to the geocoder verbatim. The geocoder can't resolve street addresses, so it returned nothing and the weather section hid itself.

Fix: `toCityQuery()` now strips hotel names, chain brands, street addresses, and zip codes to extract the actual city.

Examples:
- 'Grand Beach Hotel, 123 Main St, Miami, FL 33139' → 'Miami, FL'
- 'Park Hyatt Tokyo' → 'Tokyo'
- 'The Ritz-Carlton, 400 Elm Ave, Austin, TX' → 'Austin'

113 tests passing.