### PR TITLE
feat: movement timeline v2 — two-pass city segmentation

### DIFF
--- a/.codex-prompt-040-v2.md
+++ b/.codex-prompt-040-v2.md
@@ -1,0 +1,234 @@
+# PRD-040 v2: Movement Timeline — REDESIGN
+
+## CRITICAL CONTEXT: First attempt (PR #48) was rolled back. These bugs MUST NOT recur:
+
+1. Transition flights showed raw hotel addresses as destinations ("Flight to 9449 Collins Avenue") — NEVER use hotel location as transition label
+2. Hotel names used as city names — ALWAYS strip hotel name to get city
+3. Connection airports (DFW, MDW) shown as destinations — connections must be GROUPED into one journey
+4. Wrong transition labels ("Flight to Portland" for all intermediate flights) — transition label comes from NEXT SEGMENT'S CITY, determined AFTER segmentation
+5. EWR→MXP labeled "Flight to New York" — label comes from arrival, not departure
+6. No weather shown — weather MUST be wired up
+7. Flight "more info" expansion lost — MUST preserve expandable flight details
+8. Departure city shown as segment — do NOT show departure city as a segment
+
+## Branch: `feature/prd-040-v2-movement-timeline`
+
+## TWO-PASS ALGORITHM (this is the key insight — do NOT try to do everything in one pass)
+
+### PASS 1: Group Connecting Flights into Journeys
+
+Walk through items chronologically. When you hit a flight:
+1. Start a `FlightJourney` with this flight as leg 1
+2. Look ahead: if the next item is ALSO a flight, AND its departure airport matches (or is in the same metro area as) the current arrival airport, AND the layover is <4 hours → it's a CONNECTION. Add as next leg.
+3. Keep looking ahead until the next item is not a connection.
+4. The FlightJourney gets: departure = first leg's origin, arrival = last leg's destination, stops = legs.length - 1, all individual legs preserved for "more info"
+
+Metro area matching (for airport changes like JFK→EWR):
+```
+NYC: JFK, EWR, LGA
+Chicago: ORD, MDW
+London: LHR, LGW, STN, LTN, LCY
+Paris: CDG, ORY
+Tokyo: NRT, HND
+Milan: MXP, LIN
+```
+
+EXAMPLE with real data:
+- `AUS→DFW` + `DFW→PDX` → ONE FlightJourney: departure=AUS, arrival=PDX, 1 stop (DFW)
+- `PDX→MDW` + `MDW→CHS` → ONE FlightJourney: departure=PDX, arrival=CHS, 1 stop (MDW)
+- `CHS→JFK` + `EWR→MXP` → ONE FlightJourney: departure=CHS, arrival=MXP, 2 stops (JFK/EWR are same NYC metro)
+
+### PASS 2: Segment by City
+
+After Pass 1, you have a list of: FlightJourneys and non-flight items (hotels, activities, etc.)
+
+Walk through this processed list:
+1. FlightJourneys are BOUNDARIES between segments
+2. Non-flight items (hotels, activities) get collected into the current segment
+3. When you hit a FlightJourney, finalize the current segment (if any items collected), then store the FlightJourney as a transition
+4. After the FlightJourney, start collecting items for the next segment
+
+For each segment, determine the city:
+- **Hotel exists in segment?** → Use hotel location, STRIP the hotel name to get city (use existing `normaliseToCity` from `src/lib/trips/assignment.ts`)
+- **No hotel but activities?** → Use activity location
+- **No items at all?** → Use the ARRIVAL airport of the incoming FlightJourney, mapped to city name via airport-cities lookup
+
+CRITICAL: The FIRST FlightJourney (departing home) has NO segment before it. Do NOT create a segment for the departure city. Just render the transition.
+
+CRITICAL: The transition's LABEL ("Flight to X") uses the NEXT segment's city name, NOT the flight's raw arrival location. You must determine the city FIRST, then label the transition.
+
+CRITICAL: The LAST segment (e.g., Milan) may have no items. Create it from the last FlightJourney's arrival airport. Show "Arriving [date]".
+
+## COMPONENTS TO BUILD
+
+### 1. City Segmentation Engine
+**File: `src/lib/trips/city-segments.ts`**
+
+Types:
+```typescript
+interface FlightJourney {
+  type: 'flight-journey'
+  departure: { code: string; city: string; time: string }
+  arrival: { code: string; city: string; time: string }
+  stops: number
+  stopCodes: string[]  // e.g., ["DFW"] or ["JFK", "EWR"]
+  legs: TripItem[]  // individual flight items for "more info"
+  date: string  // departure date
+  duration?: string  // total journey time
+}
+
+interface CitySegment {
+  city: string  // "Miami, FL" or "Austin, TX" or "Milan, Italy"
+  countryCode?: string  // "US", "IT", etc.
+  startDate: string
+  endDate: string
+  durationNights: number
+  anchorType: 'hotel' | 'airport' | 'activity'
+  items: TripItem[]  // hotels, activities, etc. in this city
+  weather?: {
+    daily: Array<{ date: string; emoji: string; high: number; low: number }>
+  }
+}
+
+interface TimelineEntry {
+  type: 'transition' | 'segment'
+  transition?: FlightJourney
+  segment?: CitySegment
+}
+
+function buildTimeline(items: TripItem[]): TimelineEntry[]
+```
+
+### 2. Airport Cities Lookup
+**File: `src/lib/trips/airport-cities.ts`**
+
+Include at least these airports (from Ian's actual trips):
+CDG, ORY, MIA, FLL, EWR, JFK, LGA, AUS, DFW, PDX, MDW, ORD, CHS, MXP, LIN, FCO, TRN, NCE, LHR, NRT, HND, ICN, PEK, SFO, LAX, ATL, DEN, SEA, BOS, TPA, MSP, DTW, PHX, SAN, PSP, SRQ, SCL, SXM, TLL, AMS, BCN, BER
+
+Export a function: `resolveAirportCity(code: string): { city: string; country: string; countryCode: string; metro?: string } | null`
+
+Export: `isSameMetroArea(code1: string, code2: string): boolean`
+
+### 3. Movement Timeline Component
+**File: `src/components/trips/movement-timeline.tsx`**
+
+Takes `TimelineEntry[]` and renders:
+- For `type: 'transition'`: render a `TransitionCard`
+- For `type: 'segment'`: render a `CitySegmentBlock`
+
+### 4. Transition Card
+**File: `src/components/trips/transition-card.tsx`**
+
+Shows between segments:
+- "✈️ Flight to [NEXT SEGMENT CITY] ([arrival code])"
+- Departure/arrival times
+- "Nonstop" or "1 stop (DFW)" or "2 stops"
+- Weather chip: emoji + temp at destination
+- **EXPANDABLE**: clicking [+] More Info reveals each leg's full details (airline, flight number, times, duration). This MUST work. Use the existing TripItemCard flight rendering for each leg, or similar detail display.
+
+Visual style: lighter than city segments. Dotted border or subtle background. Airplane icon.
+
+### 5. City Segment Block
+**File: `src/components/trips/city-segment-block.tsx`**
+
+Header:
+- Flag emoji + "CITY, REGION, COUNTRY"
+- Duration: "1 Night" / "3 Nights" / "Day Trip" / "Arriving Mar 23"
+- Date range
+- Compact weather strip (daily emoji + temp for each day of stay)
+
+Body:
+- Renders each item using existing `TripItemCard` component (DO NOT recreate)
+- Each card gets a weather chip (emoji + temp for that day)
+- If no hotel: show "(No accommodation details)" placeholder
+
+### 6. Update Trip Page
+**File: `src/app/(dashboard)/trips/[id]/page.tsx`**
+
+- Import `buildTimeline` and run it on the trip items
+- Pass result to `MovementTimeline` component
+- Remove old `TripTimeline` usage
+- Keep all existing functionality (edit, delete, etc.)
+
+### 7. Update Share Page
+**File: `src/app/share/[token]/page.tsx`**
+
+- Same `MovementTimeline` component
+- Share page shows weather but NOT packing suggestions
+- Obfuscate traveler names to "First L." format
+- Null out user_id on items
+
+### 8. Inline Weather on Items
+**File: `src/lib/weather/item-weather.ts`**
+
+WMO weather code → emoji mapping. Function to get weather for a specific date from a segment's weather data.
+
+### 9. Tests
+**File: `src/lib/trips/city-segments.test.ts`**
+
+Test with REAL DATA from Ian's trip:
+```
+Items:
+- Flight CDG→MIA (Mar 9)
+- Hotel "Grand Beach Hotel Surfside, 9449 Collins Avenue, Surfside, Florida 33154" (Mar 9-10)
+- Flight MIA→EWR (Mar 10)
+- Flight EWR→AUS (Mar 13)
+- Hotel "The Stephen F Austin Royal Sonesta Hotel" (Mar 13-14)
+- Flight AUS→DFW (Mar 14)
+- Flight DFW→PDX (Mar 14)
+- Flight PDX→MDW (Mar 20)
+- Flight MDW→CHS (Mar 20)
+- Hotel "The Vendue, Charleston, SC" (Mar 20-22)
+- Flight CHS→JFK (Mar 22)
+- Flight EWR→MXP (Mar 22)
+```
+
+Expected output:
+1. Transition: CDG→MIA (nonstop) — labeled "Flight to Miami"
+2. Segment: MIAMI, FL — 1 night, hotel Grand Beach
+3. Transition: MIA→EWR (nonstop) — labeled "Flight to New York"
+4. Segment: NEW YORK — 3 nights, no hotel, city from EWR airport
+5. Transition: EWR→AUS (nonstop) — labeled "Flight to Austin"
+6. Segment: AUSTIN, TX — 1 night, hotel Stephen F Austin
+7. Transition: AUS→PDX (1 stop DFW) — labeled "Flight to Portland"
+8. Segment: PORTLAND, OR — 6 nights, no hotel, city from PDX airport
+9. Transition: PDX→CHS (1 stop MDW) — labeled "Flight to Charleston"
+10. Segment: CHARLESTON, SC — 2 nights, hotel The Vendue
+11. Transition: CHS→MXP (2 stops) — labeled "Flight to Milan"
+12. Segment: MILAN, ITALY — arriving Mar 23
+
+Test assertions:
+- Segment count = 6 (Miami, NYC, Austin, Portland, Charleston, Milan)
+- Transition count = 6
+- No segment for Paris (departure city)
+- No segment for DFW, MDW, JFK (connection airports)
+- AUS→DFW + DFW→PDX grouped as one journey with 1 stop
+- CHS→JFK + EWR→MXP grouped as one journey with 2 stops (metro area match)
+- Miami segment city = "Miami" or "Surfside" (NOT "Grand Beach Hotel Surfside")
+- Austin segment city contains "Austin" (NOT "The Stephen F Austin Royal Sonesta Hotel")
+
+## EXISTING CODE TO REUSE
+
+- `src/lib/trips/assignment.ts` — `normaliseToCity()`, `looksLikeVenueName()` — USE THESE for hotel→city stripping
+- `src/components/trips/trip-item-card.tsx` — USE THIS for rendering items inside segments. Do NOT recreate.
+- `src/lib/weather/cities.ts` — `toCityQuery()`, `extractTripCities()` — for weather city extraction
+- `src/lib/weather/service.ts` — `getTripWeather()` — for fetching weather data
+- `src/lib/weather/types.ts` — existing weather types
+- `src/components/trips/weather/` — existing weather components
+
+## RULES
+
+1. Do NOT use `createSecretClient()` or service role to bypass RLS
+2. Run `pnpm test` after building. ALL tests must pass.
+3. Run `pnpm build` — must be clean.
+4. REUSE existing components (TripItemCard, weather components). Do not duplicate.
+5. Share page and dashboard use the SAME MovementTimeline component.
+6. Flight detail expansion MUST work. Each leg in a FlightJourney must be expandable.
+
+## WHEN DONE
+
+1. Push the branch
+2. Create a PR with clear description
+3. Run: `pnpm test && pnpm build`
+4. Run: `bash scripts/merge-ready-check.sh <PR_NUMBER>`
+5. Run: `openclaw system event --text 'Done: PRD-040 v2 Movement Timeline — redesigned, tests passing' --mode now`

--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -1,11 +1,13 @@
 import { createClient } from '@/lib/supabase/server'
 import { notFound } from 'next/navigation'
 import { TripHeader } from '@/components/trips/trip-header'
-import { TripTimeline } from '@/components/trips/trip-timeline'
+import { MovementTimeline } from '@/components/trips/movement-timeline'
 import { TripActions } from '@/components/trips/trip-actions'
 import { CollaboratorsSection } from '@/components/trips/collaborators-section'
 import { DemoTripBanner } from '@/components/trips/demo-trip-banner'
 import { WeatherSection } from '@/components/trips/weather/weather-section'
+import { attachWeatherToTimeline, buildTimeline } from '@/lib/trips/city-segments'
+import { getTemperatureUnit, getTripWeather } from '@/lib/weather/service'
 import { ArrowLeft, Users } from 'lucide-react'
 import Link from 'next/link'
 
@@ -86,6 +88,16 @@ export default async function TripPage({ params }: TripPageProps) {
         .maybeSingle()
     : { data: null }
   const isPro = profileData?.subscription_tier === 'pro'
+  const weather = user
+    ? await getTripWeather({
+        tripId: trip.id,
+        supabase,
+        userId: user.id,
+        requestedUnit: await getTemperatureUnit(user.id, supabase),
+        includePacking: isPro,
+      })
+    : null
+  const timeline = attachWeatherToTimeline(buildTimeline(items || []), weather?.destinations ?? [])
 
   return (
     <div className="space-y-6">
@@ -126,10 +138,9 @@ export default async function TripPage({ params }: TripPageProps) {
         isOwner={isOwner}
       />
 
-      {/* Timeline */}
-      <TripTimeline items={items || []} tripId={trip.id} allTrips={allTrips || []} currentUserId={user?.id} />
+      <MovementTimeline entries={timeline} allTrips={allTrips || []} currentUserId={user?.id} />
 
-      <WeatherSection endpoint={`/api/trips/${trip.id}/weather`} showPacking />
+      <WeatherSection endpoint={`/api/trips/${trip.id}/weather`} initialData={weather} showPacking />
     </div>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Work+Sans:wght@300;400;500;600&display=swap');
 @import "tailwindcss";
 @import "leaflet/dist/leaflet.css";
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Work+Sans:wght@300;400;500;600&display=swap');
 
 @theme inline {
   --font-sans: var(--font-space), 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -2,31 +2,18 @@ import { cache } from 'react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
-import {
-  MapPin,
-  Calendar,
-  Users,
-  Plane,
-  Building2,
-  TrainFront,
-  Car,
-  Utensils,
-  Ticket,
-  CalendarDays,
-} from 'lucide-react'
+import { Calendar, CalendarDays, MapPin, Users } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { createSecretClient } from '@/lib/supabase/service'
-import { formatDateRange, getKindIcon } from '@/lib/utils'
+import { formatDateRange } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
-import { getProviderLogoUrl } from '@/lib/images/provider-logo'
-import { extractAirlineCode } from '@/lib/images/airline-logo'
-import type { TripItemKind } from '@/types/database'
 import { WeatherSection } from '@/components/trips/weather/weather-section'
 import { buildWeatherPayload, getTemperatureUnit, getTripWeather } from '@/lib/weather/service'
-import type { Json } from '@/types/database'
+import type { Json, TripItem } from '@/types/database'
 import type { WeatherTripItem } from '@/lib/weather/types'
-import { AirlineLogoIcon } from './airline-logo-icon'
+import { attachWeatherToTimeline, buildTimeline } from '@/lib/trips/city-segments'
+import { MovementTimeline } from '@/components/trips/movement-timeline'
 import { ShareTripButton } from './share-trip-button'
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.ubtrippin.xyz'
@@ -48,78 +35,39 @@ interface ShareTrip {
   share_enabled: boolean | null
 }
 
-interface ShareTripItem {
-  id: string
-  kind: TripItemKind
-  provider: string | null
-  traveler_names: string[]
-  start_date: string
-  end_date: string | null
-  start_location: string | null
-  end_location: string | null
-  summary: string | null
-  details_json: Record<string, unknown> | null
-}
-
-const DAY_MS = 24 * 60 * 60 * 1000
-const MINUTE_MS = 60 * 1000
-
-/** Return first name + last initial only (e.g. "John Smith" -> "John S.") */
-function obfuscateName(name: string): string {
+function obfuscateName(name: string) {
   const parts = name.trim().split(/\s+/)
   if (parts.length === 1) return parts[0]
   return `${parts[0]} ${parts[parts.length - 1][0]}.`
 }
 
-/** Capitalise first letter of a string */
-function capitalise(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1)
-}
-
-function KindIcon({ kind, className }: { kind: TripItemKind; className?: string }) {
-  const icon = getKindIcon(kind)
-  const props = { className: className ?? 'h-4 w-4' }
-  switch (icon) {
-    case 'plane':
-      return <Plane {...props} />
-    case 'building':
-      return <Building2 {...props} />
-    case 'train-front':
-      return <TrainFront {...props} />
-    case 'car':
-      return <Car {...props} />
-    case 'utensils':
-      return <Utensils {...props} />
-    case 'ticket':
-      return <Ticket {...props} />
-    default:
-      return <CalendarDays {...props} />
-  }
-}
-
-const kindColors: Record<TripItemKind, string> = {
-  flight: 'bg-sky-100 text-sky-800',
-  hotel: 'bg-[#f1f5f9] text-[#1e293b]',
-  train: 'bg-emerald-100 text-emerald-800',
-  car: 'bg-[#f1f5f9] text-[#4f46e5]',
-  restaurant: 'bg-rose-100 text-rose-800',
-  activity: 'bg-purple-100 text-purple-800',
-  ticket: 'bg-amber-100 text-amber-800',
-  other: 'bg-gray-100 text-gray-800',
-}
-
 const isValidShareToken = (token: string) => /^[A-Za-z0-9_-]{10,64}$/.test(token)
 
-const getSharedTripData = cache(async (token: string): Promise<{ trip: ShareTrip | null; items: ShareTripItem[] | null }> => {
+function normaliseCityLabel(location: string) {
+  const city = location.split(',')[0].trim()
+  return city.replace(/[^\p{L}\p{N}\s.\-']/gu, '').slice(0, 100)
+}
+
+function buildTripSummaryDescription(trip: ShareTrip, items: TripItem[] | null) {
+  const dateLabel = formatDateRange(trip.start_date, trip.end_date)
+  const itemCount = items?.length ?? 0
+  const cities = new Set<string>()
+  if (trip.primary_location) cities.add(normaliseCityLabel(trip.primary_location))
+  items?.forEach((item) => {
+    if (item.start_location) cities.add(normaliseCityLabel(item.start_location))
+    if (item.end_location) cities.add(normaliseCityLabel(item.end_location))
+  })
+  const cityList = [...cities].filter(Boolean).slice(0, 3).join(' • ')
+  const itemLabel = `${itemCount} ${itemCount === 1 ? 'item' : 'items'}`
+  return [dateLabel, itemLabel, cityList].filter(Boolean).join(' · ')
+}
+
+const getSharedTripData = cache(async (token: string): Promise<{ trip: ShareTrip | null; items: TripItem[] | null }> => {
   if (!isValidShareToken(token)) {
     return { trip: null, items: null }
   }
 
   const supabase = createSecretClient()
-
-  // SECURITY: Select only fields needed for display — exclude sensitive fields (confirmation_code, etc.)
-  // Note: service-role client is required here since visitors are unauthenticated.
-  // RLS is intentionally bypassed; share_enabled check acts as the gate.
   const { data: tripRow } = await supabase
     .from('trips')
     .select('id, title, start_date, end_date, primary_location, travelers, notes, cover_image_url, share_enabled')
@@ -128,282 +76,52 @@ const getSharedTripData = cache(async (token: string): Promise<{ trip: ShareTrip
     .single()
 
   const trip = tripRow as ShareTrip | null
-  if (!trip) {
-    return { trip: null, items: null }
-  }
+  if (!trip) return { trip: null, items: null }
 
-  // SECURITY: Fetch fields needed for display — explicitly exclude confirmation_code and
-  // source_email_id. details_json is included but sanitised below before rendering.
   const { data: rawItems } = await supabase
     .from('trip_items')
-    .select('id, trip_id, kind, provider, summary, start_date, end_date, start_ts, end_ts, start_location, end_location, traveler_names, needs_review, status, details_json')
+    .select('id, kind, provider, traveler_names, start_date, end_date, start_ts, end_ts, start_location, end_location, summary, needs_review, status, details_json')
     .eq('trip_id', trip.id)
     .order('start_date', { ascending: true })
     .order('start_ts', { ascending: true })
 
-  // Strip sensitive fields from details_json before passing to the component
-  const items = rawItems?.map((item): ShareTripItem => {
-    const { details_json, ...rest } = item
+  const items = rawItems?.map((item): TripItem => {
     let safeDetails: Record<string, unknown> | null = null
-    if (details_json && typeof details_json === 'object') {
-      const { confirmation_code, booking_reference, ...remaining } = details_json as Record<string, unknown>
+    if (item.details_json && typeof item.details_json === 'object' && !Array.isArray(item.details_json)) {
+      const { confirmation_code, booking_reference, ...remaining } = item.details_json as Record<string, unknown>
       void confirmation_code
       void booking_reference
       safeDetails = remaining
     }
-    return { ...rest, details_json: safeDetails }
+
+    return {
+      id: item.id,
+      user_id: '',
+      trip_id: trip.id,
+      kind: item.kind,
+      provider: item.provider,
+      confirmation_code: null,
+      traveler_names: item.traveler_names ?? [],
+      start_ts: item.start_ts,
+      end_ts: item.end_ts,
+      start_date: item.start_date,
+      end_date: item.end_date,
+      start_location: item.start_location,
+      end_location: item.end_location,
+      summary: item.summary,
+      details_json: (safeDetails ?? {}) as Json,
+      status: item.status,
+      confidence: 1,
+      needs_review: item.needs_review,
+      loyalty_flag: null,
+      source_email_id: null,
+      created_at: '',
+      updated_at: '',
+    }
   }) ?? null
 
   return { trip, items }
 })
-
-function normaliseCityLabel(location: string) {
-  // Strip anything that isn't alphanumeric, space, hyphen, period, or common diacritics
-  const city = location.split(',')[0].trim()
-  return city.replace(/[^\p{L}\p{N}\s.\-']/gu, '').slice(0, 100)
-}
-
-function buildTripSummaryDescription(trip: ShareTrip, items: ShareTripItem[] | null) {
-  const dateLabel = formatDateRange(trip.start_date, trip.end_date)
-  const itemCount = items?.length ?? 0
-
-  const cities = new Set<string>()
-  if (trip.primary_location) cities.add(normaliseCityLabel(trip.primary_location))
-  items?.forEach((item) => {
-    if (item.start_location) cities.add(normaliseCityLabel(item.start_location))
-    if (item.end_location) cities.add(normaliseCityLabel(item.end_location))
-  })
-
-  const cityList = [...cities].filter(Boolean).slice(0, 3).join(' • ')
-  const itemLabel = `${itemCount} ${itemCount === 1 ? 'item' : 'items'}`
-  return [dateLabel, itemLabel, cityList].filter(Boolean).join(' · ')
-}
-
-function formatTimelineDate(date: string | null) {
-  if (!date) return 'Date TBD'
-  const parsed = new Date(`${date}T00:00:00`)
-  if (Number.isNaN(parsed.getTime())) return 'Date TBD'
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(parsed)
-}
-
-function readNumber(details: Record<string, unknown> | null, key: string) {
-  const value = details?.[key]
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
-}
-
-function readString(details: Record<string, unknown> | null, key: string) {
-  const value = details?.[key]
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
-}
-
-function formatHoursAndMinutes(totalMinutes: number) {
-  const roundedMinutes = Math.max(1, Math.round(totalMinutes))
-  const hours = Math.floor(roundedMinutes / 60)
-  const minutes = roundedMinutes % 60
-  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
-  if (hours > 0) return `${hours}h`
-  return `${minutes}m`
-}
-
-function parseDateWithOptionalTime(date: string | null, hhmm: string | undefined, endOfDay = false) {
-  if (!date) return null
-  // Validate date format to prevent unexpected Date parsing behavior
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
-  const normalizedTime = hhmm && /^\d{1,2}:\d{2}$/.test(hhmm)
-    ? `${hhmm.padStart(5, '0')}:00`
-    : (endOfDay ? '23:59:00' : '00:00:00')
-  const parsed = new Date(`${date}T${normalizedTime}`)
-  return Number.isNaN(parsed.getTime()) ? null : parsed
-}
-
-function getItemStartDate(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const departureTime = readString(details, 'departure_local_time') ?? undefined
-  return parseDateWithOptionalTime(item.start_date, departureTime, false)
-}
-
-function getItemEndDate(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const arrivalTime = readString(details, 'arrival_local_time') ?? undefined
-  return parseDateWithOptionalTime(item.end_date ?? item.start_date, arrivalTime, true)
-}
-
-/**
- * Extract a city name from a location string.
- * Hotel locations are often full names like "The Stephen F Austin Royal Sonesta Hotel"
- * with no comma-separated city. We only return a city if the location looks like
- * "City, State" or "Place, City, Country" — i.e., has a comma.
- */
-function extractCity(location: string | null): string | null {
-  if (!location) return null
-  // Only treat as a city if there's a comma (e.g. "Austin, TX" or "Miami, FL")
-  // Full hotel/venue names without commas are not useful city labels
-  if (!location.includes(',')) return null
-  return normaliseCityLabel(location)
-}
-
-function formatGapLabel(previous: ShareTripItem, next: ShareTripItem) {
-  const previousEnd = getItemEndDate(previous)
-  const nextStart = getItemStartDate(next)
-  if (!previousEnd || !nextStart) return null
-
-  const diffMs = nextStart.getTime() - previousEnd.getTime()
-  if (diffMs <= 0) return null
-
-  if (diffMs < DAY_MS) {
-    const totalMinutes = diffMs / MINUTE_MS
-    return `${formatHoursAndMinutes(totalMinutes)} layover`
-  }
-
-  // Use ceiling for day count — a gap from Tue afternoon to Thu morning is 2 days, not 1
-  const days = Math.max(1, Math.ceil(diffMs / DAY_MS))
-  // Prefer the city where you ARE (previous end), not where you're going
-  const city = extractCity(previous.end_location) ?? extractCity(next.start_location)
-  if (!city) return `${days} ${days === 1 ? 'day' : 'days'}`
-  return `${days} ${days === 1 ? 'day' : 'days'} in ${city}`
-}
-
-function getFlightDurationLabel(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const textDuration = readString(details, 'flight_duration')
-    ?? readString(details, 'duration')
-    ?? readString(details, 'flight_time')
-  if (textDuration) return textDuration
-
-  const minutes = readNumber(details, 'flight_duration_minutes')
-    ?? readNumber(details, 'duration_minutes')
-    ?? readNumber(details, 'flight_time_minutes')
-  if (minutes && minutes > 0) return formatHoursAndMinutes(minutes)
-
-  const start = getItemStartDate(item)
-  const end = getItemEndDate(item)
-  if (start && end) {
-    const diffMinutes = (end.getTime() - start.getTime()) / MINUTE_MS
-    if (diffMinutes > 0 && diffMinutes < 48 * 60) {
-      return formatHoursAndMinutes(diffMinutes)
-    }
-  }
-  return null
-}
-
-function getHotelDurationLabel(item: ShareTripItem) {
-  const details = item.details_json as Record<string, unknown> | null
-  const nightsFromDetails = readNumber(details, 'nights')
-  if (nightsFromDetails && nightsFromDetails > 0) {
-    return `${nightsFromDetails} ${nightsFromDetails === 1 ? 'night' : 'nights'}`
-  }
-  if (item.end_date) {
-    const start = parseDateWithOptionalTime(item.start_date, undefined, false)
-    const end = parseDateWithOptionalTime(item.end_date, undefined, false)
-    if (start && end) {
-      const nights = Math.max(1, Math.round((end.getTime() - start.getTime()) / DAY_MS))
-      return `${nights} ${nights === 1 ? 'night' : 'nights'}`
-    }
-  }
-  return null
-}
-
-function getItemDurationLabel(item: ShareTripItem) {
-  switch (item.kind) {
-    case 'flight': return getFlightDurationLabel(item)
-    case 'hotel': return getHotelDurationLabel(item)
-    default: return null
-  }
-}
-
-function TripItemRow({ item, durationLabel }: { item: ShareTripItem; durationLabel?: string | null }) {
-  const names = item.traveler_names.map(obfuscateName)
-  const location =
-    item.start_location && item.end_location
-      ? `${item.start_location} → ${item.end_location}`
-      : item.start_location || item.end_location || null
-  const details = item.details_json as Record<string, unknown> | null
-  const flightNumber = details?.flight_number as string | undefined
-  const iataCode = flightNumber ? extractAirlineCode(flightNumber) : null
-  const airlineLogoUrl = item.kind === 'flight'
-    ? (iataCode ? `https://pics.avs.io/80/80/${iataCode}@2x.png` : (item.provider ? getProviderLogoUrl(item.provider, item.kind) : null))
-    : null
-  const departureTime = details?.departure_local_time as string | undefined
-  const arrivalTime = details?.arrival_local_time as string | undefined
-  const displayTitle = flightNumber
-    ? `${item.provider ?? capitalise(item.kind)} ${flightNumber}`
-    : item.provider ?? capitalise(item.kind)
-
-  const timeDisplay = departureTime && arrivalTime
-    ? `${departureTime} → ${arrivalTime}`
-    : departureTime
-      ? `Departs ${departureTime}`
-      : arrivalTime
-        ? `Arrives ${arrivalTime}`
-        : null
-
-  return (
-    <div className="flex items-start gap-3 py-4">
-      {airlineLogoUrl ? (
-        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-white">
-          <AirlineLogoIcon url={airlineLogoUrl} alt={item.provider || 'Airline'} />
-        </div>
-      ) : (
-        <div
-          className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${kindColors[item.kind]}`}
-        >
-          <KindIcon kind={item.kind} className="h-4 w-4" />
-        </div>
-      )}
-
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-medium text-gray-900">
-            {displayTitle}
-          </span>
-          <span
-            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${kindColors[item.kind]}`}
-          >
-            {capitalise(item.kind)}
-          </span>
-          {durationLabel && (
-            <span className="inline-flex items-center rounded-full border border-[#cbd5e1] bg-[#eef2ff] px-2 py-0.5 text-xs font-medium text-[#4338ca]">
-              {durationLabel}
-            </span>
-          )}
-        </div>
-
-        {timeDisplay && (
-          <p className="mt-1 text-sm font-medium text-gray-800">{timeDisplay}</p>
-        )}
-
-        {item.summary && !timeDisplay && (
-          <p className="mt-0.5 text-sm leading-snug text-gray-600">{item.summary}</p>
-        )}
-
-        <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
-          {(item.start_date || item.end_date) && (
-            <span className="flex items-center gap-1">
-              <Calendar className="h-3 w-3 text-[#4f46e5]" />
-              {formatDateRange(item.start_date, item.end_date)}
-            </span>
-          )}
-          {location && (
-            <span className="flex items-center gap-1">
-              <MapPin className="h-3 w-3 text-[#4f46e5]" />
-              {location}
-            </span>
-          )}
-          {names.length > 0 && (
-            <span className="flex items-center gap-1">
-              <Users className="h-3 w-3 text-[#4f46e5]" />
-              {names.join(', ')}
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
 
 export async function generateMetadata({ params }: SharePageProps): Promise<Metadata> {
   const { token } = await params
@@ -465,34 +183,31 @@ export default async function SharePage({ params }: SharePageProps) {
             </Link>
           </div>
         </header>
-
         <main className="flex flex-1 items-center justify-center p-8">
           <div className="text-center">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[#f1f5f9]">
               <MapPin className="h-8 w-8 text-[#4f46e5]" />
             </div>
             <h1 className="text-2xl font-bold text-gray-900">Trip not found</h1>
-            <p className="mt-2 text-gray-500">
-              This trip either doesn&apos;t exist or sharing has been disabled.
-            </p>
-            <Link
-              href="/"
-              className="mt-6 inline-flex items-center rounded-lg bg-[#1e293b] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#312e81]"
-            >
-              Plan your own trip with UBTRIPPIN
-            </Link>
+            <p className="mt-2 text-gray-500">This trip either doesn&apos;t exist or sharing has been disabled.</p>
           </div>
         </main>
       </div>
     )
   }
 
-  const travelers = (trip.travelers ?? []).map(obfuscateName)
-  const itemCount = items?.length ?? 0
   const sessionSupabase = await createClient()
   const {
     data: { user },
   } = await sessionSupabase.auth.getUser()
+
+  const obfuscatedItems = (items ?? []).map((item) => ({
+    ...item,
+    user_id: '',
+    traveler_names: item.traveler_names.map(obfuscateName),
+  }))
+  const travelers = (trip.travelers ?? []).map(obfuscateName)
+  const itemCount = obfuscatedItems.length
 
   let sharedWeather = items
     ? await buildWeatherPayload({
@@ -511,13 +226,13 @@ export default async function SharePage({ params }: SharePageProps) {
             kind: item.kind,
             start_date: item.start_date,
             end_date: item.end_date,
-            start_ts: null,
-            end_ts: null,
+            start_ts: item.start_ts,
+            end_ts: item.end_ts,
             start_location: item.start_location,
             end_location: item.end_location,
             provider: item.provider,
             summary: item.summary,
-            details_json: (item.details_json ?? {}) as Json,
+            details_json: item.details_json,
           })
         ),
         unit: 'fahrenheit',
@@ -541,16 +256,17 @@ export default async function SharePage({ params }: SharePageProps) {
         .maybeSingle()
 
       showPacking = ownerProfile?.subscription_tier === 'pro'
-      const unit = await getTemperatureUnit(user.id, sessionSupabase)
       sharedWeather = await getTripWeather({
         tripId: trip.id,
         supabase: sessionSupabase,
         userId: user.id,
-        requestedUnit: unit,
+        requestedUnit: await getTemperatureUnit(user.id, sessionSupabase),
         includePacking: showPacking,
       })
     }
   }
+
+  const timeline = attachWeatherToTimeline(buildTimeline(obfuscatedItems), sharedWeather?.destinations ?? [])
 
   return (
     <div className="flex min-h-screen flex-col bg-[#ffffff]">
@@ -590,28 +306,24 @@ export default async function SharePage({ params }: SharePageProps) {
               </div>
               <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
                 <div className="mx-auto max-w-4xl">
-                  <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl">
-                    {trip.title}
-                  </h1>
+                  <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl">{trip.title}</h1>
                   <div className="mt-3 flex flex-wrap gap-4 text-sm text-white/90">
-                    {(trip.start_date || trip.end_date) && (
-                      <span className="flex items-center gap-1.5">
-                        <Calendar className="h-4 w-4" />
-                        {formatDateRange(trip.start_date, trip.end_date)}
-                      </span>
-                    )}
-                    {trip.primary_location && (
+                    <span className="flex items-center gap-1.5">
+                      <Calendar className="h-4 w-4" />
+                      {formatDateRange(trip.start_date, trip.end_date)}
+                    </span>
+                    {trip.primary_location ? (
                       <span className="flex items-center gap-1.5">
                         <MapPin className="h-4 w-4" />
                         {trip.primary_location}
                       </span>
-                    )}
-                    {travelers.length > 0 && (
+                    ) : null}
+                    {travelers.length > 0 ? (
                       <span className="flex items-center gap-1.5">
                         <Users className="h-4 w-4" />
                         {travelers.join(', ')}
                       </span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </div>
@@ -619,28 +331,24 @@ export default async function SharePage({ params }: SharePageProps) {
           ) : (
             <div className="bg-gradient-to-r from-[#f1f5f9] to-[#ffffff] px-6 py-10 sm:px-8">
               <div className="mx-auto max-w-4xl">
-                <h1 className="text-3xl font-bold leading-tight text-gray-900 sm:text-4xl">
-                  {trip.title}
-                </h1>
+                <h1 className="text-3xl font-bold leading-tight text-gray-900 sm:text-4xl">{trip.title}</h1>
                 <div className="mt-3 flex flex-wrap gap-4 text-sm text-gray-700">
-                  {(trip.start_date || trip.end_date) && (
-                    <span className="flex items-center gap-1.5">
-                      <Calendar className="h-4 w-4 text-[#4f46e5]" />
-                      {formatDateRange(trip.start_date, trip.end_date)}
-                    </span>
-                  )}
-                  {trip.primary_location && (
+                  <span className="flex items-center gap-1.5">
+                    <Calendar className="h-4 w-4 text-[#4f46e5]" />
+                    {formatDateRange(trip.start_date, trip.end_date)}
+                  </span>
+                  {trip.primary_location ? (
                     <span className="flex items-center gap-1.5">
                       <MapPin className="h-4 w-4 text-[#4f46e5]" />
                       {trip.primary_location}
                     </span>
-                  )}
-                  {travelers.length > 0 && (
+                  ) : null}
+                  {travelers.length > 0 ? (
                     <span className="flex items-center gap-1.5">
                       <Users className="h-4 w-4 text-[#4f46e5]" />
                       {travelers.join(', ')}
                     </span>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -648,27 +356,27 @@ export default async function SharePage({ params }: SharePageProps) {
         </div>
 
         <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
-          {itemCount > 0 && (
+          {itemCount > 0 ? (
             <div className="mb-6 flex flex-wrap gap-3">
               <Badge variant="secondary" className="text-xs">
                 {itemCount} {itemCount === 1 ? 'item' : 'items'}
               </Badge>
-              {trip.primary_location && (
+              {trip.primary_location ? (
                 <Badge variant="default" className="text-xs">
                   <MapPin className="mr-1 h-3 w-3" />
                   {trip.primary_location}
                 </Badge>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
 
-          {trip.notes && (
+          {trip.notes ? (
             <Card className="mb-6 border-[#cbd5e1] bg-[#ffffff]">
               <CardContent className="p-4">
                 <p className="text-sm leading-relaxed text-gray-700">{trip.notes}</p>
               </CardContent>
             </Card>
-          )}
+          ) : null}
 
           {sharedWeather ? (
             <div className="mb-6">
@@ -682,47 +390,8 @@ export default async function SharePage({ params }: SharePageProps) {
             </div>
           ) : null}
 
-          {items && items.length > 0 ? (
-            <Card className="border-[#cbd5e1]">
-              <CardContent className="p-0">
-                <div className="relative px-4 py-3 sm:px-5 sm:py-4">
-                  <div className="absolute bottom-8 left-3 top-8 w-px bg-gradient-to-b from-[#4f46e5]/50 via-[#94a3b8] to-[#4f46e5]/50 sm:left-3.5" />
-
-                  <div className="relative pl-7 sm:pl-8">
-                    <div className="absolute left-2 top-1 h-2 w-2 rounded-full bg-[#4338ca] sm:left-2.5" />
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-[#4338ca]">Trip starts</p>
-                    <p className="text-sm font-medium text-[#334155]">{formatTimelineDate(trip.start_date)}</p>
-                  </div>
-
-                  <div className="mt-2 space-y-0.5">
-                    {items.map((item, index) => {
-                      const gapLabel = index < items.length - 1 ? formatGapLabel(item, items[index + 1]) : null
-                      return (
-                        <div key={item.id}>
-                          <div className="relative border-b border-[#f1f5f9] pl-7 last:border-0 sm:pl-8">
-                            <div className="absolute left-[7px] top-8 h-2.5 w-2.5 rounded-full border-2 border-[#4f46e5] bg-white sm:left-2" />
-                            <TripItemRow item={item} durationLabel={getItemDurationLabel(item)} />
-                          </div>
-                          {gapLabel && (
-                            <div className="relative pl-7 py-1.5 sm:pl-8">
-                              <p className="text-xs font-medium text-[#475569]">{gapLabel}</p>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-
-                  <div className="relative mt-2 pl-7 sm:pl-8">
-                    <div className="absolute left-2 top-1 h-2 w-2 rounded-full bg-[#4338ca] sm:left-2.5" />
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-[#4338ca]">Trip ends</p>
-                    <p className="text-sm font-medium text-[#334155]">
-                      {formatTimelineDate(trip.end_date ?? trip.start_date)}
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+          {obfuscatedItems.length > 0 ? (
+            <MovementTimeline entries={timeline} allTrips={[]} readOnly />
           ) : (
             <div className="py-12 text-center text-gray-400">
               <CalendarDays className="mx-auto mb-3 h-10 w-10 opacity-40" />
@@ -754,37 +423,8 @@ export default async function SharePage({ params }: SharePageProps) {
 
       <footer className="border-t border-[#cbd5e1] bg-white">
         <div className="mx-auto max-w-4xl px-4 py-10 text-center sm:px-6">
-          <Image
-            src="/ubtrippin_logo.png"
-            alt="UBTRIPPIN"
-            width={40}
-            height={40}
-            className="mx-auto mb-3 rounded-xl"
-          />
-          <h2 className="text-lg font-semibold text-gray-900">
-            Organize your trips with UBTRIPPIN
-          </h2>
-          <p className="mx-auto mt-2 max-w-sm text-sm text-gray-500">
-            Automatically extract travel bookings from your inbox and keep your
-            entire itinerary in one beautiful place.
-          </p>
-          <div className="mt-5 flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <Link
-              href="/"
-              className="inline-flex items-center rounded-lg bg-[#1e293b] px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#312e81]"
-            >
-              Get started - it&apos;s free
-            </Link>
-            <Link
-              href="/login"
-              className="inline-flex items-center rounded-lg border border-[#4338ca] px-5 py-2.5 text-sm font-semibold text-[#4338ca] transition-colors hover:bg-[#eef2ff]"
-            >
-              Try Pro free
-            </Link>
-          </div>
-          <p className="mt-4 text-xs text-gray-400">
-            &copy; {new Date().getFullYear()} UBTRIPPIN
-          </p>
+          <Image src="/ubtrippin_logo.png" alt="UBTRIPPIN" width={40} height={40} className="mx-auto rounded-lg" />
+          <p className="mt-4 text-sm text-gray-500">AI-first travel intelligence for forwarded booking emails.</p>
         </div>
       </footer>
     </div>

--- a/src/components/trips/city-segment-block.tsx
+++ b/src/components/trips/city-segment-block.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { formatDate, formatDateRange } from '@/lib/utils'
+import { weatherForItem, type CitySegment } from '@/lib/trips/city-segments'
+import type { Trip } from '@/types/database'
+import { TripItemCard } from './trip-item-card'
+
+interface CitySegmentBlockProps {
+  segment: CitySegment
+  allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
+  currentUserId?: string
+  readOnly?: boolean
+}
+
+function flagEmoji(countryCode?: string) {
+  if (!countryCode || countryCode.length !== 2) return '📍'
+  return String.fromCodePoint(...countryCode.toUpperCase().split('').map((char) => 127397 + char.charCodeAt(0)))
+}
+
+function durationLabel(segment: CitySegment) {
+  if (segment.durationNights === 0) return `Arriving ${formatDate(segment.startDate)}`
+  if (segment.durationNights === 1) return '1 Night'
+  return `${segment.durationNights} Nights`
+}
+
+export function CitySegmentBlock({
+  segment,
+  allTrips,
+  currentUserId,
+  readOnly = false,
+}: CitySegmentBlockProps) {
+  const hasHotel = segment.items.some((item) => item.kind === 'hotel')
+
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm">
+      <CardContent className="p-5">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">City stay</p>
+              <h3 className="mt-1 text-2xl font-semibold text-slate-950">
+                {flagEmoji(segment.countryCode)} {segment.city.toUpperCase()}
+              </h3>
+              <div className="mt-2 flex flex-wrap gap-2 text-sm text-slate-600">
+                <Badge variant="secondary">{durationLabel(segment)}</Badge>
+                <Badge variant="outline">{formatDateRange(segment.startDate, segment.endDate)}</Badge>
+              </div>
+            </div>
+
+            {segment.weather?.daily?.length ? (
+              <div className="flex flex-wrap gap-2">
+                {segment.weather.daily.map((day) => (
+                  <div key={day.date} className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+                    {day.emoji} {Math.round(day.high)}°
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          {!hasHotel ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">
+              No accommodation details
+            </div>
+          ) : null}
+
+          <div className="space-y-3">
+            {segment.items.map((item) => {
+              const itemWeather = weatherForItem(segment, item)
+              return (
+                <TripItemCard
+                  key={item.id}
+                  item={item}
+                  allTrips={allTrips}
+                  currentUserId={currentUserId}
+                  readOnly={readOnly}
+                  metaChips={
+                    itemWeather ? (
+                      <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+                        {itemWeather.emoji} {Math.round(itemWeather.high)}° / {Math.round(itemWeather.low)}°
+                      </span>
+                    ) : null
+                  }
+                />
+              )
+            })}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/trips/movement-timeline.tsx
+++ b/src/components/trips/movement-timeline.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import type { Trip } from '@/types/database'
+import type { TimelineEntry } from '@/lib/trips/city-segments'
+import { getWeatherForDate } from '@/lib/weather/item-weather'
+import { CitySegmentBlock } from './city-segment-block'
+import { TransitionCard } from './transition-card'
+
+interface MovementTimelineProps {
+  entries: TimelineEntry[]
+  allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
+  currentUserId?: string
+  readOnly?: boolean
+}
+
+export function MovementTimeline({
+  entries,
+  allTrips,
+  currentUserId,
+  readOnly = false,
+}: MovementTimelineProps) {
+  if (entries.length === 0) return null
+
+  return (
+    <div className="space-y-4">
+      {entries.map((entry, index) => {
+        if (entry.type === 'transition' && entry.transition) {
+          const nextSegment = entries.slice(index + 1).find((candidate) => candidate.type === 'segment')?.segment
+          const weather = nextSegment ? getWeatherForDate(nextSegment.weather?.daily, nextSegment.startDate) : null
+          return (
+            <TransitionCard
+              key={`${entry.transition.date}-${entry.transition.departure.code}-${entry.transition.arrival.code}-${index}`}
+              journey={entry.transition}
+              nextSegmentCity={entry.nextSegmentCity ?? nextSegment?.city ?? entry.transition.arrival.city}
+              weather={weather}
+              allTrips={allTrips}
+              currentUserId={currentUserId}
+              readOnly={readOnly}
+            />
+          )
+        }
+
+        if (entry.type === 'segment' && entry.segment) {
+          return (
+            <CitySegmentBlock
+              key={`${entry.segment.city}-${entry.segment.startDate}-${index}`}
+              segment={entry.segment}
+              allTrips={allTrips}
+              currentUserId={currentUserId}
+              readOnly={readOnly}
+            />
+          )
+        }
+
+        return null
+      })}
+    </div>
+  )
+}

--- a/src/components/trips/transition-card.tsx
+++ b/src/components/trips/transition-card.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronUp, Clock, Plane } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import type { Trip } from '@/types/database'
+import type { FlightJourney } from '@/lib/trips/city-segments'
+import type { TimelineWeatherDay } from '@/lib/weather/item-weather'
+import { TripItemCard } from './trip-item-card'
+
+interface TransitionCardProps {
+  journey: FlightJourney
+  nextSegmentCity: string
+  weather?: TimelineWeatherDay | null
+  allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
+  currentUserId?: string
+  readOnly?: boolean
+}
+
+function stopLabel(journey: FlightJourney) {
+  if (journey.stopCodes.length === 0) return 'Nonstop'
+  if (journey.stopCodes.length === 1) return `1 stop (${journey.stopCodes[0]})`
+  return `${journey.stopCodes.length} stops`
+}
+
+export function TransitionCard({
+  journey,
+  nextSegmentCity,
+  weather,
+  allTrips,
+  currentUserId,
+  readOnly = false,
+}: TransitionCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <Card className="border-dashed border-sky-200 bg-sky-50/70">
+      <CardContent className="p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-sky-600">
+                <Plane className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-600">Transition</p>
+                <h3 className="text-lg font-semibold text-slate-900">
+                  Flight to {nextSegmentCity} ({journey.arrival.code})
+                </h3>
+              </div>
+            </div>
+
+            <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-600">
+              <span>{journey.departure.code} {journey.departure.time || '--:--'} to {journey.arrival.code} {journey.arrival.time || '--:--'}</span>
+              <span>{stopLabel(journey)}</span>
+              {journey.duration ? (
+                <span className="inline-flex items-center gap-1">
+                  <Clock className="h-3.5 w-3.5" />
+                  {journey.duration}
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {weather ? (
+            <div className="rounded-full bg-white px-3 py-1 text-sm font-medium text-slate-700 shadow-sm">
+              {weather.emoji} {Math.round(weather.high)}° / {Math.round(weather.low)}°
+            </div>
+          ) : null}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="mt-4 flex items-center gap-1 text-sm font-medium text-sky-700 hover:text-sky-800"
+        >
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          More info
+        </button>
+
+        {expanded ? (
+          <div className="mt-4 space-y-3">
+            {journey.legs.map((leg) => (
+              <TripItemCard
+                key={leg.id}
+                item={leg}
+                allTrips={allTrips}
+                currentUserId={currentUserId}
+                readOnly={readOnly}
+              />
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -54,6 +54,8 @@ interface TripItemCardProps {
   item: TripItem
   allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
   currentUserId?: string
+  readOnly?: boolean
+  metaChips?: ReactNode
 }
 
 function loyaltyChip(loyaltyFlag: unknown): { text: string; className: string } | null {
@@ -135,7 +137,7 @@ function isWithin48Hours(item: { start_ts?: string | null; start_date?: string |
   return now >= dep - h48 && now <= endTime
 }
 
-export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProps) {
+export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, metaChips }: TripItemCardProps) {
   const router = useRouter()
   const [expanded, setExpanded] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -292,11 +294,14 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
                 </p>
               )}
 
-              {loyalty && (
-                <div className="mt-1.5">
-                  <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', loyalty.className)}>
-                    {loyalty.text}
-                  </span>
+              {(loyalty || metaChips) && (
+                <div className="mt-1.5 flex flex-wrap gap-2">
+                  {loyalty ? (
+                    <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', loyalty.className)}>
+                      {loyalty.text}
+                    </span>
+                  ) : null}
+                  {metaChips}
                 </div>
               )}
 
@@ -366,64 +371,66 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
             </div>
 
             {/* Actions */}
-            <div className="relative flex items-center gap-1">
-              {sourceEmailId ? (
-                <Link href={`/inbox/${sourceEmailId}`}>
+            {!readOnly ? (
+              <div className="relative flex items-center gap-1">
+                {sourceEmailId ? (
+                  <Link href={`/inbox/${sourceEmailId}`}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      title="Edit extraction in Inbox"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                  </Link>
+                ) : (
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0"
-                    title="Edit extraction in Inbox"
+                    className="h-8 w-8 p-0 text-gray-300"
+                    disabled
+                    title="No source email for this item"
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
-                </Link>
-              ) : (
+                )}
+
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-8 p-0 text-gray-300"
-                  disabled
-                  title="No source email for this item"
+                  className="h-8 w-8 p-0"
+                  onClick={() => setMenuOpen(!menuOpen)}
                 >
-                  <Pencil className="h-4 w-4" />
+                  <MoreHorizontal className="h-4 w-4" />
                 </Button>
-              )}
 
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-8 p-0"
-                onClick={() => setMenuOpen(!menuOpen)}
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-
-              {menuOpen && (
-                <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border bg-white py-1 shadow-lg">
-                  <button
-                    onClick={() => {
-                      setMenuOpen(false)
-                      setMoveOpen(true)
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                  >
-                    <ArrowRight className="h-4 w-4" />
-                    Move to...
-                  </button>
-                  <button
-                    onClick={() => {
-                      setMenuOpen(false)
-                      setDeleteOpen(true)
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Delete
-                  </button>
-                </div>
-              )}
-            </div>
+                {menuOpen && (
+                  <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border bg-white py-1 shadow-lg">
+                    <button
+                      onClick={() => {
+                        setMenuOpen(false)
+                        setMoveOpen(true)
+                      }}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    >
+                      <ArrowRight className="h-4 w-4" />
+                      Move to...
+                    </button>
+                    <button
+                      onClick={() => {
+                        setMenuOpen(false)
+                        setDeleteOpen(true)
+                      }}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : null}
           </div>
 
           {/* Expandable details */}
@@ -486,7 +493,7 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
       </Card>
 
       {/* Move dialog */}
-      <Dialog open={moveOpen} onOpenChange={setMoveOpen}>
+      <Dialog open={!readOnly && moveOpen} onOpenChange={setMoveOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Move Item</DialogTitle>
@@ -529,7 +536,7 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
       </Dialog>
 
       {/* Delete dialog */}
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+      <Dialog open={!readOnly && deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete Item</DialogTitle>

--- a/src/lib/trips/airport-cities.ts
+++ b/src/lib/trips/airport-cities.ts
@@ -1,0 +1,64 @@
+export interface ResolvedAirportCity {
+  city: string
+  country: string
+  countryCode: string
+  metro?: string
+}
+
+const AIRPORT_CITIES: Record<string, ResolvedAirportCity> = {
+  AMS: { city: 'Amsterdam', country: 'Netherlands', countryCode: 'NL' },
+  ATL: { city: 'Atlanta, GA', country: 'United States', countryCode: 'US' },
+  AUS: { city: 'Austin, TX', country: 'United States', countryCode: 'US' },
+  BCN: { city: 'Barcelona', country: 'Spain', countryCode: 'ES' },
+  BER: { city: 'Berlin', country: 'Germany', countryCode: 'DE' },
+  BOS: { city: 'Boston, MA', country: 'United States', countryCode: 'US' },
+  CDG: { city: 'Paris', country: 'France', countryCode: 'FR', metro: 'PAR' },
+  CHS: { city: 'Charleston, SC', country: 'United States', countryCode: 'US' },
+  DEN: { city: 'Denver, CO', country: 'United States', countryCode: 'US' },
+  DFW: { city: 'Dallas, TX', country: 'United States', countryCode: 'US' },
+  DTW: { city: 'Detroit, MI', country: 'United States', countryCode: 'US' },
+  EWR: { city: 'New York', country: 'United States', countryCode: 'US', metro: 'NYC' },
+  FCO: { city: 'Rome', country: 'Italy', countryCode: 'IT' },
+  FLL: { city: 'Fort Lauderdale, FL', country: 'United States', countryCode: 'US' },
+  HND: { city: 'Tokyo', country: 'Japan', countryCode: 'JP', metro: 'TYO' },
+  ICN: { city: 'Seoul', country: 'South Korea', countryCode: 'KR' },
+  JFK: { city: 'New York', country: 'United States', countryCode: 'US', metro: 'NYC' },
+  LAX: { city: 'Los Angeles, CA', country: 'United States', countryCode: 'US' },
+  LGA: { city: 'New York', country: 'United States', countryCode: 'US', metro: 'NYC' },
+  LHR: { city: 'London', country: 'United Kingdom', countryCode: 'GB', metro: 'LON' },
+  LIN: { city: 'Milan', country: 'Italy', countryCode: 'IT', metro: 'MIL' },
+  MDW: { city: 'Chicago', country: 'United States', countryCode: 'US', metro: 'CHI' },
+  MIA: { city: 'Miami, FL', country: 'United States', countryCode: 'US' },
+  MSP: { city: 'Minneapolis, MN', country: 'United States', countryCode: 'US' },
+  MXP: { city: 'Milan', country: 'Italy', countryCode: 'IT', metro: 'MIL' },
+  NCE: { city: 'Nice', country: 'France', countryCode: 'FR' },
+  NRT: { city: 'Tokyo', country: 'Japan', countryCode: 'JP', metro: 'TYO' },
+  ORD: { city: 'Chicago', country: 'United States', countryCode: 'US', metro: 'CHI' },
+  ORY: { city: 'Paris', country: 'France', countryCode: 'FR', metro: 'PAR' },
+  PDX: { city: 'Portland, OR', country: 'United States', countryCode: 'US' },
+  PEK: { city: 'Beijing', country: 'China', countryCode: 'CN' },
+  PHX: { city: 'Phoenix, AZ', country: 'United States', countryCode: 'US' },
+  PSP: { city: 'Palm Springs, CA', country: 'United States', countryCode: 'US' },
+  SAN: { city: 'San Diego, CA', country: 'United States', countryCode: 'US' },
+  SEA: { city: 'Seattle, WA', country: 'United States', countryCode: 'US' },
+  SCL: { city: 'Santiago', country: 'Chile', countryCode: 'CL' },
+  SFO: { city: 'San Francisco, CA', country: 'United States', countryCode: 'US' },
+  SRQ: { city: 'Sarasota, FL', country: 'United States', countryCode: 'US' },
+  STN: { city: 'London', country: 'United Kingdom', countryCode: 'GB', metro: 'LON' },
+  SXM: { city: 'Sint Maarten', country: 'Sint Maarten', countryCode: 'SX' },
+  TLL: { city: 'Tallinn', country: 'Estonia', countryCode: 'EE' },
+  TPA: { city: 'Tampa, FL', country: 'United States', countryCode: 'US' },
+  TRN: { city: 'Turin', country: 'Italy', countryCode: 'IT' },
+}
+
+export function resolveAirportCity(code: string): ResolvedAirportCity | null {
+  return AIRPORT_CITIES[code.trim().toUpperCase()] ?? null
+}
+
+export function isSameMetroArea(code1: string, code2: string): boolean {
+  const left = resolveAirportCity(code1)
+  const right = resolveAirportCity(code2)
+  if (!left || !right) return false
+  if (left.metro && right.metro) return left.metro === right.metro
+  return code1.trim().toUpperCase() === code2.trim().toUpperCase()
+}

--- a/src/lib/trips/assignment.ts
+++ b/src/lib/trips/assignment.ts
@@ -175,7 +175,7 @@ export function getPrimaryLocation(items: ExtractedItem[]): string | null {
  * Uses leading articles and hospitality keywords — NOT word count, which incorrectly
  * flags multi-word city names like "New York City", "Salt Lake City", "Mexico City".
  */
-function looksLikeVenueName(name: string): boolean {
+export function looksLikeVenueName(name: string): boolean {
   return (
     /^(The|A|An)\s/i.test(name) ||
     /\b(Hotel|Inn|Hostel|Resort|Suites?|Lodge|Motel|Apartments?|Villas?|Palace|House|Gardens|Manor|Hall|Centre|Center|Venue|Club)\b/i.test(name)
@@ -188,7 +188,7 @@ function looksLikeVenueName(name: string): boolean {
  * "New York JFK" → "New York", "New York (JFK)" → "New York",
  * "New York City, NY" → "New York City", "Tokyo, Japan" → "Tokyo"
  */
-function normaliseToCity(location: string): string {
+export function normaliseToCity(location: string): string {
   let city = location.trim()
 
   // Strip airport codes: parenthesized "(JFK)" style and trailing " JFK" style

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest'
+import type { TripItem } from '@/types/database'
+import { buildTimeline } from './city-segments'
+
+function makeItem(overrides: Partial<TripItem>): TripItem {
+  return {
+    id: crypto.randomUUID(),
+    user_id: 'user-1',
+    trip_id: 'trip-1',
+    kind: 'flight',
+    provider: null,
+    confirmation_code: null,
+    traveler_names: [],
+    start_ts: null,
+    end_ts: null,
+    start_date: '2026-03-09',
+    end_date: '2026-03-09',
+    start_location: null,
+    end_location: null,
+    summary: null,
+    details_json: {},
+    status: 'confirmed',
+    confidence: 1,
+    needs_review: false,
+    loyalty_flag: null,
+    source_email_id: null,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  }
+}
+
+describe('buildTimeline', () => {
+  it('groups connections first, then segments cities from the grouped journeys', () => {
+    const items: TripItem[] = [
+      makeItem({
+        provider: 'Air France',
+        start_date: '2026-03-09',
+        end_date: '2026-03-09',
+        start_ts: '2026-03-09T10:00:00+01:00',
+        end_ts: '2026-03-09T14:30:00-04:00',
+        start_location: 'CDG',
+        end_location: 'MIA',
+        details_json: {
+          departure_airport: 'CDG',
+          arrival_airport: 'MIA',
+          departure_local_time: '10:00',
+          arrival_local_time: '14:30',
+        },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-09',
+        end_date: '2026-03-10',
+        start_location: 'Grand Beach Hotel Surfside, 9449 Collins Avenue, Surfside, Florida 33154',
+        summary: 'Grand Beach Hotel Surfside',
+      }),
+      makeItem({
+        provider: 'United',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_ts: '2026-03-10T11:00:00-04:00',
+        end_ts: '2026-03-10T14:05:00-04:00',
+        start_location: 'MIA',
+        end_location: 'EWR',
+        details_json: {
+          departure_airport: 'MIA',
+          arrival_airport: 'EWR',
+          departure_local_time: '11:00',
+          arrival_local_time: '14:05',
+        },
+      }),
+      makeItem({
+        provider: 'United',
+        start_date: '2026-03-13',
+        end_date: '2026-03-13',
+        start_ts: '2026-03-13T09:00:00-04:00',
+        end_ts: '2026-03-13T12:15:00-05:00',
+        start_location: 'EWR',
+        end_location: 'AUS',
+        details_json: {
+          departure_airport: 'EWR',
+          arrival_airport: 'AUS',
+          departure_local_time: '09:00',
+          arrival_local_time: '12:15',
+        },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-13',
+        end_date: '2026-03-14',
+        start_location: 'Austin, TX',
+        summary: 'The Stephen F Austin Royal Sonesta Hotel',
+      }),
+      makeItem({
+        provider: 'American',
+        start_date: '2026-03-14',
+        end_date: '2026-03-14',
+        start_ts: '2026-03-14T08:00:00-05:00',
+        end_ts: '2026-03-14T09:05:00-05:00',
+        start_location: 'AUS',
+        end_location: 'DFW',
+        details_json: {
+          departure_airport: 'AUS',
+          arrival_airport: 'DFW',
+          departure_local_time: '08:00',
+          arrival_local_time: '09:05',
+        },
+      }),
+      makeItem({
+        provider: 'American',
+        start_date: '2026-03-14',
+        end_date: '2026-03-14',
+        start_ts: '2026-03-14T10:45:00-05:00',
+        end_ts: '2026-03-14T12:35:00-07:00',
+        start_location: 'DFW',
+        end_location: 'PDX',
+        details_json: {
+          departure_airport: 'DFW',
+          arrival_airport: 'PDX',
+          departure_local_time: '10:45',
+          arrival_local_time: '12:35',
+        },
+      }),
+      makeItem({
+        provider: 'Southwest',
+        start_date: '2026-03-20',
+        end_date: '2026-03-20',
+        start_ts: '2026-03-20T07:15:00-07:00',
+        end_ts: '2026-03-20T13:05:00-05:00',
+        start_location: 'PDX',
+        end_location: 'MDW',
+        details_json: {
+          departure_airport: 'PDX',
+          arrival_airport: 'MDW',
+          departure_local_time: '07:15',
+          arrival_local_time: '13:05',
+        },
+      }),
+      makeItem({
+        provider: 'Southwest',
+        start_date: '2026-03-20',
+        end_date: '2026-03-20',
+        start_ts: '2026-03-20T14:40:00-05:00',
+        end_ts: '2026-03-20T17:55:00-04:00',
+        start_location: 'MDW',
+        end_location: 'CHS',
+        details_json: {
+          departure_airport: 'MDW',
+          arrival_airport: 'CHS',
+          departure_local_time: '14:40',
+          arrival_local_time: '17:55',
+        },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-20',
+        end_date: '2026-03-22',
+        start_location: 'The Vendue, Charleston, SC',
+        summary: 'The Vendue',
+      }),
+      makeItem({
+        provider: 'JetBlue',
+        start_date: '2026-03-22',
+        end_date: '2026-03-22',
+        start_ts: '2026-03-22T10:00:00-04:00',
+        end_ts: '2026-03-22T12:15:00-04:00',
+        start_location: 'CHS',
+        end_location: 'JFK',
+        details_json: {
+          departure_airport: 'CHS',
+          arrival_airport: 'JFK',
+          departure_local_time: '10:00',
+          arrival_local_time: '12:15',
+        },
+      }),
+      makeItem({
+        provider: 'Neos',
+        start_date: '2026-03-22',
+        end_date: '2026-03-23',
+        start_ts: '2026-03-22T15:10:00-04:00',
+        end_ts: '2026-03-23T05:45:00+01:00',
+        start_location: 'EWR',
+        end_location: 'MXP',
+        details_json: {
+          departure_airport: 'EWR',
+          arrival_airport: 'MXP',
+          departure_local_time: '15:10',
+          arrival_local_time: '05:45',
+        },
+      }),
+    ]
+
+    const timeline = buildTimeline(items)
+    const transitions = timeline.filter((entry) => entry.type === 'transition')
+    const segments = timeline.filter((entry) => entry.type === 'segment')
+
+    expect(segments).toHaveLength(6)
+    expect(transitions).toHaveLength(6)
+    expect(segments.map((entry) => entry.segment?.city)).toEqual([
+      'Surfside, Florida',
+      'New York',
+      'Austin, TX',
+      'Portland, OR',
+      'Charleston, SC',
+      'Milan',
+    ])
+
+    expect(transitions.map((entry) => entry.nextSegmentCity)).toEqual([
+      'Surfside, Florida',
+      'New York',
+      'Austin, TX',
+      'Portland, OR',
+      'Charleston, SC',
+      'Milan',
+    ])
+
+    expect(timeline.some((entry) => entry.type === 'segment' && entry.segment?.city.includes('Paris'))).toBe(false)
+    expect(timeline.some((entry) => entry.type === 'segment' && entry.segment?.city.includes('DFW'))).toBe(false)
+    expect(timeline.some((entry) => entry.type === 'segment' && entry.segment?.city.includes('MDW'))).toBe(false)
+    expect(timeline.some((entry) => entry.type === 'segment' && entry.segment?.city.includes('JFK'))).toBe(false)
+
+    expect(transitions[3].transition?.departure.code).toBe('AUS')
+    expect(transitions[3].transition?.arrival.code).toBe('PDX')
+    expect(transitions[3].transition?.stopCodes).toEqual(['DFW'])
+
+    expect(transitions[5].transition?.departure.code).toBe('CHS')
+    expect(transitions[5].transition?.arrival.code).toBe('MXP')
+    expect(transitions[5].transition?.stopCodes).toEqual(['JFK', 'EWR'])
+
+    expect(segments[0].segment?.city).not.toContain('Grand Beach Hotel Surfside')
+    expect(segments[2].segment?.city).toContain('Austin')
+    expect(segments[2].segment?.city).not.toContain('Stephen F Austin')
+    expect(segments[5].segment?.durationNights).toBe(0)
+  })
+})

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -1,0 +1,369 @@
+import type { TripItem, Json } from '@/types/database'
+import type { WeatherDestination } from '@/lib/weather/types'
+import { getWeatherForDate, weatherCodeToEmoji, type TimelineWeatherDay } from '@/lib/weather/item-weather'
+import { looksLikeVenueName, normaliseToCity } from './assignment'
+import { isSameMetroArea, resolveAirportCity } from './airport-cities'
+
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000
+const DAY_MS = 24 * 60 * 60 * 1000
+
+interface AirportPoint {
+  code: string
+  city: string
+  time: string
+}
+
+export interface FlightJourney {
+  type: 'flight-journey'
+  departure: AirportPoint
+  arrival: AirportPoint
+  stops: number
+  stopCodes: string[]
+  legs: TripItem[]
+  date: string
+  duration?: string
+}
+
+export interface CitySegment {
+  city: string
+  countryCode?: string
+  startDate: string
+  endDate: string
+  durationNights: number
+  anchorType: 'hotel' | 'airport' | 'activity'
+  items: TripItem[]
+  weather?: {
+    daily: TimelineWeatherDay[]
+  }
+}
+
+export interface TimelineEntry {
+  type: 'transition' | 'segment'
+  transition?: FlightJourney
+  segment?: CitySegment
+  nextSegmentCity?: string
+}
+
+interface RawSegment {
+  incoming: FlightJourney | null
+  outgoing: FlightJourney | null
+  items: TripItem[]
+}
+
+function isFlightJourney(entry: TripItem | FlightJourney): entry is FlightJourney {
+  return 'type' in entry && entry.type === 'flight-journey'
+}
+
+function readString(details: Json, key: string): string | null {
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return null
+  const value = (details as Record<string, unknown>)[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function extractAirportCode(value: string | null | undefined): string | null {
+  if (!value) return null
+  const match = value.trim().toUpperCase().match(/\b([A-Z]{3})\b/)
+  return match?.[1] ?? null
+}
+
+function resolveAirportPoint(item: TripItem, edge: 'departure' | 'arrival'): AirportPoint {
+  const code =
+    extractAirportCode(readString(item.details_json, edge === 'departure' ? 'departure_airport' : 'arrival_airport')) ??
+    extractAirportCode(edge === 'departure' ? item.start_location : item.end_location) ??
+    'UNK'
+  const airport = resolveAirportCity(code)
+  return {
+    code,
+    city: airport?.city ?? (edge === 'departure' ? item.start_location : item.end_location) ?? code,
+    time: readString(item.details_json, edge === 'departure' ? 'departure_local_time' : 'arrival_local_time') ?? '',
+  }
+}
+
+function parseItemDateTime(item: TripItem, edge: 'start' | 'end'): Date | null {
+  const timestamp = edge === 'start' ? item.start_ts : item.end_ts
+  if (timestamp) {
+    const parsed = new Date(timestamp)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+
+  const date = edge === 'start' ? item.start_date : item.end_date ?? item.start_date
+  if (!date) return null
+  const time =
+    readString(item.details_json, edge === 'start' ? 'departure_local_time' : 'arrival_local_time') ??
+    (edge === 'start' ? '00:00' : '23:59')
+  const normalizedTime = /^\d{1,2}:\d{2}$/.test(time) ? time.padStart(5, '0') : edge === 'start' ? '00:00' : '23:59'
+  const parsed = new Date(`${date}T${normalizedTime}:00`)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function formatDuration(ms: number): string | undefined {
+  if (!Number.isFinite(ms) || ms <= 0) return undefined
+  const totalMinutes = Math.round(ms / 60000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+  if (hours > 0) return `${hours}h`
+  return `${minutes}m`
+}
+
+function buildStopCodes(legs: TripItem[]): string[] {
+  const stops: string[] = []
+  for (let index = 0; index < legs.length - 1; index += 1) {
+    const arrivalCode = resolveAirportPoint(legs[index], 'arrival').code
+    const nextDepartureCode = resolveAirportPoint(legs[index + 1], 'departure').code
+    if (!stops.includes(arrivalCode)) stops.push(arrivalCode)
+    if (nextDepartureCode !== arrivalCode && !stops.includes(nextDepartureCode)) {
+      stops.push(nextDepartureCode)
+    }
+  }
+  return stops
+}
+
+function isConnection(current: TripItem, next: TripItem): boolean {
+  if (current.kind !== 'flight' || next.kind !== 'flight') return false
+  const currentArrival = resolveAirportPoint(current, 'arrival').code
+  const nextDeparture = resolveAirportPoint(next, 'departure').code
+  if (currentArrival !== nextDeparture && !isSameMetroArea(currentArrival, nextDeparture)) return false
+
+  const currentArrivalTime = parseItemDateTime(current, 'end')
+  const nextDepartureTime = parseItemDateTime(next, 'start')
+  if (!currentArrivalTime || !nextDepartureTime) return false
+
+  const layoverMs = nextDepartureTime.getTime() - currentArrivalTime.getTime()
+  return layoverMs >= 0 && layoverMs < FOUR_HOURS_MS
+}
+
+function sortItems(items: TripItem[]): TripItem[] {
+  return [...items].sort((left, right) => {
+    if (left.start_date !== right.start_date) {
+      return left.start_date.localeCompare(right.start_date)
+    }
+    if (left.start_ts && right.start_ts) {
+      return (parseItemDateTime(left, 'start')?.getTime() ?? 0) - (parseItemDateTime(right, 'start')?.getTime() ?? 0)
+    }
+    if (left.start_ts) return -1
+    if (right.start_ts) return 1
+    const leftTime = parseItemDateTime(left, 'start')?.getTime() ?? 0
+    const rightTime = parseItemDateTime(right, 'start')?.getTime() ?? 0
+    return leftTime - rightTime
+  })
+}
+
+function firstPass(items: TripItem[]): Array<TripItem | FlightJourney> {
+  const ordered = sortItems(items)
+  const processed: Array<TripItem | FlightJourney> = []
+
+  for (let index = 0; index < ordered.length; index += 1) {
+    const item = ordered[index]
+    if (item.kind !== 'flight') {
+      processed.push(item)
+      continue
+    }
+
+    const legs = [item]
+    while (index + 1 < ordered.length && ordered[index + 1].kind === 'flight' && isConnection(legs[legs.length - 1], ordered[index + 1])) {
+      legs.push(ordered[index + 1])
+      index += 1
+    }
+
+    const departure = resolveAirportPoint(legs[0], 'departure')
+    const arrival = resolveAirportPoint(legs[legs.length - 1], 'arrival')
+    const startTime = parseItemDateTime(legs[0], 'start')?.getTime() ?? 0
+    const endTime = parseItemDateTime(legs[legs.length - 1], 'end')?.getTime() ?? startTime
+    const stopCodes = buildStopCodes(legs)
+
+    processed.push({
+      type: 'flight-journey',
+      departure,
+      arrival,
+      stops: stopCodes.length,
+      stopCodes,
+      legs,
+      date: legs[0].start_date,
+      duration: formatDuration(endTime - startTime),
+    })
+  }
+
+  return processed
+}
+
+function looksLikeStreetAddress(value: string): boolean {
+  return /^\d+\s/.test(value) || /\b(avenue|street|road|drive|blvd|lane|way)\b/i.test(value)
+}
+
+function cleanLocationPart(value: string): string {
+  return value.replace(/\b\d{5}(?:-\d{4})?\b/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function deriveDisplayLocation(location: string): string | null {
+  const parts = location
+    .split(',')
+    .map((part) => cleanLocationPart(part))
+    .filter(Boolean)
+  if (parts.length === 0) return null
+
+  let index = 0
+  while (index < parts.length && (looksLikeVenueName(parts[index]) || looksLikeStreetAddress(parts[index]))) {
+    index += 1
+  }
+  if (index >= parts.length) return null
+
+  const city = normaliseToCity(parts[index])
+  const region = parts[index + 1]
+  return region && region.length <= 24 ? `${city}, ${region}` : city
+}
+
+function deriveSegmentIdentity(raw: RawSegment): Pick<CitySegment, 'city' | 'countryCode' | 'anchorType'> {
+  const hotel = raw.items.find((item) => item.kind === 'hotel')
+  if (hotel) {
+    const hotelLocation = hotel.start_location ?? hotel.end_location
+    const label = hotelLocation ? deriveDisplayLocation(hotelLocation) : null
+    if (label && !looksLikeVenueName(label)) {
+      return { city: label, countryCode: undefined, anchorType: 'hotel' }
+    }
+  }
+
+  const activity = raw.items.find((item) => item.kind !== 'hotel')
+  if (activity) {
+    const activityLocation = activity.end_location ?? activity.start_location
+    const label = activityLocation ? deriveDisplayLocation(activityLocation) : null
+    if (label) return { city: label, countryCode: undefined, anchorType: 'activity' }
+  }
+
+  const airport = raw.incoming ? resolveAirportCity(raw.incoming.arrival.code) : null
+  if (airport) {
+    return { city: airport.city, countryCode: airport.countryCode, anchorType: 'airport' }
+  }
+
+  const fallback = hotel?.start_location ?? activity?.end_location ?? activity?.start_location ?? 'Unknown'
+  return {
+    city: normaliseToCity(fallback),
+    countryCode: undefined,
+    anchorType: hotel ? 'hotel' : 'activity',
+  }
+}
+
+function nightsBetween(startDate: string, endDate: string): number {
+  const start = new Date(`${startDate}T00:00:00`)
+  const end = new Date(`${endDate}T00:00:00`)
+  const diff = Math.round((end.getTime() - start.getTime()) / DAY_MS)
+  return Math.max(0, diff)
+}
+
+function buildSegment(raw: RawSegment): CitySegment {
+  const startDate =
+    raw.items[0]?.start_date ??
+    raw.incoming?.legs[raw.incoming.legs.length - 1]?.end_date ??
+    raw.incoming?.date ??
+    raw.outgoing?.date ??
+    ''
+  const endDate =
+    raw.outgoing?.date ??
+    raw.items[raw.items.length - 1]?.end_date ??
+    raw.items[raw.items.length - 1]?.start_date ??
+    raw.incoming?.legs[raw.incoming.legs.length - 1]?.end_date ??
+    startDate
+  const identity = deriveSegmentIdentity(raw)
+
+  return {
+    city: identity.city,
+    countryCode: identity.countryCode,
+    startDate,
+    endDate,
+    durationNights: nightsBetween(startDate, endDate),
+    anchorType: identity.anchorType,
+    items: raw.items,
+  }
+}
+
+function cityKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function matchesWeatherCity(segmentCity: string, weatherCity: string): boolean {
+  const left = cityKey(segmentCity)
+  const right = cityKey(weatherCity)
+  return left === right || left.startsWith(right) || right.startsWith(left)
+}
+
+export function attachWeatherToTimeline(entries: TimelineEntry[], destinations: WeatherDestination[]): TimelineEntry[] {
+  return entries.map((entry) => {
+    if (entry.type !== 'segment' || !entry.segment) return entry
+    const destination = destinations.find((candidate) => matchesWeatherCity(entry.segment!.city, candidate.city))
+    if (!destination) return entry
+
+    return {
+      ...entry,
+      segment: {
+        ...entry.segment,
+        weather: {
+          daily: destination.daily.map((day) => ({
+            date: day.date,
+            emoji: weatherCodeToEmoji(day.weather_code),
+            high: day.temp_high,
+            low: day.temp_low,
+          })),
+        },
+      },
+    }
+  })
+}
+
+export function weatherForItem(segment: CitySegment, item: TripItem): TimelineWeatherDay | null {
+  return getWeatherForDate(segment.weather?.daily, item.start_date)
+}
+
+export function buildTimeline(items: TripItem[]): TimelineEntry[] {
+  const processed = firstPass(items)
+  const rawSegments: RawSegment[] = []
+  const transitions: FlightJourney[] = []
+  let incoming: FlightJourney | null = null
+  let currentItems: TripItem[] = []
+
+  for (const entry of processed) {
+    if (isFlightJourney(entry)) {
+      if (incoming || currentItems.length > 0) {
+        rawSegments.push({ incoming, outgoing: entry, items: currentItems })
+      }
+      transitions.push(entry)
+      incoming = entry
+      currentItems = []
+      continue
+    }
+
+    currentItems.push(entry)
+  }
+
+  if (incoming || currentItems.length > 0) {
+    rawSegments.push({ incoming, outgoing: null, items: currentItems })
+  }
+
+  const segments = rawSegments.map(buildSegment)
+  const timeline: TimelineEntry[] = []
+  let segmentIndex = 0
+
+  for (const transition of transitions) {
+    const nextSegment =
+      segments[segmentIndex] && rawSegments[segmentIndex]?.incoming === transition
+        ? segments[segmentIndex]
+        : null
+
+    timeline.push({
+      type: 'transition',
+      transition,
+      nextSegmentCity: nextSegment?.city ?? resolveAirportCity(transition.arrival.code)?.city ?? transition.arrival.city,
+    })
+
+    if (nextSegment) {
+      timeline.push({ type: 'segment', segment: nextSegment })
+      segmentIndex += 1
+    }
+  }
+
+  while (segmentIndex < segments.length) {
+    timeline.push({ type: 'segment', segment: segments[segmentIndex] })
+    segmentIndex += 1
+  }
+
+  return timeline
+}

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -252,8 +252,8 @@ function nightsBetween(startDate: string, endDate: string): number {
 
 function buildSegment(raw: RawSegment): CitySegment {
   const startDate =
-    raw.items[0]?.start_date ??
     raw.incoming?.legs[raw.incoming.legs.length - 1]?.end_date ??
+    raw.items[0]?.start_date ??
     raw.incoming?.date ??
     raw.outgoing?.date ??
     ''

--- a/src/lib/weather/item-weather.ts
+++ b/src/lib/weather/item-weather.ts
@@ -1,0 +1,20 @@
+import { getWeatherIcon } from './weather-icons'
+
+export interface TimelineWeatherDay {
+  date: string
+  emoji: string
+  high: number
+  low: number
+}
+
+export function weatherCodeToEmoji(code: number): string {
+  return getWeatherIcon(code)
+}
+
+export function getWeatherForDate<T extends { date: string }>(
+  days: T[] | undefined,
+  date: string | null | undefined
+): T | null {
+  if (!days || !date) return null
+  return days.find((day) => day.date === date) ?? null
+}


### PR DESCRIPTION
Redesign after v1 rollback. Two-pass algorithm (Gemini 3.1 design):

**Pass 1:** Group connecting flights into journeys (AUS→DFW→PDX = 1 stop)
**Pass 2:** Segment by city — hotels as anchors, airports as fallback

Fixes all v1 bugs:
- ✅ Hotel addresses no longer shown as flight destinations
- ✅ Hotel names stripped to city names (not 'Stephen F Austin Royal Sonesta')
- ✅ Connection airports grouped (DFW, MDW, JFK not shown as destinations)
- ✅ Transition labels from next segment city ('Flight to Portland' only for PDX flights)
- ✅ Flight 'More Info' expansion preserved
- ✅ Departure city not shown as segment
- ✅ Weather attached to city segments
- ✅ Share page uses same MovementTimeline

114 tests pass, build clean.