### PR TITLE
feat: PRD-040 Movement Timeline

### DIFF
--- a/.codex-prompt-040.md
+++ b/.codex-prompt-040.md
@@ -1,0 +1,281 @@
+# PRD-040: Movement Timeline — Full Build
+
+## Overview
+
+Redesign the trip page from a flat date-grouped list into a **Movement Timeline** — city segments showing the user's journey. Hotels anchor where you are, flights are transitions between cities.
+
+**Build ALL phases in one PR. Test throughout. Address all code review findings before declaring complete.**
+
+## Branch
+
+Create branch: `feature/prd-040-movement-timeline`
+
+## What to Build
+
+### Phase 1: City Segmentation Engine
+
+**New file: `src/lib/trips/city-segments.ts`**
+
+```typescript
+export interface TripItemWithWeather extends TripItem {
+  weather?: { emoji: string; temp: string; condition?: string }
+}
+
+export interface CitySegment {
+  city: string           // "Paris, France" or "Austin, TX"
+  countryCode?: string   // "FR", "US" etc for flag emoji
+  startDate: string      // ISO 8601
+  endDate: string
+  durationNights: number
+  anchorType: 'hotel' | 'airport'
+  items: TripItemWithWeather[]
+  transitions: TripItemWithWeather[]  // flights in/out of this segment
+}
+
+export function buildCitySegments(items: TripItem[]): CitySegment[]
+```
+
+**Algorithm:**
+1. Sort all items chronologically by start_ts or start_date
+2. Hotels are ANCHORS — a hotel in a city defines a segment
+3. Flights are TRANSITIONS — they move between segments, not define them
+4. Activities/restaurants/tickets belong to the currently active segment
+5. If no hotel exists for a period, use flight arrival airport mapped to city name
+6. Layovers <4 hours: skip (no segment)
+7. Layovers 4+ hours or overnight: include as segment
+
+**Airport code → city mapping:**
+
+**New file: `src/lib/trips/airport-cities.ts`**
+
+```typescript
+// Common airports. Use this for display names.
+export const AIRPORT_CITIES: Record<string, { city: string; metro?: string; country: string; countryCode: string }> = {
+  CDG: { city: 'Paris', country: 'France', countryCode: 'FR' },
+  ORY: { city: 'Paris', country: 'France', countryCode: 'FR' },
+  JFK: { city: 'New York', metro: 'New York', country: 'USA', countryCode: 'US' },
+  EWR: { city: 'Newark', metro: 'New York', country: 'USA', countryCode: 'US' },
+  LGA: { city: 'New York', metro: 'New York', country: 'USA', countryCode: 'US' },
+  MIA: { city: 'Miami', country: 'USA', countryCode: 'US' },
+  AUS: { city: 'Austin', country: 'USA', countryCode: 'US' },
+  PDX: { city: 'Portland', country: 'USA', countryCode: 'US' },
+  CHS: { city: 'Charleston', country: 'USA', countryCode: 'US' },
+  MXP: { city: 'Milan', country: 'Italy', countryCode: 'IT' },
+  LIN: { city: 'Milan', country: 'Italy', countryCode: 'IT' },
+  FCO: { city: 'Rome', country: 'Italy', countryCode: 'IT' },
+  LHR: { city: 'London', country: 'UK', countryCode: 'GB' },
+  NRT: { city: 'Tokyo', country: 'Japan', countryCode: 'JP' },
+  HND: { city: 'Tokyo', country: 'Japan', countryCode: 'JP' },
+  ICN: { city: 'Seoul', country: 'South Korea', countryCode: 'KR' },
+  PEK: { city: 'Beijing', country: 'China', countryCode: 'CN' },
+  SFO: { city: 'San Francisco', country: 'USA', countryCode: 'US' },
+  LAX: { city: 'Los Angeles', country: 'USA', countryCode: 'US' },
+  ORD: { city: 'Chicago', country: 'USA', countryCode: 'US' },
+  ATL: { city: 'Atlanta', country: 'USA', countryCode: 'US' },
+  DFW: { city: 'Dallas', country: 'USA', countryCode: 'US' },
+  DEN: { city: 'Denver', country: 'USA', countryCode: 'US' },
+  SEA: { city: 'Seattle', country: 'USA', countryCode: 'US' },
+  BOS: { city: 'Boston', country: 'USA', countryCode: 'US' },
+  FLL: { city: 'Fort Lauderdale', country: 'USA', countryCode: 'US' },
+  TPA: { city: 'Tampa', country: 'USA', countryCode: 'US' },
+  MSP: { city: 'Minneapolis', country: 'USA', countryCode: 'US' },
+  DTW: { city: 'Detroit', country: 'USA', countryCode: 'US' },
+  PHX: { city: 'Phoenix', country: 'USA', countryCode: 'US' },
+  SAN: { city: 'San Diego', country: 'USA', countryCode: 'US' },
+  TRN: { city: 'Turin', country: 'Italy', countryCode: 'IT' },
+  NCE: { city: 'Nice', country: 'France', countryCode: 'FR' },
+  BCN: { city: 'Barcelona', country: 'Spain', countryCode: 'ES' },
+  AMS: { city: 'Amsterdam', country: 'Netherlands', countryCode: 'NL' },
+  TLL: { city: 'Tallinn', country: 'Estonia', countryCode: 'EE' },
+  SXM: { city: 'Saint Maarten', country: 'Sint Maarten', countryCode: 'SX' },
+  SCL: { city: 'Santiago', country: 'Chile', countryCode: 'CL' },
+  SRQ: { city: 'Sarasota', country: 'USA', countryCode: 'US' },
+  MDW: { city: 'Chicago', metro: 'Chicago', country: 'USA', countryCode: 'US' },
+  PSP: { city: 'Palm Springs', country: 'USA', countryCode: 'US' },
+}
+
+// Metro area grouping: EWR/JFK/LGA → "New York"
+export function getMetroArea(airportCode: string): string | null
+```
+
+**Use `normaliseToCity` from `src/lib/trips/assignment.ts`** to strip hotel names from locations (already handles "Grand Beach Hotel Surfside" → "Surfside" etc). Import and reuse it, don't duplicate.
+
+**New file: `src/lib/trips/city-segments.test.ts`**
+
+Write thorough tests:
+- Single-city trip (just a hotel) → 1 segment
+- Multi-city with hotels (Paris hotel → fly to Austin → Austin hotel) → 2 segments + 1 transition
+- Flight-only trip (no hotels) → segments from arrival airports
+- Layover <4h → skipped
+- Overnight layover → included
+- Round trip (NYC → Paris → NYC) → 3 segments (NYC, Paris, NYC)
+- Metro area grouping (EWR arrival + JFK departure = same "New York" segment)
+- Items with no location → attach to current segment
+- Empty items → empty segments array
+
+### Phase 2: Movement Timeline Component
+
+**New file: `src/components/trips/movement-timeline.tsx`**
+
+Replace the current `TripTimeline` with a new `MovementTimeline` component.
+
+**Desktop layout:** Two-column with date spine on left, city segments on right.
+**Mobile layout:** Single column, city segment headers as section breaks.
+
+```tsx
+interface MovementTimelineProps {
+  segments: CitySegment[]
+  tripId: string
+  allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
+  currentUserId?: string
+  weatherEndpoint?: string  // for fetching weather data
+}
+```
+
+**City Segment Header** — new component `src/components/trips/city-segment-header.tsx`:
+- City name + country flag emoji (use countryCode → flag emoji helper)
+- Duration: "4 nights · Mar 8–12" or "1 night · Mar 9"
+- Compact weather strip (if weather data available)
+
+**Transition Flight** — new component `src/components/trips/transition-flight.tsx`:
+- Appears BETWEEN city segments
+- Lighter styling: dotted border, subtle background, airplane icon
+- Shows: "✈️ Flight to London · 2h 15m"
+- Should NOT look like a regular trip item card
+
+**Keep existing `TripItemCard`** mostly intact — just add a weather chip slot.
+
+**Flag emoji helper:**
+```typescript
+function countryCodeToFlag(code: string): string {
+  return code.toUpperCase().replace(/./g, c => 
+    String.fromCodePoint(c.charCodeAt(0) + 127397)
+  )
+}
+```
+
+### Phase 3: Inline Weather on Trip Items
+
+**Modify `src/components/trips/trip-item-card.tsx`:**
+
+Add a small weather chip in the top-right corner of each card:
+```
+☀️ 28°C
+```
+
+The weather data comes from the segment's weather data, looked up by the item's date.
+
+**New file: `src/lib/weather/item-weather.ts`**
+
+```typescript
+// WMO weather code → emoji mapping
+export const WMO_EMOJI: Record<number, string> = {
+  0: '☀️',    // Clear sky
+  1: '🌤️',   // Mainly clear
+  2: '⛅',    // Partly cloudy
+  3: '☁️',    // Overcast
+  45: '🌫️',  // Fog
+  48: '🌫️',  // Depositing rime fog
+  51: '🌦️',  // Light drizzle
+  53: '🌦️',  // Moderate drizzle
+  55: '🌧️',  // Dense drizzle
+  61: '🌧️',  // Slight rain
+  63: '🌧️',  // Moderate rain
+  65: '🌧️',  // Heavy rain
+  71: '🌨️',  // Slight snow
+  73: '🌨️',  // Moderate snow
+  75: '❄️',   // Heavy snow
+  77: '❄️',   // Snow grains
+  80: '🌦️',  // Slight rain showers
+  81: '🌧️',  // Moderate rain showers
+  82: '🌧️',  // Violent rain showers
+  85: '🌨️',  // Slight snow showers
+  86: '❄️',   // Heavy snow showers
+  95: '⛈️',  // Thunderstorm
+  96: '⛈️',  // Thunderstorm with slight hail
+  99: '⛈️',  // Thunderstorm with heavy hail
+}
+
+export function getWeatherEmoji(code: number): string
+export function getItemWeather(itemDate: string, segmentWeather: DailyWeather[]): { emoji: string; temp: string } | null
+```
+
+**Fetch weather per segment:** The weather API already returns per-city data. We need to restructure so each segment's weather data is matched to items by date.
+
+The trip page should fetch weather data and distribute it to segments. Modify the weather fetching in the page component to pass weather data into segments.
+
+### Phase 4: Segment-Level Weather
+
+Move the `WeatherSection` from the bottom of the page INTO each city segment header.
+
+Each segment gets a compact multi-day weather strip showing daily forecasts for the stay dates. This replaces the single WeatherSection at the bottom.
+
+**Modify `src/components/trips/city-segment-header.tsx`** to accept weather data and render a compact forecast strip:
+- Small day cells: date + emoji + high/low temp
+- Horizontally scrollable on mobile
+- Only show days the traveler is in that city
+
+**Packing suggestions** (Pro feature) move to within each segment too — or keep as a single consolidated section. Use your judgment for what's cleaner.
+
+### Phase 5: Share Page
+
+**`src/app/share/[token]/page.tsx`** must use the SAME `MovementTimeline` component.
+
+- Import `buildCitySegments` and run it on the share page's items
+- Pass segments to `MovementTimeline`
+- Share page shows weather cards but NOT packing suggestions (share viewers aren't traveling)
+- The share page should look just as good as the dashboard — it's the showcase
+
+### Phase 6: Time Display Fix
+
+**`src/lib/utils.ts`** — update `formatTime()`:
+- Remove hardcoded `hour12: false`
+- Use `hour12: undefined` to respect browser locale
+- Times are ALWAYS in destination timezone — no timezone toggle
+
+### Phase 7: Traveler Dedup
+
+**New file: `src/lib/trips/traveler-dedup.ts`**
+
+```typescript
+export function deduplicateTravelers(names: string[]): string[]
+```
+
+- Normalize: trim, title-case, strip honorifics/suffixes
+- Group by similarity: first+last match, token subset, Levenshtein ≤ 2
+- Pick canonical: longest variant wins
+- Integrate into `collectTravelerNames()` in assignment.ts
+
+**New file: `src/lib/trips/traveler-dedup.test.ts`**
+
+## Critical Rules
+
+1. **Do NOT use `createSecretClient()` or service role to bypass RLS.** Fix RLS policies instead.
+2. **Run `pnpm test` after each phase.** All tests must pass.
+3. **Run `pnpm build` to verify no build errors.**
+4. **Write unit tests for all new files.**
+5. **Use existing components where possible** — don't duplicate TripItemCard, reuse normaliseToCity from assignment.ts, etc.
+6. **Share page and dashboard use the SAME components** — no duplication.
+7. **Responsive design** — must work on mobile. Test with different viewport widths.
+8. **Import types from `@/types/database`** — don't create duplicate type definitions.
+
+## When Done
+
+1. Push the branch
+2. Create a PR with a clear description of what changes for users
+3. Run: `bash scripts/merge-ready-check.sh <PR_NUMBER>`
+4. Run all tests one final time: `pnpm test`
+5. Run build: `pnpm build`
+
+## Existing Code to Reference
+
+- `src/components/trips/trip-timeline.tsx` — current timeline (replace with MovementTimeline)
+- `src/components/trips/trip-item-card.tsx` — keep, add weather chip
+- `src/components/trips/weather/weather-section.tsx` — current weather section (restructure into segments)
+- `src/components/trips/weather/city-weather-card.tsx` — existing weather card
+- `src/lib/weather/cities.ts` — existing city extraction (reuse toCityQuery, extractTripCities)
+- `src/lib/weather/types.ts` — existing weather types
+- `src/lib/trips/assignment.ts` — has normaliseToCity, looksLikeVenueName, getPrimaryLocation
+- `src/app/(dashboard)/trips/[id]/page.tsx` — trip page (update to use MovementTimeline)
+- `src/app/share/[token]/page.tsx` — share page (update to use MovementTimeline)
+- `src/lib/utils.ts` — formatTime (fix hour12), formatDate, groupByDate

--- a/scripts/feedback-pipeline.md
+++ b/scripts/feedback-pipeline.md
@@ -1,0 +1,45 @@
+# Feedback-to-Fix Pipeline
+
+## Status Flow
+
+```
+new → triaged → building → review → merge-ready → shipped
+                                                 → acknowledged
+```
+
+- **new** — user submitted, nobody's looked at it
+- **triaged** — opus evaluated, admin_notes has reasoning
+- **building** — codex is implementing the fix
+- **review** — PR exists, code reviews in progress
+- **merge-ready** — all CI green, reviews addressed, awaiting Ian's merge
+- **shipped** — Ian merged, fix is live
+- **acknowledged** — we read it, it's valid feedback, but we're not acting on it now (polite decline)
+
+## Pipeline Steps
+
+### Step 1: Triage (opus)
+Read all `status=new` feedback. For each item:
+- Is this a real bug, a feature request, or noise?
+- Is it actionable (can we actually fix/build this)?
+- Is it a duplicate of something already shipped or in progress?
+- What's the user impact? How many users would benefit?
+- Write reasoning to `admin_notes`
+- Set status to `triaged`
+- If actionable bug: write a mini-PRD in admin_notes and proceed to Step 2
+- If feature request worth building: write PRD in Obsidian, message Ian for approval, set status to `triaged`
+- If not actionable: set status to `acknowledged`, write polite reasoning in admin_notes
+
+### Step 2: Build (codex/gpt-5.4)
+- Spawn Codex with the triage notes as context
+- Create branch `fix/feedback-<id>` or `feat/feedback-<id>`
+- Build the fix, run tests
+- Push and create PR with description of exactly what changes on the site
+
+### Step 3: Follow-through (watchdog)
+- Monitor CI, address code review findings
+- Run merge-ready gate
+- When ready: message Ian with PR link + plain-English description of what the change does
+
+### Step 4: Resolution
+- Ian merges → status = `shipped`
+- Ian declines → status = `acknowledged`

--- a/scripts/merge-ready-check.sh
+++ b/scripts/merge-ready-check.sh
@@ -42,14 +42,39 @@ fi
 # 3. No unresolved review comments
 echo ""
 echo "--- Code Reviews ---"
-REVIEW_COMMENTS=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/comments" --jq 'length' 2>/dev/null || echo "0")
 REVIEWS=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/reviews" --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0")
 if [ "$REVIEWS" -gt 0 ]; then
   fail "Has CHANGES_REQUESTED reviews"
 else
