### PR TITLE
fix: live terminal/gate overrides stale booking data

### DIFF
--- a/src/components/trips/item-details/flight-details.tsx
+++ b/src/components/trips/item-details/flight-details.tsx
@@ -6,11 +6,19 @@ import { Plane, MapPin, Clock, Armchair } from 'lucide-react'
 import type { FlightDetails } from '@/types/database'
 import { getProviderLogoUrl } from '@/lib/images/provider-logo'
 
-interface FlightDetailsViewProps {
-  details: FlightDetails
+interface LiveOverrides {
+  departure_terminal?: string | null
+  departure_gate?: string | null
+  arrival_terminal?: string | null
+  arrival_gate?: string | null
 }
 
-export function FlightDetailsView({ details }: FlightDetailsViewProps) {
+interface FlightDetailsViewProps {
+  details: FlightDetails
+  liveOverrides?: LiveOverrides
+}
+
+export function FlightDetailsView({ details, liveOverrides }: FlightDetailsViewProps) {
   const [logoError, setLogoError] = useState(false)
 
   const {
@@ -18,13 +26,19 @@ export function FlightDetailsView({ details }: FlightDetailsViewProps) {
     airline,
     departure_airport,
     arrival_airport,
-    departure_terminal,
-    arrival_terminal,
-    departure_gate,
-    arrival_gate,
+    departure_terminal: booking_departure_terminal,
+    arrival_terminal: booking_arrival_terminal,
+    departure_gate: booking_departure_gate,
+    arrival_gate: booking_arrival_gate,
     cabin_class,
     seat,
   } = details
+
+  // Live data (FlightAware) overrides stale booking data
+  const departure_terminal = liveOverrides?.departure_terminal ?? booking_departure_terminal
+  const departure_gate = liveOverrides?.departure_gate ?? booking_departure_gate
+  const arrival_terminal = liveOverrides?.arrival_terminal ?? booking_arrival_terminal
+  const arrival_gate = liveOverrides?.arrival_gate ?? booking_arrival_gate
 
   const flightCode = flight_number
     ? airline

--- a/src/components/trips/item-status-badge.tsx
+++ b/src/components/trips/item-status-badge.tsx
@@ -18,7 +18,7 @@ type LiveStatus =
   | 'arrived'
   | 'unknown'
 
-interface StatusPayload {
+export interface StatusPayload {
   status: LiveStatus
   delay_minutes: number | null
   gate: string | null
@@ -32,6 +32,8 @@ interface ItemStatusBadgeProps {
   itemId: string
   /** The departure time shown on the card (from booking data), e.g. "10:40" */
   scheduledDeparture?: string | null
+  /** Called when live status data is fetched, so parent can pass terminal/gate to details */
+  onStatusUpdate?: (payload: StatusPayload) => void
 }
 
 const STATUS_META: Record<LiveStatus, { label: string; toneClass: string }> = {
@@ -89,7 +91,7 @@ function renderLastChecked(iso: string | null): string {
   return `Last checked ${formatDistanceToNow(checked, { addSuffix: true })}`
 }
 
-export function ItemStatusBadge({ itemId, scheduledDeparture }: ItemStatusBadgeProps) {
+export function ItemStatusBadge({ itemId, scheduledDeparture, onStatusUpdate }: ItemStatusBadgeProps) {
   const [status, setStatus] = useState<StatusPayload | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -126,6 +128,10 @@ export function ItemStatusBadge({ itemId, scheduledDeparture }: ItemStatusBadgeP
   useEffect(() => {
     void loadStatus()
   }, [loadStatus])
+
+  useEffect(() => {
+    if (status && onStatusUpdate) onStatusUpdate(status)
+  }, [status, onStatusUpdate])
 
   useEffect(() => {
     const timer = setInterval(() => {

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -48,7 +48,7 @@ import {
   TicketDetailsView,
   GenericDetailsView,
 } from './item-details'
-import { ItemStatusBadge } from './item-status-badge'
+import { ItemStatusBadge, type StatusPayload } from './item-status-badge'
 
 interface TripItemCardProps {
   item: TripItem
@@ -138,6 +138,7 @@ function isWithin48Hours(item: { start_ts?: string | null; start_date?: string |
 export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProps) {
   const router = useRouter()
   const [expanded, setExpanded] = useState(false)
+  const [liveStatus, setLiveStatus] = useState<StatusPayload | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [moveOpen, setMoveOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -357,6 +358,7 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
                   scheduledDeparture={
                     typeof details?.departure_local_time === 'string' ? details.departure_local_time : undefined
                   }
+                  onStatusUpdate={setLiveStatus}
                 />
               )}
 
@@ -449,7 +451,13 @@ export function TripItemCard({ item, allTrips, currentUserId }: TripItemCardProp
               {expanded && (
                 <div className="mt-3">
                   {item.kind === 'flight' && (
-                    <FlightDetailsView details={details as FlightDetails} />
+                    <FlightDetailsView
+                      details={details as FlightDetails}
+                      liveOverrides={liveStatus ? {
+                        departure_terminal: liveStatus.terminal,
+                        departure_gate: liveStatus.gate,
+                      } : undefined}
+                    />
                   )}
                   {item.kind === 'hotel' && (
                     <HotelDetailsView details={details as HotelDetails} />


### PR DESCRIPTION
Flight details showed Terminal 2C (from booking email) while FlightAware had Terminal 2A (correct, confirmed by boarding pass).

Fix: StatusBadge passes live terminal/gate up via callback → TripItemCard forwards to FlightDetailsView as liveOverrides → live data wins.

Build clean, tests pass.