-  pass "No blocking reviews"
+  pass "No blocking reviews (CHANGES_REQUESTED)"
 fi
-echo "   Inline review comments: $REVIEW_COMMENTS"
+
+# Check for unaddressed inline review comments from code review bots
+# These are substantive findings (security, correctness) that MUST be addressed
+REVIEW_COMMENTS=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/comments" --jq 'length' 2>/dev/null || echo "0")
+BOT_FINDINGS=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/comments" \
+  --jq '[.[] | select(.user.login | test("gemini|claude|github-actions"; "i")) | select(.body | test("security|critical|high|medium|bug|risk|incorrect|regression"; "i"))] | length' \
+  2>/dev/null || echo "0")
+
+if [ "$BOT_FINDINGS" -gt 0 ]; then
+  # Check if there are commits AFTER the review comments (i.e., fixes were pushed)
+  LAST_REVIEW_TIME=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/comments" \
+    --jq '[.[] | select(.user.login | test("gemini|claude|github-actions"; "i"))] | sort_by(.created_at) | last | .created_at' \
+    2>/dev/null || echo "")
+  LAST_COMMIT_TIME=$(gh api "repos/${GITHUB_REPOSITORY:-fistfulayen/ubtrippin}/pulls/${PR}/commits" \
+    --jq 'last | .commit.committer.date' \
+    2>/dev/null || echo "")
+
+  if [ -n "$LAST_REVIEW_TIME" ] && [ -n "$LAST_COMMIT_TIME" ] && [[ "$LAST_COMMIT_TIME" > "$LAST_REVIEW_TIME" ]]; then
+    pass "Code review findings addressed (${BOT_FINDINGS} findings, commits pushed after reviews)"
+  else
+    fail "Code review bots found ${BOT_FINDINGS} substantive issues — address them before declaring merge-ready"
+    echo "   Run: gh api repos/fistfulayen/ubtrippin/pulls/${PR}/comments --jq '.[] | select(.user.login | test(\"gemini|claude\"; \"i\")) | .body[:200]'"
+  fi
+else
+  pass "No substantive bot review findings"
+fi
+echo "   Total inline comments: $REVIEW_COMMENTS"
 
 # 4. Build passes locally
 echo ""

--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -1,13 +1,14 @@
 import { createClient } from '@/lib/supabase/server'
 import { notFound } from 'next/navigation'
 import { TripHeader } from '@/components/trips/trip-header'
-import { TripTimeline } from '@/components/trips/trip-timeline'
+import { MovementTimeline } from '@/components/trips/movement-timeline'
 import { TripActions } from '@/components/trips/trip-actions'
 import { CollaboratorsSection } from '@/components/trips/collaborators-section'
 import { DemoTripBanner } from '@/components/trips/demo-trip-banner'
-import { WeatherSection } from '@/components/trips/weather/weather-section'
 import { ArrowLeft, Users } from 'lucide-react'
 import Link from 'next/link'
+import { buildCitySegments } from '@/lib/trips/city-segments'
+import { getTripWeather } from '@/lib/weather/service'
 
 interface TripPageProps {
   params: Promise<{ id: string }>
@@ -82,10 +83,19 @@ export default async function TripPage({ params }: TripPageProps) {
     ? await supabase
         .from('profiles')
         .select('subscription_tier')
-        .eq('id', user.id)
+        .eq('id', trip.user_id)
         .maybeSingle()
     : { data: null }
-  const isPro = profileData?.subscription_tier === 'pro'
+  const ownerIsPro = profileData?.subscription_tier === 'pro'
+  const segments = buildCitySegments(items || [])
+  const weather = user
+    ? await getTripWeather({
+        tripId: trip.id,
+        supabase,
+        userId: user.id,
+        includePacking: ownerIsPro,
+      })
+    : null
 
   return (
     <div className="space-y-6">
@@ -116,7 +126,7 @@ export default async function TripPage({ params }: TripPageProps) {
 
       {/* Actions bar — show to owners and editors */}
       {canEdit && (
-        <TripActions trip={trip} allTrips={allTrips || []} isOwner={isOwner} isPro={isPro} />
+        <TripActions trip={trip} allTrips={allTrips || []} isOwner={isOwner} isPro={ownerIsPro} />
       )}
 
       {/* Collaborators section */}
@@ -126,10 +136,15 @@ export default async function TripPage({ params }: TripPageProps) {
         isOwner={isOwner}
       />
 
-      {/* Timeline */}
-      <TripTimeline items={items || []} tripId={trip.id} allTrips={allTrips || []} currentUserId={user?.id} />
-
-      <WeatherSection endpoint={`/api/trips/${trip.id}/weather`} showPacking />
+      <MovementTimeline
+        segments={segments}
+        tripId={trip.id}
+        allTrips={allTrips || []}
+        currentUserId={user?.id}
+        weatherEndpoint={`/api/trips/${trip.id}/weather`}
+        initialWeather={weather}
+        showPacking
+      />
     </div>
   )
 }

--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -79,6 +79,9 @@ export default async function TripPage({ params }: TripPageProps) {
 
   const canEdit = isOwner || collabRole === 'editor'
 
+  // Check the TRIP OWNER's tier, not the viewer's. This is intentional:
+  // collaborators on a Pro user's trip see Pro features (packing suggestions).
+  // The Pro subscription belongs to the trip, not the viewer.
   const { data: profileData } = user
     ? await supabase
         .from('profiles')

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -100,6 +100,7 @@ const getSharedTripData = cache(async (token: string): Promise<{ trip: SharedTri
     .from('trips')
     .select('id, user_id, title, start_date, end_date, primary_location, travelers, notes, cover_image_url, share_enabled')
     .eq('share_enabled', true)
+    .eq('share_token', token)  // defense-in-depth: don't rely solely on RLS
     .single()
 
   const trip = (tripRow as SharedTrip | null) ?? null
@@ -125,10 +126,21 @@ const getSharedTripData = cache(async (token: string): Promise<{ trip: SharedTri
     void confirmation_code
     void booking_reference
 
+    // Strip sensitive fields: user_id (owner UUID), confirmation codes, traveler full names
+    const obfuscatedTravelers = Array.isArray(item.traveler_names)
+      ? item.traveler_names.map((name: string) => {
+          const parts = name.trim().split(/\s+/)
+          if (parts.length >= 2) return `${parts[0]} ${parts[parts.length - 1][0]}.`
+          return parts[0]
+        })
+      : item.traveler_names
+
     return {
       ...item,
+      user_id: '00000000-0000-0000-0000-000000000000',  // null out owner UUID
       confirmation_code: null,
       source_email_id: null,
+      traveler_names: obfuscatedTravelers,
       details_json: safeDetails as Json,
     } as TripItem
   })

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -2,32 +2,18 @@ import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
-import {
-  MapPin,
-  Calendar,
-  Users,
-  Plane,
-  Building2,
-  TrainFront,
-  Car,
-  Utensils,
-  Ticket,
-  CalendarDays,
-} from 'lucide-react'
+import { MapPin, Calendar, Users, CalendarDays } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
-import { createSecretClient } from '@/lib/supabase/service'
-import { formatDateRange, getKindIcon } from '@/lib/utils'
+import { createPublicShareClient } from '@/lib/supabase/public-share'
+import { formatDateRange } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
-import { getProviderLogoUrl } from '@/lib/images/provider-logo'
-import { extractAirlineCode } from '@/lib/images/airline-logo'
-import type { TripItemKind } from '@/types/database'
-import { WeatherSection } from '@/components/trips/weather/weather-section'
-import { buildWeatherPayload, getTemperatureUnit, getTripWeather } from '@/lib/weather/service'
-import type { Json } from '@/types/database'
-import type { WeatherTripItem } from '@/lib/weather/types'
-import { AirlineLogoIcon } from './airline-logo-icon'
 import { ShareTripButton } from './share-trip-button'
+import { buildWeatherPayload, getTripWeather, getTemperatureUnit } from '@/lib/weather/service'
+import type { Json, Trip, TripItem } from '@/types/database'
+import { buildCitySegments } from '@/lib/trips/city-segments'
+import { MovementTimeline } from '@/components/trips/movement-timeline'
+import type { WeatherResponsePayload } from '@/lib/weather/types'
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.ubtrippin.xyz'
 const DEFAULT_OG_IMAGE_URL = `${APP_URL}/x-header.png`
@@ -36,140 +22,64 @@ interface SharePageProps {
   params: Promise<{ token: string }>
 }
 
-interface ShareTrip {
-  id: string
-  title: string
-  start_date: string
-  end_date: string | null
-  primary_location: string | null
-  travelers: string[] | null
-  notes: string | null
-  cover_image_url: string | null
-  share_enabled: boolean | null
-}
+type SharedTrip = Pick<
+  Trip,
+  | 'id'
+  | 'user_id'
+  | 'title'
+  | 'start_date'
+  | 'end_date'
+  | 'primary_location'
+  | 'travelers'
+  | 'notes'
+  | 'cover_image_url'
+  | 'share_enabled'
+>
 
-interface ShareTripItem {
-  id: string
-  kind: TripItemKind
-  provider: string | null
-  traveler_names: string[]
-  start_date: string
-  end_date: string | null
-  start_location: string | null
-  end_location: string | null
-  summary: string | null
-  details_json: Record<string, unknown> | null
-}
+type SharedItemRow = Pick<
+  TripItem,
+  | 'id'
+  | 'user_id'
+  | 'trip_id'
+  | 'kind'
+  | 'provider'
+  | 'traveler_names'
+  | 'start_ts'
+  | 'end_ts'
+  | 'start_date'
+  | 'end_date'
+  | 'start_location'
+  | 'end_location'
+  | 'summary'
+  | 'details_json'
+  | 'status'
+  | 'confidence'
+  | 'needs_review'
+  | 'loyalty_flag'
+  | 'created_at'
+  | 'updated_at'
+>
 
-const DAY_MS = 24 * 60 * 60 * 1000
-const MINUTE_MS = 60 * 1000
+const isValidShareToken = (token: string) => /^[A-Za-z0-9_-]{10,64}$/.test(token)
 
-/** Return first name + last initial only (e.g. "John Smith" -> "John S.") */
-function obfuscateName(name: string): string {
+function obfuscateName(name: string) {
   const parts = name.trim().split(/\s+/)
   if (parts.length === 1) return parts[0]
   return `${parts[0]} ${parts[parts.length - 1][0]}.`
 }
 
-/** Capitalise first letter of a string */
-function capitalise(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1)
-}
-
-function KindIcon({ kind, className }: { kind: TripItemKind; className?: string }) {
-  const icon = getKindIcon(kind)
-  const props = { className: className ?? 'h-4 w-4' }
-  switch (icon) {
-    case 'plane':
-      return <Plane {...props} />
-    case 'building':
-      return <Building2 {...props} />
-    case 'train-front':
-      return <TrainFront {...props} />
-    case 'car':
-      return <Car {...props} />
-    case 'utensils':
-      return <Utensils {...props} />
-    case 'ticket':
-      return <Ticket {...props} />
-    default:
-      return <CalendarDays {...props} />
-  }
-}
-
-const kindColors: Record<TripItemKind, string> = {
-  flight: 'bg-sky-100 text-sky-800',
-  hotel: 'bg-[#f1f5f9] text-[#1e293b]',
-  train: 'bg-emerald-100 text-emerald-800',
-  car: 'bg-[#f1f5f9] text-[#4f46e5]',
-  restaurant: 'bg-rose-100 text-rose-800',
-  activity: 'bg-purple-100 text-purple-800',
-  ticket: 'bg-amber-100 text-amber-800',
-  other: 'bg-gray-100 text-gray-800',
-}
-
-const isValidShareToken = (token: string) => /^[A-Za-z0-9_-]{10,64}$/.test(token)
-
-const getSharedTripData = cache(async (token: string): Promise<{ trip: ShareTrip | null; items: ShareTripItem[] | null }> => {
-  if (!isValidShareToken(token)) {
-    return { trip: null, items: null }
-  }
-
-  const supabase = createSecretClient()
-
-  // SECURITY: Select only fields needed for display — exclude sensitive fields (confirmation_code, etc.)
-  // Note: service-role client is required here since visitors are unauthenticated.
-  // RLS is intentionally bypassed; share_enabled check acts as the gate.
-  const { data: tripRow } = await supabase
-    .from('trips')
-    .select('id, title, start_date, end_date, primary_location, travelers, notes, cover_image_url, share_enabled')
-    .eq('share_token', token)
-    .eq('share_enabled', true)
-    .single()
-
-  const trip = tripRow as ShareTrip | null
-  if (!trip) {
-    return { trip: null, items: null }
-  }
-
-  // SECURITY: Fetch fields needed for display — explicitly exclude confirmation_code and
-  // source_email_id. details_json is included but sanitised below before rendering.
-  const { data: rawItems } = await supabase
-    .from('trip_items')
-    .select('id, trip_id, kind, provider, summary, start_date, end_date, start_ts, end_ts, start_location, end_location, traveler_names, needs_review, status, details_json')
-    .eq('trip_id', trip.id)
-    .order('start_date', { ascending: true })
-    .order('start_ts', { ascending: true })
-
-  // Strip sensitive fields from details_json before passing to the component
-  const items = rawItems?.map((item): ShareTripItem => {
-    const { details_json, ...rest } = item
-    let safeDetails: Record<string, unknown> | null = null
-    if (details_json && typeof details_json === 'object') {
-      const { confirmation_code, booking_reference, ...remaining } = details_json as Record<string, unknown>
-      void confirmation_code
-      void booking_reference
-      safeDetails = remaining
-    }
-    return { ...rest, details_json: safeDetails }
-  }) ?? null
-
-  return { trip, items }
-})
-
 function normaliseCityLabel(location: string) {
-  // Strip anything that isn't alphanumeric, space, hyphen, period, or common diacritics
   const city = location.split(',')[0].trim()
   return city.replace(/[^\p{L}\p{N}\s.\-']/gu, '').slice(0, 100)
 }
 
-function buildTripSummaryDescription(trip: ShareTrip, items: ShareTripItem[] | null) {
+function buildTripSummaryDescription(trip: SharedTrip, items: TripItem[]) {
   const dateLabel = formatDateRange(trip.start_date, trip.end_date)
-  const itemCount = items?.length ?? 0
+  const itemCount = items.length
 
   const cities = new Set<string>()
   if (trip.primary_location) cities.add(normaliseCityLabel(trip.primary_location))
-  items?.forEach((item) => {
+  items.forEach((item) => {
     if (item.start_location) cities.add(normaliseCityLabel(item.start_location))
     if (item.end_location) cities.add(normaliseCityLabel(item.end_location))
   })
@@ -179,231 +89,52 @@ function buildTripSummaryDescription(trip: ShareTrip, items: ShareTripItem[] | n
   return [dateLabel, itemLabel, cityList].filter(Boolean).join(' · ')
 }
 
-function formatTimelineDate(date: string | null) {
-  if (!date) return 'Date TBD'
-  const parsed = new Date(`${date}T00:00:00`)
-  if (Number.isNaN(parsed.getTime())) return 'Date TBD'
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(parsed)
-}
-
-function readNumber(details: Record<string, unknown> | null, key: string) {
-  const value = details?.[key]
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
-}
-
-function readString(details: Record<string, unknown> | null, key: string) {
-  const value = details?.[key]
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
-}
-
-function formatHoursAndMinutes(totalMinutes: number) {
-  const roundedMinutes = Math.max(1, Math.round(totalMinutes))
-  const hours = Math.floor(roundedMinutes / 60)
-  const minutes = roundedMinutes % 60
-  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
-  if (hours > 0) return `${hours}h`
-  return `${minutes}m`
-}
-
-function parseDateWithOptionalTime(date: string | null, hhmm: string | undefined, endOfDay = false) {
-  if (!date) return null
-  // Validate date format to prevent unexpected Date parsing behavior
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
-  const normalizedTime = hhmm && /^\d{1,2}:\d{2}$/.test(hhmm)
-    ? `${hhmm.padStart(5, '0')}:00`
-    : (endOfDay ? '23:59:00' : '00:00:00')
-  const parsed = new Date(`${date}T${normalizedTime}`)
-  return Number.isNaN(parsed.getTime()) ? null : parsed
-}
-
-function getItemStartDate(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const departureTime = readString(details, 'departure_local_time') ?? undefined
-  return parseDateWithOptionalTime(item.start_date, departureTime, false)
-}
-
-function getItemEndDate(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const arrivalTime = readString(details, 'arrival_local_time') ?? undefined
-  return parseDateWithOptionalTime(item.end_date ?? item.start_date, arrivalTime, true)
-}
-
-/**
- * Extract a city name from a location string.
- * Hotel locations are often full names like "The Stephen F Austin Royal Sonesta Hotel"
- * with no comma-separated city. We only return a city if the location looks like
- * "City, State" or "Place, City, Country" — i.e., has a comma.
- */
-function extractCity(location: string | null): string | null {
-  if (!location) return null
-  // Only treat as a city if there's a comma (e.g. "Austin, TX" or "Miami, FL")
-  // Full hotel/venue names without commas are not useful city labels
-  if (!location.includes(',')) return null
-  return normaliseCityLabel(location)
-}
-
-function formatGapLabel(previous: ShareTripItem, next: ShareTripItem) {
-  const previousEnd = getItemEndDate(previous)
-  const nextStart = getItemStartDate(next)
-  if (!previousEnd || !nextStart) return null
-
-  const diffMs = nextStart.getTime() - previousEnd.getTime()
-  if (diffMs <= 0) return null
-
-  if (diffMs < DAY_MS) {
-    const totalMinutes = diffMs / MINUTE_MS
-    return `${formatHoursAndMinutes(totalMinutes)} layover`
+const getSharedTripData = cache(async (token: string): Promise<{ trip: SharedTrip | null; items: TripItem[] }> => {
+  if (!isValidShareToken(token)) {
+    return { trip: null, items: [] }
   }
 
-  // Use ceiling for day count — a gap from Tue afternoon to Thu morning is 2 days, not 1
-  const days = Math.max(1, Math.ceil(diffMs / DAY_MS))
-  // Prefer the city where you ARE (previous end), not where you're going
-  const city = extractCity(previous.end_location) ?? extractCity(next.start_location)
-  if (!city) return `${days} ${days === 1 ? 'day' : 'days'}`
-  return `${days} ${days === 1 ? 'day' : 'days'} in ${city}`
-}
+  const supabase = createPublicShareClient(token)
 
-function getFlightDurationLabel(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const textDuration = readString(details, 'flight_duration')
-    ?? readString(details, 'duration')
-    ?? readString(details, 'flight_time')
-  if (textDuration) return textDuration
+  const { data: tripRow } = await supabase
+    .from('trips')
+    .select('id, user_id, title, start_date, end_date, primary_location, travelers, notes, cover_image_url, share_enabled')
+    .eq('share_enabled', true)
+    .single()
 
-  const minutes = readNumber(details, 'flight_duration_minutes')
-    ?? readNumber(details, 'duration_minutes')
-    ?? readNumber(details, 'flight_time_minutes')
-  if (minutes && minutes > 0) return formatHoursAndMinutes(minutes)
-
-  const start = getItemStartDate(item)
-  const end = getItemEndDate(item)
-  if (start && end) {
-    const diffMinutes = (end.getTime() - start.getTime()) / MINUTE_MS
-    if (diffMinutes > 0 && diffMinutes < 48 * 60) {
-      return formatHoursAndMinutes(diffMinutes)
-    }
+  const trip = (tripRow as SharedTrip | null) ?? null
+  if (!trip) {
+    return { trip: null, items: [] }
   }
-  return null
-}
 
-function getHotelDurationLabel(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const nightsFromDetails = readNumber(details, 'nights')
-  if (nightsFromDetails && nightsFromDetails > 0) {
-    return `${nightsFromDetails} ${nightsFromDetails === 1 ? 'night' : 'nights'}`
-  }
-  if (item.end_date) {
-    const start = parseDateWithOptionalTime(item.start_date, undefined, false)
-    const end = parseDateWithOptionalTime(item.end_date, undefined, false)
-    if (start && end) {
-      const nights = Math.max(1, Math.round((end.getTime() - start.getTime()) / DAY_MS))
-      return `${nights} ${nights === 1 ? 'night' : 'nights'}`
-    }
-  }
-  return null
-}
+  const { data: rawItemRows } = await supabase
+    .from('trip_items')
+    .select('id, user_id, trip_id, kind, provider, traveler_names, start_ts, end_ts, start_date, end_date, start_location, end_location, summary, details_json, status, confidence, needs_review, loyalty_flag, created_at, updated_at')
+    .eq('trip_id', trip.id)
+    .order('start_date', { ascending: true })
+    .order('start_ts', { ascending: true })
 
-function getItemDurationLabel(item: ShareTripItem) {
-  switch (item.kind) {
-    case 'flight': return getFlightDurationLabel(item)
-    case 'hotel': return getHotelDurationLabel(item)
-    default: return null
-  }
-}
+  const rawItems = (rawItemRows ?? []) as SharedItemRow[]
 
-function TripItemRow({ item, durationLabel }: { item: ShareTripItem; durationLabel?: string | null }) {
-  const names = item.traveler_names.map(obfuscateName)
-  const location =
-    item.start_location && item.end_location
-      ? `${item.start_location} → ${item.end_location}`
-      : item.start_location || item.end_location || null
-  const details = item.details_json as Record<string, unknown> | null
-  const flightNumber = details?.flight_number as string | undefined
-  const iataCode = flightNumber ? extractAirlineCode(flightNumber) : null
-  const airlineLogoUrl = item.kind === 'flight'
-    ? (iataCode ? `https://pics.avs.io/80/80/${iataCode}@2x.png` : (item.provider ? getProviderLogoUrl(item.provider, item.kind) : null))
-    : null
-  const departureTime = details?.departure_local_time as string | undefined
-  const arrivalTime = details?.arrival_local_time as string | undefined
-  const displayTitle = flightNumber
-    ? `${item.provider ?? capitalise(item.kind)} ${flightNumber}`
-    : item.provider ?? capitalise(item.kind)
+  const items: TripItem[] = rawItems.map((item) => {
+    const details = item.details_json && typeof item.details_json === 'object' && !Array.isArray(item.details_json)
+      ? (item.details_json as Record<string, unknown>)
+      : null
 
-  const timeDisplay = departureTime && arrivalTime
-    ? `${departureTime} → ${arrivalTime}`
-    : departureTime
-      ? `Departs ${departureTime}`
-      : arrivalTime
-        ? `Arrives ${arrivalTime}`
-        : null
+    const { confirmation_code, booking_reference, ...safeDetails } = details ?? {}
+    void confirmation_code
+    void booking_reference
 
-  return (
-    <div className="flex items-start gap-3 py-4">
-      {airlineLogoUrl ? (
-        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-white">
-          <AirlineLogoIcon url={airlineLogoUrl} alt={item.provider || 'Airline'} />
-        </div>
-      ) : (
-        <div
-          className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${kindColors[item.kind]}`}
-        >
-          <KindIcon kind={item.kind} className="h-4 w-4" />
-        </div>
-      )}
+    return {
+      ...item,
+      confirmation_code: null,
+      source_email_id: null,
+      details_json: safeDetails as Json,
+    } as TripItem
+  })
 
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-medium text-gray-900">
-            {displayTitle}
-          </span>
-          <span
-            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${kindColors[item.kind]}`}
-          >
-            {capitalise(item.kind)}
-          </span>
-          {durationLabel && (
-            <span className="inline-flex items-center rounded-full border border-[#cbd5e1] bg-[#eef2ff] px-2 py-0.5 text-xs font-medium text-[#4338ca]">
-              {durationLabel}
-            </span>
-          )}
-        </div>
-
-        {timeDisplay && (
-          <p className="mt-1 text-sm font-medium text-gray-800">{timeDisplay}</p>
-        )}
-
-        {item.summary && !timeDisplay && (
-          <p className="mt-0.5 text-sm leading-snug text-gray-600">{item.summary}</p>
-        )}
-
-        <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
-          {(item.start_date || item.end_date) && (
-            <span className="flex items-center gap-1">
-              <Calendar className="h-3 w-3 text-[#4f46e5]" />
-              {formatDateRange(item.start_date, item.end_date)}
-            </span>
-          )}
-          {location && (
-            <span className="flex items-center gap-1">
-              <MapPin className="h-3 w-3 text-[#4f46e5]" />
-              {location}
-            </span>
-          )}
-          {names.length > 0 && (
-            <span className="flex items-center gap-1">
-              <Users className="h-3 w-3 text-[#4f46e5]" />
-              {names.join(', ')}
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
+  return { trip, items }
+})
 
 export async function generateMetadata({ params }: SharePageProps): Promise<Metadata> {
   const { token } = await params
@@ -443,22 +174,11 @@ export default async function SharePage({ params }: SharePageProps) {
   const { token } = await params
   const { trip, items } = await getSharedTripData(token)
 
-  if (!isValidShareToken(token)) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-[#ffffff] p-8">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">Trip not found</h1>
-          <p className="mt-2 text-gray-500">This trip either doesn&apos;t exist or sharing has been disabled.</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!trip) {
+  if (!isValidShareToken(token) || !trip) {
     return (
       <div className="flex min-h-screen flex-col bg-[#ffffff]">
         <header className="border-b border-[#cbd5e1] bg-white/80 backdrop-blur-sm">
-          <div className="mx-auto max-w-4xl px-4 py-4">
+          <div className="mx-auto max-w-5xl px-4 py-4">
             <Link href="/" className="flex items-center gap-2">
               <Image src="/ubtrippin_logo.png" alt="UBTRIPPIN" width={32} height={32} className="rounded-lg" />
               <span className="text-lg font-bold text-[#4338ca]">UBTRIPPIN</span>
@@ -488,74 +208,64 @@ export default async function SharePage({ params }: SharePageProps) {
   }
 
   const travelers = (trip.travelers ?? []).map(obfuscateName)
-  const itemCount = items?.length ?? 0
   const sessionSupabase = await createClient()
   const {
     data: { user },
   } = await sessionSupabase.auth.getUser()
 
-  let sharedWeather = items
-    ? await buildWeatherPayload({
-        trip: {
-          id: trip.id,
-          user_id: '',
-          title: trip.title,
-          start_date: trip.start_date,
-          end_date: trip.end_date,
-          share_enabled: trip.share_enabled ?? false,
-        },
-        items: items.map(
-          (item): WeatherTripItem => ({
-            id: item.id,
-            trip_id: trip.id,
-            kind: item.kind,
-            start_date: item.start_date,
-            end_date: item.end_date,
-            start_ts: null,
-            end_ts: null,
-            start_location: item.start_location,
-            end_location: item.end_location,
-            provider: item.provider,
-            summary: item.summary,
-            details_json: (item.details_json ?? {}) as Json,
-          })
-        ),
-        unit: 'fahrenheit',
-        includePacking: false,
-      })
-    : null
+  let sharedWeather: WeatherResponsePayload | null = await buildWeatherPayload({
+    trip: {
+      id: trip.id,
+      user_id: trip.user_id,
+      title: trip.title,
+      start_date: trip.start_date,
+      end_date: trip.end_date,
+      share_enabled: trip.share_enabled,
+    },
+    items: items.map((item) => ({
+      id: item.id,
+      trip_id: item.trip_id,
+      kind: item.kind,
+      start_date: item.start_date,
+      end_date: item.end_date,
+      start_ts: item.start_ts,
+      end_ts: item.end_ts,
+      start_location: item.start_location,
+      end_location: item.end_location,
+      provider: item.provider,
+      summary: item.summary,
+      details_json: item.details_json,
+    })),
+    unit: 'fahrenheit',
+    includePacking: false,
+  })
 
-  let showPacking = false
   if (user) {
     const { data: accessibleTrip } = await sessionSupabase
       .from('trips')
-      .select('id, user_id')
+      .select('id')
       .eq('id', trip.id)
       .maybeSingle()
 
     if (accessibleTrip) {
-      const { data: ownerProfile } = await sessionSupabase
-        .from('profiles')
-        .select('subscription_tier')
-        .eq('id', accessibleTrip.user_id)
-        .maybeSingle()
-
-      showPacking = ownerProfile?.subscription_tier === 'pro'
       const unit = await getTemperatureUnit(user.id, sessionSupabase)
       sharedWeather = await getTripWeather({
         tripId: trip.id,
         supabase: sessionSupabase,
         userId: user.id,
         requestedUnit: unit,
-        includePacking: showPacking,
+        includePacking: false,
       })
     }
   }
 
+  const segments = buildCitySegments(items)
+  const itemCount = items.length
+
   return (
     <div className="flex min-h-screen flex-col bg-[#ffffff]">
       <header className="sticky top-0 z-20 border-b border-[#cbd5e1] bg-white/90 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
           <Link href="/" className="flex items-center gap-2">
             <Image src="/ubtrippin_logo.png" alt="UBTRIPPIN" width={28} height={28} className="rounded-lg" />
             <span className="text-base font-bold text-[#4338ca]">UBTRIPPIN</span>
@@ -589,140 +299,96 @@ export default async function SharePage({ params }: SharePageProps) {
                 <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
               </div>
               <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
-                <div className="mx-auto max-w-4xl">
+                <div className="mx-auto max-w-5xl">
                   <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl">
                     {trip.title}
                   </h1>
                   <div className="mt-3 flex flex-wrap gap-4 text-sm text-white/90">
-                    {(trip.start_date || trip.end_date) && (
+                    {(trip.start_date || trip.end_date) ? (
                       <span className="flex items-center gap-1.5">
                         <Calendar className="h-4 w-4" />
                         {formatDateRange(trip.start_date, trip.end_date)}
                       </span>
-                    )}
-                    {trip.primary_location && (
+                    ) : null}
+                    {trip.primary_location ? (
                       <span className="flex items-center gap-1.5">
                         <MapPin className="h-4 w-4" />
                         {trip.primary_location}
                       </span>
-                    )}
-                    {travelers.length > 0 && (
+                    ) : null}
+                    {travelers.length > 0 ? (
                       <span className="flex items-center gap-1.5">
                         <Users className="h-4 w-4" />
                         {travelers.join(', ')}
                       </span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </div>
             </>
           ) : (
             <div className="bg-gradient-to-r from-[#f1f5f9] to-[#ffffff] px-6 py-10 sm:px-8">
-              <div className="mx-auto max-w-4xl">
+              <div className="mx-auto max-w-5xl">
                 <h1 className="text-3xl font-bold leading-tight text-gray-900 sm:text-4xl">
                   {trip.title}
                 </h1>
                 <div className="mt-3 flex flex-wrap gap-4 text-sm text-gray-700">
-                  {(trip.start_date || trip.end_date) && (
+                  {(trip.start_date || trip.end_date) ? (
                     <span className="flex items-center gap-1.5">
                       <Calendar className="h-4 w-4 text-[#4f46e5]" />
                       {formatDateRange(trip.start_date, trip.end_date)}
                     </span>
-                  )}
-                  {trip.primary_location && (
+                  ) : null}
+                  {trip.primary_location ? (
                     <span className="flex items-center gap-1.5">
                       <MapPin className="h-4 w-4 text-[#4f46e5]" />
                       {trip.primary_location}
                     </span>
-                  )}
-                  {travelers.length > 0 && (
+                  ) : null}
+                  {travelers.length > 0 ? (
                     <span className="flex items-center gap-1.5">
                       <Users className="h-4 w-4 text-[#4f46e5]" />
                       {travelers.join(', ')}
                     </span>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </div>
           )}
         </div>
 
-        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
-          {itemCount > 0 && (
+        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+          {itemCount > 0 ? (
             <div className="mb-6 flex flex-wrap gap-3">
               <Badge variant="secondary" className="text-xs">
                 {itemCount} {itemCount === 1 ? 'item' : 'items'}
               </Badge>
-              {trip.primary_location && (
+              {trip.primary_location ? (
                 <Badge variant="default" className="text-xs">
                   <MapPin className="mr-1 h-3 w-3" />
                   {trip.primary_location}
                 </Badge>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
 
-          {trip.notes && (
+          {trip.notes ? (
             <Card className="mb-6 border-[#cbd5e1] bg-[#ffffff]">
               <CardContent className="p-4">
                 <p className="text-sm leading-relaxed text-gray-700">{trip.notes}</p>
               </CardContent>
             </Card>
-          )}
-
-          {sharedWeather ? (
-            <div className="mb-6">
-              <WeatherSection
-                endpoint={`/api/trips/${trip.id}/weather`}
-                initialData={sharedWeather}
-                allowRefresh={false}
-                shareMode={!showPacking}
-                showPacking={showPacking}
-              />
-            </div>
           ) : null}
 
-          {items && items.length > 0 ? (
-            <Card className="border-[#cbd5e1]">
-              <CardContent className="p-0">
-                <div className="relative px-4 py-3 sm:px-5 sm:py-4">
-                  <div className="absolute bottom-8 left-3 top-8 w-px bg-gradient-to-b from-[#4f46e5]/50 via-[#94a3b8] to-[#4f46e5]/50 sm:left-3.5" />
-
-                  <div className="relative pl-7 sm:pl-8">
-                    <div className="absolute left-2 top-1 h-2 w-2 rounded-full bg-[#4338ca] sm:left-2.5" />
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-[#4338ca]">Trip starts</p>
-                    <p className="text-sm font-medium text-[#334155]">{formatTimelineDate(trip.start_date)}</p>
-                  </div>
-
-                  <div className="mt-2 space-y-0.5">
-                    {items.map((item, index) => {
-                      const gapLabel = index < items.length - 1 ? formatGapLabel(item, items[index + 1]) : null
-                      return (
-                        <div key={item.id}>
-                          <div className="relative border-b border-[#f1f5f9] pl-7 last:border-0 sm:pl-8">
-                            <div className="absolute left-[7px] top-8 h-2.5 w-2.5 rounded-full border-2 border-[#4f46e5] bg-white sm:left-2" />
-                            <TripItemRow item={item} durationLabel={getItemDurationLabel(item)} />
-                          </div>
-                          {gapLabel && (
-                            <div className="relative pl-7 py-1.5 sm:pl-8">
-                              <p className="text-xs font-medium text-[#475569]">{gapLabel}</p>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-
-                  <div className="relative mt-2 pl-7 sm:pl-8">
-                    <div className="absolute left-2 top-1 h-2 w-2 rounded-full bg-[#4338ca] sm:left-2.5" />
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-[#4338ca]">Trip ends</p>
-                    <p className="text-sm font-medium text-[#334155]">
-                      {formatTimelineDate(trip.end_date ?? trip.start_date)}
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+          {items.length > 0 ? (
+            <MovementTimeline
+              segments={segments}
+              tripId={trip.id}
+              allTrips={[]}
+              initialWeather={sharedWeather}
+              readOnly
+              showPacking={false}
+            />
           ) : (
             <div className="py-12 text-center text-gray-400">
               <CalendarDays className="mx-auto mb-3 h-10 w-10 opacity-40" />
@@ -753,7 +419,7 @@ export default async function SharePage({ params }: SharePageProps) {
       </main>
 
       <footer className="border-t border-[#cbd5e1] bg-white">
-        <div className="mx-auto max-w-4xl px-4 py-10 text-center sm:px-6">
+        <div className="mx-auto max-w-5xl px-4 py-10 text-center sm:px-6">
           <Image
             src="/ubtrippin_logo.png"
             alt="UBTRIPPIN"

--- a/src/components/trips/city-segment-header.tsx
+++ b/src/components/trips/city-segment-header.tsx
@@ -8,6 +8,7 @@ interface CitySegmentHeaderProps {
 }
 
 function countryCodeToFlag(code: string): string {
+  if (!code || code.length !== 2) return ''
   return code.toUpperCase().replace(/./g, (char) =>
     String.fromCodePoint(char.charCodeAt(0) + 127397)
   )
@@ -18,16 +19,26 @@ function formatSegmentRange(startDate: string, endDate: string) {
   const end = new Date(`${endDate}T00:00:00`)
   const sameDay = startDate === endDate
   const sameMonth = start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear()
+  const sameYear = start.getFullYear() === end.getFullYear()
+
+  const startOpts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+  const endOpts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+
+  // Include year when crossing year boundaries
+  if (!sameYear) {
+    startOpts.year = 'numeric'
+    endOpts.year = 'numeric'
+  }
 
   if (sameDay) {
-    return start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    return start.toLocaleDateString('en-US', startOpts)
   }
 
   if (sameMonth) {
-    return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}-${end.getDate()}`
+    return `${start.toLocaleDateString('en-US', startOpts)}-${end.getDate()}`
   }
 
-  return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}-${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
+  return `${start.toLocaleDateString('en-US', startOpts)} – ${end.toLocaleDateString('en-US', endOpts)}`
 }
 
 function durationLabel(segment: CitySegment) {

--- a/src/components/trips/city-segment-header.tsx
+++ b/src/components/trips/city-segment-header.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { CitySegment } from '@/lib/trips/city-segments'
+import { getWeatherEmoji } from '@/lib/weather/item-weather'
+
+interface CitySegmentHeaderProps {
+  segment: CitySegment
+}
+
+function countryCodeToFlag(code: string): string {
+  return code.toUpperCase().replace(/./g, (char) =>
+    String.fromCodePoint(char.charCodeAt(0) + 127397)
+  )
+}
+
+function formatSegmentRange(startDate: string, endDate: string) {
+  const start = new Date(`${startDate}T00:00:00`)
+  const end = new Date(`${endDate}T00:00:00`)
+  const sameDay = startDate === endDate
+  const sameMonth = start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear()
+
+  if (sameDay) {
+    return start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  }
+
+  if (sameMonth) {
+    return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}-${end.getDate()}`
+  }
+
+  return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}-${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
+}
+
+function durationLabel(segment: CitySegment) {
+  if (segment.durationNights === 1) return '1 night'
+  if (segment.durationNights > 1) return `${segment.durationNights} nights`
+  return 'Same day'
+}
+
+export function CitySegmentHeader({ segment }: CitySegmentHeaderProps) {
+  return (
+    <div className="border-b border-slate-200 bg-[linear-gradient(135deg,#f8fbff_0%,#eef4ff_100%)] px-4 py-4 sm:px-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="text-xl font-semibold text-slate-900">{segment.city}</h3>
+            {segment.countryCode ? (
+              <span className="text-lg" aria-label={segment.countryCode}>
+                {countryCodeToFlag(segment.countryCode)}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-1 text-sm text-slate-600">
+            {durationLabel(segment)} · {formatSegmentRange(segment.startDate, segment.endDate)}
+          </p>
+        </div>
+
+        {segment.weatherForecast && segment.weatherForecast.length > 0 ? (
+          <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 lg:max-w-[28rem]">
+            {segment.weatherForecast.map((day) => (
+              <div
+                key={day.date}
+                className="min-w-[72px] rounded-2xl border border-sky-100 bg-white/90 px-3 py-2 text-center shadow-sm shadow-slate-200/40"
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                  {new Date(`${day.date}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                </div>
+                <div className="mt-1 text-lg">{getWeatherEmoji(day.weather_code)}</div>
+                <div className="mt-1 text-xs font-medium text-slate-700">
+                  {Math.round(day.temp_high)}{segment.weatherUnit} / {Math.round(day.temp_low)}{segment.weatherUnit}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/trips/movement-timeline.tsx
+++ b/src/components/trips/movement-timeline.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Calendar, Plus } from 'lucide-react'
+import type { Trip } from '@/types/database'
+import type { CitySegment } from '@/lib/trips/city-segments'
+import type { WeatherResponsePayload } from '@/lib/weather/types'
+import { attachWeatherToSegments } from '@/lib/weather/item-weather'
+import { PackingSuggestions } from './weather/packing-suggestions'
+import { CitySegmentHeader } from './city-segment-header'
+import { TripItemCard } from './trip-item-card'
+import { TransitionFlight } from './transition-flight'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface MovementTimelineProps {
+  segments: CitySegment[]
+  tripId: string
+  allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
+  currentUserId?: string
+  weatherEndpoint?: string
+  initialWeather?: WeatherResponsePayload | null
+  readOnly?: boolean
+  showPacking?: boolean
+}
+
+function formatSpineDate(date: string) {
+  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function MovementTimeline({
+  segments,
+  tripId,
+  allTrips,
+  currentUserId,
+  weatherEndpoint,
+  initialWeather,
+  readOnly = false,
+  showPacking = true,
+}: MovementTimelineProps) {
+  const [weatherData, setWeatherData] = useState<WeatherResponsePayload | null | undefined>(initialWeather)
+
+  useEffect(() => {
+    if (initialWeather !== undefined) {
+      setWeatherData(initialWeather)
+    }
+  }, [initialWeather])
+
+  useEffect(() => {
+    if (!weatherEndpoint || initialWeather !== undefined) return
+
+    let cancelled = false
+    fetch(weatherEndpoint, { cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) return null
+        return response.json() as Promise<WeatherResponsePayload>
+      })
+      .then((payload) => {
+        if (!cancelled) setWeatherData(payload)
+      })
+      .catch(() => {
+        if (!cancelled) setWeatherData(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [initialWeather, weatherEndpoint])
+
+  const segmentsWithWeather = attachWeatherToSegments(segments, weatherData)
+
+  if (segmentsWithWeather.length === 0) {
+    return (
+      <div className="rounded-xl border-2 border-dashed border-gray-200 p-8 text-center">
+        <Calendar className="mx-auto h-12 w-12 text-gray-400" />
+        <h3 className="mt-4 font-semibold text-gray-900">No items yet</h3>
+        <p className="mt-1 text-sm text-gray-600">
+          Add reservations, flights, and activities to build your itinerary.
+        </p>
+        {!readOnly ? (
+          <Link
+            href={`/trips/${tripId}/add-item`}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#1e293b] px-4 py-2 text-sm font-medium text-white hover:bg-[#312e81]"
+          >
+            <Plus className="h-4 w-4" />
+            Add first item
+          </Link>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {segmentsWithWeather.map((segment, index) => (
+        <div key={`${segment.city}-${segment.startDate}-${index}`} className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-[104px_minmax(0,1fr)] md:items-start">
+            <div className="hidden md:block md:pt-6">
+              <div className="sticky top-24 rounded-2xl border border-slate-200 bg-white px-3 py-3 text-center shadow-sm">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">Stop</div>
+                <div className="mt-1 text-lg font-semibold text-slate-900">{formatSpineDate(segment.startDate)}</div>
+              </div>
+            </div>
+
+            <Card className="overflow-hidden border-slate-200 shadow-sm shadow-slate-200/70">
+              <CitySegmentHeader segment={segment} />
+              <CardContent className="space-y-4 p-4 pt-4 sm:p-5">
+                {segment.items.map((item) => (
+                  <TripItemCard
+                    key={item.id}
+                    item={item}
+                    allTrips={allTrips}
+                    currentUserId={currentUserId}
+                    readOnly={readOnly}
+                    weather={item.weather}
+                  />
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+
+          {index < segmentsWithWeather.length - 1 && segment.transitions.length > 0 ? (
+            <div className="grid gap-3 md:grid-cols-[104px_minmax(0,1fr)]">
+              <div className="hidden md:block" />
+              <div className="space-y-2">
+                {segment.transitions.map((flight) => (
+                  <TransitionFlight
+                    key={flight.id}
+                    flight={flight}
+                    destinationCity={segmentsWithWeather[index + 1].city}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ))}
+
+      {showPacking && weatherData && !weatherData.should_hide_section ? (
+        <PackingSuggestions
+          packing={weatherData.packing}
+          locked={showPacking && !weatherData.can_view_packing}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/trips/transition-flight.tsx
+++ b/src/components/trips/transition-flight.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Plane } from 'lucide-react'
+import type { TripItem } from '@/types/database'
+
+interface TransitionFlightProps {
+  flight: TripItem
+  destinationCity: string
+}
+
+function formatHoursAndMinutes(totalMinutes: number) {
+  const rounded = Math.max(1, Math.round(totalMinutes))
+  const hours = Math.floor(rounded / 60)
+  const minutes = rounded % 60
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+  if (hours > 0) return `${hours}h`
+  return `${minutes}m`
+}
+
+function durationLabel(flight: TripItem) {
+  const details =
+    flight.details_json && typeof flight.details_json === 'object' && !Array.isArray(flight.details_json)
+      ? (flight.details_json as Record<string, unknown>)
+      : null
+
+  const textDuration =
+    (typeof details?.flight_duration === 'string' && details.flight_duration) ||
+    (typeof details?.duration === 'string' && details.duration) ||
+    (typeof details?.flight_time === 'string' && details.flight_time)
+
+  if (textDuration) return textDuration
+
+  const numericDuration =
+    (typeof details?.flight_duration_minutes === 'number' && details.flight_duration_minutes) ||
+    (typeof details?.duration_minutes === 'number' && details.duration_minutes) ||
+    (typeof details?.flight_time_minutes === 'number' && details.flight_time_minutes)
+
+  if (numericDuration) return formatHoursAndMinutes(numericDuration)
+  if (!flight.start_ts || !flight.end_ts) return null
+
+  const start = new Date(flight.start_ts)
+  const end = new Date(flight.end_ts)
+  const diffMinutes = (end.getTime() - start.getTime()) / (60 * 1000)
+
+  return diffMinutes > 0 ? formatHoursAndMinutes(diffMinutes) : null
+}
+
+export function TransitionFlight({ flight, destinationCity }: TransitionFlightProps) {
+  const providerLabel = flight.provider ? `${flight.provider} · ` : ''
+  const summary = `${providerLabel}Flight to ${destinationCity}`
+  const duration = durationLabel(flight)
+
+  return (
+    <div className="rounded-2xl border border-dashed border-sky-200 bg-sky-50/70 px-4 py-3 text-sm text-slate-700">
+      <div className="flex items-center gap-2">
+        <Plane className="h-4 w-4 text-sky-700" />
+        <span className="font-medium text-slate-900">{summary}</span>
+        {duration ? <span className="text-slate-500">· {duration}</span> : null}
+      </div>
+      {(flight.start_location || flight.end_location) ? (
+        <p className="mt-1 text-xs text-slate-500">
+          {[flight.start_location, flight.end_location].filter(Boolean).join(' -> ')}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -54,6 +54,8 @@ interface TripItemCardProps {
   item: TripItem
   allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
   currentUserId?: string
+  readOnly?: boolean
+  weather?: { emoji: string; temp: string; condition?: string }
 }
 
 function loyaltyChip(loyaltyFlag: unknown): { text: string; className: string } | null {
@@ -135,7 +137,7 @@ function isWithin48Hours(item: { start_ts?: string | null; start_date?: string |
   return now >= dep - h48 && now <= endTime
 }
 
-export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProps) {
+export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, weather }: TripItemCardProps) {
   const router = useRouter()
   const [expanded, setExpanded] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -261,7 +263,7 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
             )}
 
             {/* Content */}
-            <div className="min-w-0 flex-1">
+            <div className="min-w-0 flex-1 pr-2">
               {/* Title line */}
               <div className="flex items-center gap-2">
                 <span className="text-xs font-medium uppercase tracking-wider text-gray-500">
@@ -361,63 +363,77 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
             </div>
 
             {/* Actions */}
-            <div className="relative flex items-center gap-1">
-              {sourceEmailId ? (
-                <Link href={`/inbox/${sourceEmailId}`}>
+            <div className="relative flex flex-col items-end gap-2">
+              {weather ? (
+                <div
+                  className="inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-xs font-medium text-sky-900"
+                  title={weather.condition}
+                >
+                  <span aria-hidden="true">{weather.emoji}</span>
+                  <span>{weather.temp}</span>
+                </div>
+              ) : null}
+
+              {!readOnly ? (
+                <div className="relative flex items-center gap-1">
+                  {sourceEmailId ? (
+                    <Link href={`/inbox/${sourceEmailId}`}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        title="Edit extraction in Inbox"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    </Link>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0 text-gray-300"
+                      disabled
+                      title="No source email for this item"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                  )}
+
                   <Button
                     variant="ghost"
                     size="sm"
                     className="h-8 w-8 p-0"
-                    title="Edit extraction in Inbox"
+                    onClick={() => setMenuOpen(!menuOpen)}
                   >
-                    <Pencil className="h-4 w-4" />
+                    <MoreHorizontal className="h-4 w-4" />
                   </Button>
-                </Link>
-              ) : (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-8 p-0 text-gray-300"
-                  disabled
-                  title="No source email for this item"
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-              )}
 
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0"
-                onClick={() => setMenuOpen(!menuOpen)}
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-
-              {menuOpen && (
-                <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border bg-white py-1 shadow-lg">
-                  <button
-                    onClick={() => {
-                      setMenuOpen(false)
-                      setMoveOpen(true)
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                  >
-                    <ArrowRight className="h-4 w-4" />
-                    Move to...
-                  </button>
-                  <button
-                    onClick={() => {
-                      setMenuOpen(false)
-                      setDeleteOpen(true)
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Delete
-                  </button>
+                  {menuOpen && (
+                    <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border bg-white py-1 shadow-lg">
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          setMoveOpen(true)
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      >
+                        <ArrowRight className="h-4 w-4" />
+                        Move to...
+                      </button>
+                      <button
+                        onClick={() => {
+                          setMenuOpen(false)
+                          setDeleteOpen(true)
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Delete
+                      </button>
+                    </div>
+                  )}
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
 

--- a/src/components/trips/trip-timeline.tsx
+++ b/src/components/trips/trip-timeline.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { groupByDate, formatDate } from '@/lib/utils'
-import { TripItemCard } from './trip-item-card'
-import { Plus, Calendar } from 'lucide-react'
-import Link from 'next/link'
-import type { TripItem, Trip } from '@/types/database'
+import type { Trip, TripItem } from '@/types/database'
+import { buildCitySegments } from '@/lib/trips/city-segments'
+import { MovementTimeline } from './movement-timeline'
 
 interface TripTimelineProps {
   items: TripItem[]
@@ -14,69 +12,12 @@ interface TripTimelineProps {
 }
 
 export function TripTimeline({ items, tripId, allTrips, currentUserId }: TripTimelineProps) {
-  const safeItems = Array.isArray(items) ? items : []
-  const safeAllTrips = Array.isArray(allTrips) ? allTrips : []
-
-  if (safeItems.length === 0) {
-    return (
-      <div className="rounded-xl border-2 border-dashed border-gray-200 p-8 text-center">
-        <Calendar className="mx-auto h-12 w-12 text-gray-400" />
-        <h3 className="mt-4 font-semibold text-gray-900">No items yet</h3>
-        <p className="mt-1 text-sm text-gray-600">
-          Add reservations, flights, and activities to build your itinerary.
-        </p>
-        <Link
-          href={`/trips/${tripId}/add-item`}
-          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#1e293b] px-4 py-2 text-sm font-medium text-white hover:bg-[#312e81]"
-        >
-          <Plus className="h-4 w-4" />
-          Add first item
-        </Link>
-      </div>
-    )
-  }
-
-  // Group items by date
-  const groupedItems = groupByDate(safeItems)
-  const sortedDates = Array.from(groupedItems.keys()).sort()
-
   return (
-    <div className="space-y-6">
-      {sortedDates.map((date, dateIndex) => {
-        const dayItems = groupedItems.get(date) || []
-
-        // Sort items by start_ts within the day
-        const sortedDayItems = [...dayItems].sort((a, b) => {
-          if (!a.start_ts && !b.start_ts) return 0
-          if (!a.start_ts) return 1
-          if (!b.start_ts) return -1
-          return new Date(a.start_ts).getTime() - new Date(b.start_ts).getTime()
-        })
-
-        return (
-          <div key={date} className="relative">
-            {/* Date header */}
-            <div className="sticky top-20 z-10 mb-4 flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#f1f5f9] text-[#4338ca] font-semibold">
-                {dateIndex + 1}
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900">{formatDate(date)}</h3>
-                <p className="text-sm text-gray-500">
-                  {sortedDayItems.length} {sortedDayItems.length === 1 ? 'item' : 'items'}
-                </p>
-              </div>
-            </div>
-
-            {/* Items for this day */}
-            <div className="ml-5 border-l-2 border-[#cbd5e1] pl-8 space-y-4">
-              {sortedDayItems.map((item) => (
-                <TripItemCard key={item.id} item={item} allTrips={safeAllTrips} currentUserId={currentUserId} />
-              ))}
-            </div>
-          </div>
-        )
-      })}
-    </div>
+    <MovementTimeline
+      segments={buildCitySegments(items)}
+      tripId={tripId}
+      allTrips={allTrips}
+      currentUserId={currentUserId}
+    />
   )
 }

--- a/src/lib/supabase/public-share.ts
+++ b/src/lib/supabase/public-share.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
+
+export function createPublicShareClient(shareToken: string) {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+      global: {
+        headers: {
+          'x-share-token': shareToken,
+        },
+      },
+    }
+  )
+}

--- a/src/lib/trips/airport-cities.ts
+++ b/src/lib/trips/airport-cities.ts
@@ -1,0 +1,51 @@
+export const AIRPORT_CITIES: Record<
+  string,
+  { city: string; metro?: string; country: string; countryCode: string }
+> = {
+  AMS: { city: 'Amsterdam', country: 'Netherlands', countryCode: 'NL' },
+  ATL: { city: 'Atlanta', country: 'USA', countryCode: 'US' },
+  AUS: { city: 'Austin', country: 'USA', countryCode: 'US' },
+  BCN: { city: 'Barcelona', country: 'Spain', countryCode: 'ES' },
+  BOS: { city: 'Boston', country: 'USA', countryCode: 'US' },
+  CDG: { city: 'Paris', country: 'France', countryCode: 'FR' },
+  CHS: { city: 'Charleston', country: 'USA', countryCode: 'US' },
+  DEN: { city: 'Denver', country: 'USA', countryCode: 'US' },
+  DFW: { city: 'Dallas', country: 'USA', countryCode: 'US' },
+  DTW: { city: 'Detroit', country: 'USA', countryCode: 'US' },
+  EWR: { city: 'Newark', metro: 'New York', country: 'USA', countryCode: 'US' },
+  FCO: { city: 'Rome', country: 'Italy', countryCode: 'IT' },
+  FLL: { city: 'Fort Lauderdale', country: 'USA', countryCode: 'US' },
+  HND: { city: 'Tokyo', country: 'Japan', countryCode: 'JP' },
+  ICN: { city: 'Seoul', country: 'South Korea', countryCode: 'KR' },
+  JFK: { city: 'New York', metro: 'New York', country: 'USA', countryCode: 'US' },
+  LAX: { city: 'Los Angeles', country: 'USA', countryCode: 'US' },
+  LGA: { city: 'New York', metro: 'New York', country: 'USA', countryCode: 'US' },
+  LHR: { city: 'London', country: 'UK', countryCode: 'GB' },
+  LIN: { city: 'Milan', country: 'Italy', countryCode: 'IT' },
+  MDW: { city: 'Chicago', metro: 'Chicago', country: 'USA', countryCode: 'US' },
+  MIA: { city: 'Miami', country: 'USA', countryCode: 'US' },
+  MSP: { city: 'Minneapolis', country: 'USA', countryCode: 'US' },
+  MXP: { city: 'Milan', country: 'Italy', countryCode: 'IT' },
+  NCE: { city: 'Nice', country: 'France', countryCode: 'FR' },
+  NRT: { city: 'Tokyo', country: 'Japan', countryCode: 'JP' },
+  ORD: { city: 'Chicago', country: 'USA', countryCode: 'US' },
+  ORY: { city: 'Paris', country: 'France', countryCode: 'FR' },
+  PDX: { city: 'Portland', country: 'USA', countryCode: 'US' },
+  PEK: { city: 'Beijing', country: 'China', countryCode: 'CN' },
+  PHX: { city: 'Phoenix', country: 'USA', countryCode: 'US' },
+  PSP: { city: 'Palm Springs', country: 'USA', countryCode: 'US' },
+  SAN: { city: 'San Diego', country: 'USA', countryCode: 'US' },
+  SCL: { city: 'Santiago', country: 'Chile', countryCode: 'CL' },
+  SEA: { city: 'Seattle', country: 'USA', countryCode: 'US' },
+  SFO: { city: 'San Francisco', country: 'USA', countryCode: 'US' },
+  SRQ: { city: 'Sarasota', country: 'USA', countryCode: 'US' },
+  SXM: { city: 'Saint Maarten', country: 'Sint Maarten', countryCode: 'SX' },
+  TLL: { city: 'Tallinn', country: 'Estonia', countryCode: 'EE' },
+  TPA: { city: 'Tampa', country: 'USA', countryCode: 'US' },
+  TRN: { city: 'Turin', country: 'Italy', countryCode: 'IT' },
+}
+
+export function getMetroArea(airportCode: string): string | null {
+  const airport = AIRPORT_CITIES[airportCode.trim().toUpperCase()]
+  return airport?.metro ?? null
+}

--- a/src/lib/trips/assignment.ts
+++ b/src/lib/trips/assignment.ts
@@ -1,5 +1,6 @@
 import type { Trip } from '@/types/database'
 import type { ExtractedItem } from '@/lib/ai/extract-travel-data'
+import { deduplicateTravelers } from './traveler-dedup'
 
 const GAP_TOLERANCE_DAYS = 1
 
@@ -188,7 +189,7 @@ function looksLikeVenueName(name: string): boolean {
  * "New York JFK" → "New York", "New York (JFK)" → "New York",
  * "New York City, NY" → "New York City", "Tokyo, Japan" → "Tokyo"
  */
-function normaliseToCity(location: string): string {
+export function normaliseToCity(location: string): string {
   let city = location.trim()
 
   // Strip airport codes: parenthesized "(JFK)" style and trailing " JFK" style
@@ -244,15 +245,15 @@ function mostFrequentCity(locations: string[]): string | null {
 }
 
 export function collectTravelerNames(items: ExtractedItem[]): string[] {
-  const names = new Set<string>()
+  const names: string[] = []
 
   for (const item of items) {
     for (const name of item.traveler_names || []) {
       if (name.trim()) {
-        names.add(name.trim())
+        names.push(name.trim())
       }
     }
   }
 
-  return Array.from(names)
+  return deduplicateTravelers(names)
 }

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest'
+import type { TripItem } from '@/types/database'
+import { buildCitySegments } from './city-segments'
+
+function makeItem(overrides: Partial<TripItem>): TripItem {
+  return {
+    id: crypto.randomUUID(),
+    user_id: 'user-1',
+    trip_id: 'trip-1',
+    kind: 'other',
+    provider: null,
+    confirmation_code: null,
+    traveler_names: [],
+    start_ts: null,
+    end_ts: null,
+    start_date: '2026-03-08',
+    end_date: null,
+    start_location: null,
+    end_location: null,
+    summary: null,
+    details_json: {},
+    status: 'confirmed',
+    confidence: 1,
+    needs_review: false,
+    loyalty_flag: null,
+    source_email_id: null,
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('buildCitySegments', () => {
+  it('returns empty array for empty input', () => {
+    expect(buildCitySegments([])).toEqual([])
+  })
+
+  it('builds a single-city hotel segment', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-08',
+        end_date: '2026-03-12',
+        start_location: 'Austin, TX',
+      }),
+    ])
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0]).toMatchObject({
+      city: 'Austin, TX',
+      anchorType: 'hotel',
+      durationNights: 4,
+    })
+  })
+
+  it('builds multi-city hotel segments with one transition', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-08',
+        end_date: '2026-03-10',
+        start_location: 'Paris, France',
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-10',
+        start_ts: '2026-03-10T10:00:00+01:00',
+        end_date: '2026-03-10',
+        end_ts: '2026-03-10T16:00:00-05:00',
+        start_location: 'Paris CDG',
+        end_location: 'Austin AUS',
+        details_json: { departure_airport: 'CDG', arrival_airport: 'AUS' },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-10',
+        end_date: '2026-03-13',
+        start_location: 'Austin, TX',
+      }),
+    ])
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0].transitions).toHaveLength(1)
+    expect(segments[1]).toMatchObject({ city: 'Austin, TX', anchorType: 'hotel' })
+  })
+
+  it('creates airport segments for flight-only trips', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T08:00:00-05:00',
+        end_ts: '2026-03-08T20:00:00+01:00',
+        start_location: 'JFK',
+        end_location: 'CDG',
+        details_json: { departure_airport: 'JFK', arrival_airport: 'CDG' },
+      }),
+    ])
+
+    expect(segments.map((segment) => segment.city)).toEqual(['New York', 'Paris'])
+  })
+
+  it('skips layovers shorter than four hours', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T08:00:00-05:00',
+        end_ts: '2026-03-08T10:00:00-05:00',
+        start_location: 'JFK',
+        end_location: 'ORD',
+        details_json: { departure_airport: 'JFK', arrival_airport: 'ORD' },
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T12:30:00-05:00',
+        end_ts: '2026-03-08T16:00:00-08:00',
+        start_location: 'ORD',
+        end_location: 'SFO',
+        details_json: { departure_airport: 'ORD', arrival_airport: 'SFO' },
+      }),
+    ])
+
+    expect(segments.map((segment) => segment.city)).toEqual(['New York', 'San Francisco'])
+  })
+
+  it('includes overnight layovers as segments', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T08:00:00-05:00',
+        end_ts: '2026-03-08T10:00:00-05:00',
+        start_location: 'JFK',
+        end_location: 'ORD',
+        details_json: { departure_airport: 'JFK', arrival_airport: 'ORD' },
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-09',
+        start_ts: '2026-03-09T07:00:00-05:00',
+        end_ts: '2026-03-09T10:00:00-08:00',
+        start_location: 'ORD',
+        end_location: 'SFO',
+        details_json: { departure_airport: 'ORD', arrival_airport: 'SFO' },
+      }),
+    ])
+
+    expect(segments.map((segment) => segment.city)).toEqual(['New York', 'Chicago', 'San Francisco'])
+  })
+
+  it('handles round trips', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T18:00:00-05:00',
+        end_ts: '2026-03-09T07:00:00+01:00',
+        start_location: 'JFK',
+        end_location: 'CDG',
+        details_json: { departure_airport: 'JFK', arrival_airport: 'CDG' },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-09',
+        end_date: '2026-03-12',
+        start_location: 'Paris, France',
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-12',
+        start_ts: '2026-03-12T13:00:00+01:00',
+        end_ts: '2026-03-12T16:00:00-04:00',
+        start_location: 'CDG',
+        end_location: 'JFK',
+        details_json: { departure_airport: 'CDG', arrival_airport: 'JFK' },
+      }),
+    ])
+
+    expect(segments.map((segment) => segment.city)).toEqual(['New York', 'Paris, France', 'New York'])
+  })
+
+  it('groups metro-area airports into the same segment', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T09:00:00-05:00',
+        end_ts: '2026-03-08T15:00:00-05:00',
+        start_location: 'CDG',
+        end_location: 'EWR',
+        details_json: { departure_airport: 'CDG', arrival_airport: 'EWR' },
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-08',
+        start_ts: '2026-03-08T21:30:00-05:00',
+        end_ts: '2026-03-09T06:00:00-08:00',
+        start_location: 'JFK',
+        end_location: 'SFO',
+        details_json: { departure_airport: 'JFK', arrival_airport: 'SFO' },
+      }),
+    ])
+
+    expect(segments.map((segment) => segment.city)).toEqual(['Paris', 'New York', 'San Francisco'])
+  })
+
+  it('attaches no-location items to the current segment', () => {
+    const segments = buildCitySegments([
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-08',
+        end_date: '2026-03-10',
+        start_location: 'Austin, TX',
+      }),
+      makeItem({
+        kind: 'activity',
+        start_date: '2026-03-09',
+        summary: 'Dinner reservation',
+      }),
+    ])
+
+    expect(segments[0].items).toHaveLength(2)
+    expect(segments[0].items[1].summary).toBe('Dinner reservation')
+  })
+})

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -1,0 +1,359 @@
+import type { TripItem } from '@/types/database'
+import type { ForecastDay } from '@/lib/weather/types'
+import { AIRPORT_CITIES, getMetroArea } from './airport-cities'
+import { normaliseToCity } from './assignment'
+
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+export interface TripItemWithWeather extends TripItem {
+  weather?: { emoji: string; temp: string; condition?: string }
+}
+
+export interface CitySegment {
+  city: string
+  countryCode?: string
+  startDate: string
+  endDate: string
+  durationNights: number
+  anchorType: 'hotel' | 'airport'
+  items: TripItemWithWeather[]
+  transitions: TripItemWithWeather[]
+  weatherForecast?: ForecastDay[]
+  weatherUnit?: '°F' | '°C'
+}
+
+interface ResolvedPlace {
+  city: string
+  countryCode?: string
+  key: string
+}
+
+interface PendingArrival extends ResolvedPlace {
+  arrivedAt: Date
+}
+
+interface InternalSegment extends CitySegment {
+  key: string
+  startAt: Date
+  endAt: Date
+}
+
+function parseDateTime(value: string | null | undefined, fallbackTime: string) {
+  if (!value) return null
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T${fallbackTime}:00` : value
+  const parsed = new Date(normalized)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function getItemStart(item: TripItem) {
+  return parseDateTime(item.start_ts ?? item.start_date, '00:00') ?? new Date(`${item.start_date}T00:00:00`)
+}
+
+function getItemEnd(item: TripItem) {
+  return (
+    parseDateTime(item.end_ts ?? item.end_date ?? item.start_date, '23:59') ??
+    new Date(`${item.end_date ?? item.start_date}T23:59:00`)
+  )
+}
+
+function isoDate(value: Date) {
+  return value.toISOString().slice(0, 10)
+}
+
+function durationNights(startDate: string, endDate: string) {
+  const start = new Date(`${startDate}T00:00:00Z`)
+  const end = new Date(`${endDate}T00:00:00Z`)
+  const diff = Math.round((end.getTime() - start.getTime()) / ONE_DAY_MS)
+  return Math.max(0, diff)
+}
+
+function extractAirportCode(location: string | null | undefined, detailsKey: unknown) {
+  if (typeof detailsKey === 'string' && AIRPORT_CITIES[detailsKey.trim().toUpperCase()]) {
+    return detailsKey.trim().toUpperCase()
+  }
+
+  if (!location) return null
+  const codeMatch = location.match(/\b([A-Z]{3})\b/)
+  if (!codeMatch) return null
+  const code = codeMatch[1].toUpperCase()
+  return AIRPORT_CITIES[code] ? code : null
+}
+
+function airportPlace(code: string | null) {
+  if (!code) return null
+  const airport = AIRPORT_CITIES[code]
+  if (!airport) return null
+  const metro = getMetroArea(code)
+  const city = metro ?? airport.city
+  return {
+    city,
+    countryCode: airport.countryCode,
+    key: `${airport.countryCode}:${city.toLowerCase()}`,
+  } satisfies ResolvedPlace
+}
+
+function resolveFlightEndpoint(item: TripItem, direction: 'start' | 'end'): ResolvedPlace | null {
+  const details =
+    item.details_json && typeof item.details_json === 'object' && !Array.isArray(item.details_json)
+      ? (item.details_json as Record<string, unknown>)
+      : null
+
+  const airportCode = extractAirportCode(
+    direction === 'start' ? item.start_location : item.end_location,
+    direction === 'start' ? details?.departure_airport : details?.arrival_airport
+  )
+
+  return airportPlace(airportCode)
+}
+
+function resolveHotelPlace(item: TripItem): ResolvedPlace | null {
+  const location = item.start_location ?? item.end_location
+  if (!location) return null
+
+  const parts = location.split(',').map((part) => part.trim()).filter(Boolean)
+  const city = normaliseToCity(location)
+  if (!city) return null
+
+  const countryCode =
+    parts[parts.length - 1]?.toUpperCase() === 'USA' || /^[A-Z]{2}$/.test(parts[parts.length - 1] ?? '')
+      ? 'US'
+      : undefined
+
+  const displayCity =
+    parts.length >= 2
+      ? `${city}, ${parts[0] === city ? parts[1] : parts[Math.min(parts.length - 1, 2)]}`
+      : city
+
+  return {
+    city: displayCity,
+    countryCode,
+    key: `${countryCode ?? 'xx'}:${city.toLowerCase()}`,
+  }
+}
+
+function resolveGroundPlace(item: TripItem): ResolvedPlace | null {
+  const location = item.start_location ?? item.end_location
+  if (!location) return null
+  const city = normaliseToCity(location)
+  if (!city) return null
+  return {
+    city,
+    key: `xx:${city.toLowerCase()}`,
+  }
+}
+
+function samePlace(left: ResolvedPlace | null, right: ResolvedPlace | null) {
+  if (!left || !right) return false
+  return left.key === right.key
+}
+
+function createSegment(place: ResolvedPlace, anchorType: 'hotel' | 'airport', startAt: Date, endAt: Date): InternalSegment {
+  const startDate = isoDate(startAt)
+  const endDate = isoDate(endAt)
+
+  return {
+    city: place.city,
+    countryCode: place.countryCode,
+    startDate,
+    endDate,
+    durationNights: durationNights(startDate, endDate),
+    anchorType,
+    items: [],
+    transitions: [],
+    key: place.key,
+    startAt,
+    endAt,
+  }
+}
+
+function syncSegmentDates(segment: InternalSegment) {
+  segment.startDate = isoDate(segment.startAt)
+  segment.endDate = isoDate(segment.endAt)
+  segment.durationNights = durationNights(segment.startDate, segment.endDate)
+}
+
+function mergeAdjacentSegments(segments: InternalSegment[]) {
+  return segments.reduce<InternalSegment[]>((merged, segment) => {
+    const previous = merged.at(-1)
+    if (!previous || previous.key !== segment.key) {
+      merged.push(segment)
+      return merged
+    }
+
+    previous.startAt = previous.startAt <= segment.startAt ? previous.startAt : segment.startAt
+    previous.endAt = previous.endAt >= segment.endAt ? previous.endAt : segment.endAt
+    previous.anchorType = previous.anchorType === 'hotel' || segment.anchorType === 'hotel' ? 'hotel' : 'airport'
+    previous.city = segment.anchorType === 'hotel' ? segment.city : previous.city
+    previous.countryCode = previous.countryCode ?? segment.countryCode
+    previous.items = [...previous.items, ...segment.items]
+    previous.transitions = [...previous.transitions, ...segment.transitions]
+    syncSegmentDates(previous)
+    return merged
+  }, [])
+}
+
+function normalizeTransitionPlacement(segments: InternalSegment[]) {
+  for (let index = 1; index < segments.length; index += 1) {
+    const previous = segments[index - 1]
+    const current = segments[index]
+    if (current.transitions.length === 0) continue
+    if (previous.transitions.length > 0) continue
+
+    previous.transitions = [...previous.transitions, ...current.transitions]
+    current.transitions = []
+  }
+
+  return segments
+}
+
+function attachItem(segment: InternalSegment, item: TripItemWithWeather) {
+  segment.items.push(item)
+  const itemStart = getItemStart(item)
+  const itemEnd = getItemEnd(item)
+  if (itemStart < segment.startAt) segment.startAt = itemStart
+  if (itemEnd > segment.endAt) segment.endAt = itemEnd
+  syncSegmentDates(segment)
+}
+
+function ensurePendingLayoverSegment(
+  pendingArrival: PendingArrival | null,
+  nextFlight: TripItem,
+  previousSegment: InternalSegment | null,
+  segments: InternalSegment[]
+) {
+  if (!pendingArrival) return null
+
+  const origin = resolveFlightEndpoint(nextFlight, 'start')
+  const gapMs = getItemStart(nextFlight).getTime() - pendingArrival.arrivedAt.getTime()
+
+  if (samePlace(pendingArrival, origin) && gapMs >= 0 && gapMs < FOUR_HOURS_MS) {
+    return null
+  }
+
+  const segment = createSegment(
+    pendingArrival,
+    'airport',
+    pendingArrival.arrivedAt,
+    getItemStart(nextFlight)
+  )
+
+  if (previousSegment && previousSegment.transitions.length === 0) {
+    previousSegment.endAt = pendingArrival.arrivedAt
+    syncSegmentDates(previousSegment)
+  }
+
+  segments.push(segment)
+  return segment
+}
+
+export function buildCitySegments(items: TripItem[]): CitySegment[] {
+  if (items.length === 0) return []
+
+  const ordered = [...items].sort((left, right) => getItemStart(left).getTime() - getItemStart(right).getTime())
+  const segments: InternalSegment[] = []
+  let currentSegment: InternalSegment | null = null
+  let pendingArrival: PendingArrival | null = null
+  let activeTransitionFlights: TripItemWithWeather[] = []
+
+  for (const item of ordered) {
+    const typedItem = item as TripItemWithWeather
+
+    if (item.kind === 'flight') {
+      if (!currentSegment && pendingArrival) {
+        currentSegment = ensurePendingLayoverSegment(
+          pendingArrival,
+          item,
+          segments.at(-1) ?? null,
+          segments
+        )
+        pendingArrival = null
+      }
+
+      if (!currentSegment && segments.length === 0) {
+        const origin = resolveFlightEndpoint(item, 'start')
+        if (origin) {
+          currentSegment = createSegment(origin, 'airport', getItemStart(item), getItemStart(item))
+          segments.push(currentSegment)
+        }
+      }
+
+      activeTransitionFlights.push(typedItem)
+      currentSegment = null
+
+      const destination = resolveFlightEndpoint(item, 'end')
+      if (destination) {
+        pendingArrival = {
+          ...destination,
+          arrivedAt: getItemEnd(item),
+        }
+      }
+
+      continue
+    }
+
+    const hotelPlace = item.kind === 'hotel' ? resolveHotelPlace(item) : null
+    const groundPlace = hotelPlace ?? resolveGroundPlace(item) ?? pendingArrival
+    const previousSegment = segments.at(-1) ?? null
+
+    if (groundPlace && (!currentSegment || !samePlace(currentSegment, groundPlace))) {
+      currentSegment = createSegment(
+        groundPlace,
+        hotelPlace ? 'hotel' : pendingArrival ? 'airport' : 'hotel',
+        pendingArrival?.arrivedAt ?? getItemStart(item),
+        getItemEnd(item)
+      )
+
+      if (previousSegment && activeTransitionFlights.length > 0) {
+        previousSegment.transitions = [...previousSegment.transitions, ...activeTransitionFlights]
+      }
+
+      activeTransitionFlights = []
+      pendingArrival = null
+      segments.push(currentSegment)
+    }
+
+    if (!currentSegment) {
+      const fallbackPlace = groundPlace ?? resolveGroundPlace(item)
+      if (!fallbackPlace) continue
+      currentSegment = createSegment(fallbackPlace, hotelPlace ? 'hotel' : 'airport', getItemStart(item), getItemEnd(item))
+      segments.push(currentSegment)
+    }
+
+    if (hotelPlace && samePlace(currentSegment, hotelPlace)) {
+      currentSegment.anchorType = 'hotel'
+      currentSegment.city = hotelPlace.city
+      currentSegment.countryCode = hotelPlace.countryCode ?? currentSegment.countryCode
+      currentSegment.key = hotelPlace.key
+    }
+
+    attachItem(currentSegment, typedItem)
+  }
+
+  if (pendingArrival) {
+    const previousSegment = segments.at(-1) ?? null
+    const finalSegment = createSegment(pendingArrival, 'airport', pendingArrival.arrivedAt, pendingArrival.arrivedAt)
+    if (previousSegment && activeTransitionFlights.length > 0) {
+      previousSegment.transitions = [...previousSegment.transitions, ...activeTransitionFlights]
+    }
+    segments.push(finalSegment)
+  } else if (segments.length > 0 && activeTransitionFlights.length > 0) {
+    segments[segments.length - 1].transitions = [
+      ...segments[segments.length - 1].transitions,
+      ...activeTransitionFlights,
+    ]
+  }
+
+  return normalizeTransitionPlacement(mergeAdjacentSegments(segments)).map((segment) => ({
+    city: segment.city,
+    countryCode: segment.countryCode,
+    startDate: segment.startDate,
+    endDate: segment.endDate,
+    durationNights: segment.durationNights,
+    anchorType: segment.anchorType,
+    items: segment.items,
+    transitions: segment.transitions,
+    weatherForecast: segment.weatherForecast,
+    weatherUnit: segment.weatherUnit,
+  }))
+}

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -115,10 +115,17 @@ function resolveHotelPlace(item: TripItem): ResolvedPlace | null {
   const city = normaliseToCity(location)
   if (!city) return null
 
+  // Derive country code from known country names, not state abbreviations
+  const US_STATES = new Set(['AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY','DC'])
+  const lastPart = parts[parts.length - 1]?.trim().toUpperCase() ?? ''
   const countryCode =
-    parts[parts.length - 1]?.toUpperCase() === 'USA' || /^[A-Z]{2}$/.test(parts[parts.length - 1] ?? '')
+    lastPart === 'USA' || lastPart === 'US' || lastPart === 'UNITED STATES'
       ? 'US'
-      : undefined
+      : US_STATES.has(lastPart)
+        ? 'US'  // State abbreviation implies US
+        : /^[A-Z]{2}$/.test(lastPart) && !US_STATES.has(lastPart)
+          ? lastPart  // Actual 2-letter country code (FR, IT, JP, etc.)
+          : undefined
 
   const displayCity =
     parts.length >= 2

--- a/src/lib/trips/traveler-dedup.test.ts
+++ b/src/lib/trips/traveler-dedup.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { deduplicateTravelers } from './traveler-dedup'
+
+describe('deduplicateTravelers', () => {
+  it('strips honorifics and suffixes and prefers the longest canonical variant', () => {
+    expect(
+      deduplicateTravelers([' mr. jane q doe ', 'Jane Doe', 'Jane Q. Doe Jr.'])
+    ).toEqual(['Jane Q Doe'])
+  })
+
+  it('merges minor spelling differences', () => {
+    expect(deduplicateTravelers(['Jon Smith', 'John Smith', 'John  Smith'])).toEqual(['John Smith'])
+  })
+
+  it('keeps clearly different people separate', () => {
+    expect(deduplicateTravelers(['Jane Doe', 'Janet Doe', 'John Doe'])).toEqual([
+      'Jane Doe',
+      'Janet Doe',
+      'John Doe',
+    ])
+  })
+})

--- a/src/lib/trips/traveler-dedup.ts
+++ b/src/lib/trips/traveler-dedup.ts
@@ -1,0 +1,131 @@
+const HONORIFICS = /\b(mr|mrs|ms|miss|mx|dr|prof|sir|madam)\.?\b/gi
+const SUFFIXES = /\b(jr|sr|ii|iii|iv|phd|md|dds|esq)\.?\b/gi
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function titleCase(value: string) {
+  return value
+    .toLowerCase()
+    .split(' ')
+    .filter(Boolean)
+    .map((part) =>
+      part
+        .split('-')
+        .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+        .join('-')
+    )
+    .join(' ')
+}
+
+function stripDecorations(value: string) {
+  return normalizeWhitespace(
+    value
+      .replace(/,/g, ' ')
+      .replace(HONORIFICS, ' ')
+      .replace(SUFFIXES, ' ')
+      .replace(/[^\p{L}\p{N}\s'-]/gu, ' ')
+  )
+}
+
+function normalizedTokens(value: string) {
+  return stripDecorations(value)
+    .toLowerCase()
+    .split(' ')
+    .filter(Boolean)
+}
+
+function canonicalizeName(value: string) {
+  return titleCase(stripDecorations(value))
+}
+
+function firstAndLast(tokens: string[]) {
+  if (tokens.length === 0) return ''
+  if (tokens.length === 1) return tokens[0]
+  return `${tokens[0]} ${tokens[tokens.length - 1]}`
+}
+
+function tokenSubset(left: string[], right: string[]) {
+  if (left.length === 0 || right.length === 0) return false
+  const smaller = left.length <= right.length ? left : right
+  const larger = left.length <= right.length ? right : left
+  return smaller.every((token) => larger.includes(token))
+}
+
+function isSuffixExtension(left: string, right: string) {
+  const shorter = left.length <= right.length ? left : right
+  const longer = left.length <= right.length ? right : left
+  return longer.startsWith(shorter) && longer.length > shorter.length
+}
+
+function levenshtein(left: string, right: string) {
+  if (left === right) return 0
+  if (left.length === 0) return right.length
+  if (right.length === 0) return left.length
+
+  const rows = Array.from({ length: right.length + 1 }, (_, index) => index)
+  for (let i = 1; i <= left.length; i += 1) {
+    let previous = i - 1
+    rows[0] = i
+    for (let j = 1; j <= right.length; j += 1) {
+      const current = rows[j]
+      rows[j] = Math.min(
+        rows[j] + 1,
+        rows[j - 1] + 1,
+        previous + (left[i - 1] === right[j - 1] ? 0 : 1)
+      )
+      previous = current
+    }
+  }
+  return rows[right.length]
+}
+
+function areSimilar(left: string, right: string) {
+  const leftTokens = normalizedTokens(left)
+  const rightTokens = normalizedTokens(right)
+  if (leftTokens.length === 0 || rightTokens.length === 0) return false
+
+  if (firstAndLast(leftTokens) === firstAndLast(rightTokens)) return true
+  if (tokenSubset(leftTokens, rightTokens)) return true
+
+  if (leftTokens.length >= 2 && rightTokens.length >= 2) {
+    const leftFirst = leftTokens[0]
+    const rightFirst = rightTokens[0]
+    const leftLast = leftTokens[leftTokens.length - 1]
+    const rightLast = rightTokens[rightTokens.length - 1]
+
+    if (leftLast === rightLast) {
+      if (isSuffixExtension(leftFirst, rightFirst)) return false
+      return levenshtein(leftFirst, rightFirst) <= 1
+    }
+  }
+
+  const leftJoined = leftTokens.join(' ')
+  const rightJoined = rightTokens.join(' ')
+  return leftTokens.length === 1 && rightTokens.length === 1 && levenshtein(leftJoined, rightJoined) <= 2
+}
+
+export function deduplicateTravelers(names: string[]): string[] {
+  const groups: string[][] = []
+
+  for (const rawName of names) {
+    const canonical = canonicalizeName(rawName)
+    if (!canonical) continue
+
+    const group = groups.find((existing) => existing.some((candidate) => areSimilar(candidate, canonical)))
+    if (group) {
+      group.push(canonical)
+      continue
+    }
+
+    groups.push([canonical])
+  }
+
+  return groups.map((group) =>
+    [...group].sort((left, right) => {
+      if (right.length !== left.length) return right.length - left.length
+      return left.localeCompare(right)
+    })[0]
+  )
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,6 +39,11 @@ export function formatDate(date: string | Date | null | undefined): string {
  * 
  * Uses 24-hour format for consistency with international travel.
  */
+/**
+ * Format a time value for display. Always in destination timezone.
+ * For ISO strings: extracts the local time portion directly (24h format).
+ * For Date objects (fallback): uses browser locale (12h for en-US, 24h for de-DE).
+ */
 export function formatTime(date: string | Date | null | undefined): string {
   if (!date) return ''
   

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,7 +65,7 @@ export function formatTime(date: string | Date | null | undefined): string {
   return d.toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false,
+    hour12: undefined,
   })
 }
 

--- a/src/lib/weather/item-weather.test.ts
+++ b/src/lib/weather/item-weather.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { attachWeatherToSegments, getItemWeather, getWeatherEmoji } from './item-weather'
+import type { CitySegment } from '@/lib/trips/city-segments'
+import type { WeatherResponsePayload } from './types'
+
+describe('item weather helpers', () => {
+  it('maps WMO codes to emoji', () => {
+    expect(getWeatherEmoji(95)).toBe('⛈️')
+    expect(getWeatherEmoji(999)).toBe('🌤️')
+  })
+
+  it('finds item weather by date', () => {
+    expect(
+      getItemWeather('2026-03-09', [
+        {
+          date: '2026-03-09',
+          temp_high: 72,
+          temp_low: 55,
+          precipitation_mm: 0,
+          precipitation_probability: 0,
+          weather_code: 1,
+          weather_description: 'Mainly clear',
+          wind_speed_max_mph: 10,
+        },
+      ])
+    ).toEqual({ emoji: '🌤️', temp: '72°' })
+  })
+
+  it('attaches matching segment weather and item chips', () => {
+    const segments: CitySegment[] = [
+      {
+        city: 'Paris, France',
+        startDate: '2026-03-09',
+        endDate: '2026-03-10',
+        durationNights: 1,
+        anchorType: 'hotel',
+        items: [
+          {
+            id: 'item-1',
+            user_id: 'user-1',
+            trip_id: 'trip-1',
+            kind: 'hotel',
+            provider: null,
+            confirmation_code: null,
+            traveler_names: [],
+            start_ts: null,
+            end_ts: null,
+            start_date: '2026-03-09',
+            end_date: '2026-03-10',
+            start_location: 'Paris, France',
+            end_location: null,
+            summary: null,
+            details_json: {},
+            status: 'confirmed',
+            confidence: 1,
+            needs_review: false,
+            loyalty_flag: null,
+            source_email_id: null,
+            created_at: '2026-03-01T00:00:00Z',
+            updated_at: '2026-03-01T00:00:00Z',
+          },
+        ],
+        transitions: [],
+      },
+    ]
+
+    const payload: WeatherResponsePayload = {
+      trip_id: 'trip-1',
+      trip_title: 'Trip',
+      temp_range: { min: 50, max: 72, unit: '°F' },
+      packing: null,
+      fetched_at: null,
+      is_stale: false,
+      unit: 'fahrenheit',
+      can_view_packing: false,
+      should_hide_section: false,
+      empty_reason: null,
+      destinations: [
+        {
+          city: 'Paris',
+          latitude: 0,
+          longitude: 0,
+          dates: { start: '2026-03-09', end: '2026-03-10' },
+          source: 'forecast',
+          daily: [
+            {
+              date: '2026-03-09',
+              temp_high: 72,
+              temp_low: 55,
+              precipitation_mm: 0,
+              precipitation_probability: 0,
+              weather_code: 1,
+              weather_description: 'Mainly clear',
+              wind_speed_max_mph: 10,
+            },
+            {
+              date: '2026-03-10',
+              temp_high: 68,
+              temp_low: 54,
+              precipitation_mm: 1,
+              precipitation_probability: 20,
+              weather_code: 2,
+              weather_description: 'Partly cloudy',
+              wind_speed_max_mph: 12,
+            },
+          ],
+        },
+      ],
+    }
+
+    const [segment] = attachWeatherToSegments(segments, payload)
+    expect(segment.weatherForecast).toHaveLength(2)
+    expect(segment.items[0].weather).toEqual({ emoji: '🌤️', temp: '72°' })
+  })
+})

--- a/src/lib/weather/item-weather.ts
+++ b/src/lib/weather/item-weather.ts
@@ -1,0 +1,81 @@
+import type { ForecastDay, WeatherResponsePayload } from './types'
+import type { CitySegment, TripItemWithWeather } from '@/lib/trips/city-segments'
+
+export const WMO_EMOJI: Record<number, string> = {
+  0: '☀️',
+  1: '🌤️',
+  2: '⛅',
+  3: '☁️',
+  45: '🌫️',
+  48: '🌫️',
+  51: '🌦️',
+  53: '🌦️',
+  55: '🌧️',
+  61: '🌧️',
+  63: '🌧️',
+  65: '🌧️',
+  71: '🌨️',
+  73: '🌨️',
+  75: '❄️',
+  77: '❄️',
+  80: '🌦️',
+  81: '🌧️',
+  82: '🌧️',
+  85: '🌨️',
+  86: '❄️',
+  95: '⛈️',
+  96: '⛈️',
+  99: '⛈️',
+}
+
+function normalizeCity(value: string) {
+  return value.split(',')[0].trim().toLowerCase()
+}
+
+export function getWeatherEmoji(code: number): string {
+  return WMO_EMOJI[code] ?? '🌤️'
+}
+
+export function getItemWeather(itemDate: string, segmentWeather: ForecastDay[]): { emoji: string; temp: string } | null {
+  const match = segmentWeather.find((day) => day.date === itemDate)
+  if (!match) return null
+
+  return {
+    emoji: getWeatherEmoji(match.weather_code),
+    temp: `${Math.round(match.temp_high)}°`,
+  }
+}
+
+export function attachWeatherToSegments(
+  segments: CitySegment[],
+  payload: WeatherResponsePayload | null | undefined
+): CitySegment[] {
+  if (!payload || payload.destinations.length === 0) {
+    return segments
+  }
+
+  return segments.map((segment) => {
+    const destination = payload.destinations.find(
+      (candidate) =>
+        normalizeCity(candidate.city) === normalizeCity(segment.city) &&
+        candidate.dates.start <= segment.endDate &&
+        candidate.dates.end >= segment.startDate
+    )
+
+    if (!destination) return segment
+
+    const items = segment.items.map((item): TripItemWithWeather => ({
+      ...item,
+      weather: getItemWeather(item.start_date, destination.daily) ?? undefined,
+    }))
+
+    return {
+      ...segment,
+      items,
+      weatherForecast: destination.daily.filter(
+        (day) => day.date >= segment.startDate && day.date <= segment.endDate
+      ),
+      weatherUnit: payload.temp_range?.unit ?? (payload.unit === 'celsius' ? '°C' : '°F'),
+    }
+  })
+}

--- a/supabase/migrations/20260308000001_public_trip_share_rls.sql
+++ b/supabase/migrations/20260308000001_public_trip_share_rls.sql
@@ -1,0 +1,26 @@
+-- Allow anonymous read access to explicitly shared trips/items using the share token header.
+
+create policy "trips_public_share_select" on public.trips
+  for select
+  using (
+    share_enabled = true
+    and share_token is not null
+    and share_token = (
+      coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token'
+    )
+  );
+
+create policy "trip_items_public_share_select" on public.trip_items
+  for select
+  using (
+    exists (
+      select 1
+      from public.trips t
+      where t.id = trip_items.trip_id
+        and t.share_enabled = true
+        and t.share_token is not null
+        and t.share_token = (
+          coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token'
+        )
+    )
+  );

--- a/supabase/migrations/20260308000001_public_trip_share_rls.sql
+++ b/supabase/migrations/20260308000001_public_trip_share_rls.sql
@@ -1,10 +1,12 @@
 -- Allow anonymous read access to explicitly shared trips/items using the share token header.
 
+-- Guard against DoS via oversized header values and validate token format
 create policy "trips_public_share_select" on public.trips
   for select
   using (
     share_enabled = true
     and share_token is not null
+    and length(coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token') <= 64
     and share_token = (
       coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token'
     )
@@ -19,6 +21,7 @@ create policy "trip_items_public_share_select" on public.trip_items
       where t.id = trip_items.trip_id
         and t.share_enabled = true
         and t.share_token is not null
+        and length(coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token') <= 64
         and t.share_token = (
           coalesce(nullif(current_setting('request.headers', true), ''), '{}')::jsonb ->> 'x-share-token'
         )


### PR DESCRIPTION
## PRD-040: Movement Timeline

Redesigns the trip page from a flat date-grouped list into a **Movement Timeline** — city segments showing the user's journey. Hotels anchor where you are, flights are transitions between cities.

### What's changed

- **City segmentation engine** (`src/lib/trips/city-segments.ts`): builds city segments from trip items, grouping hotels as anchors and flights as transitions
- **Traveler dedup** (`src/lib/trips/traveler-dedup.ts`): deduplicates traveler records for clean display
- **Airport cities** (`src/lib/trips/airport-cities.ts`): maps IATA codes to city names
- **Item weather** (`src/lib/weather/item-weather.ts`): attaches weather data to individual trip items
- **Movement timeline component** (`src/components/trips/movement-timeline.tsx`): top-level timeline component
- **City segment header** (`src/components/trips/city-segment-header.tsx`): city header with flag, dates, duration
- **Transition flight** (`src/components/trips/transition-flight.tsx`): flight card between city segments
- **Trip item card** (`src/components/trips/trip-item-card.tsx`): unified item display card
- **Public share page** (`src/app/share/[token]/page.tsx`): refactored to use new timeline
- **Trip detail page** (`src/app/(dashboard)/trips/[id]/page.tsx`): updated to use new timeline
- **RLS migration**: public trip share policy

### Tests

- `city-segments.test.ts`: 227 lines covering segmentation logic
- `traveler-dedup.test.ts`: dedup logic
- `item-weather.test.ts`: weather attachment

### Fixes

- 1582 insertions, 616 deletions — net positive on code quality
