### PR TITLE
fix: flight status uses gate departure, not takeoff time

### DIFF
--- a/src/components/trips/item-status-badge.tsx
+++ b/src/components/trips/item-status-badge.tsx
@@ -32,6 +32,8 @@ interface ItemStatusBadgeProps {
   itemId: string
   /** The departure time shown on the card (from booking data), e.g. "10:40" */
   scheduledDeparture?: string | null
+  /** The item's start_ts in UTC (ISO string), used to derive local timezone offset */
+  startTs?: string | null
   /** Called when live status data is fetched, so parent can pass terminal/gate to details */
   onStatusUpdate?: (payload: StatusPayload) => void
 }
@@ -91,7 +93,36 @@ function renderLastChecked(iso: string | null): string {
   return `Last checked ${formatDistanceToNow(checked, { addSuffix: true })}`
 }
 
-export function ItemStatusBadge({ itemId, scheduledDeparture, onStatusUpdate }: ItemStatusBadgeProps) {
+/**
+ * Derive the UTC offset (in ms) of the departure airport from the booking's
+ * local time and UTC timestamp.  e.g. local 10:40 + UTC 09:40 → +1h (CET).
+ */
+function deriveOffsetMs(localTime: string | null | undefined, utcIso: string | null | undefined): number | null {
+  if (!localTime || !utcIso) return null
+  const m = localTime.match(/^(\d{1,2}):(\d{2})$/)
+  if (!m) return null
+  const localMinutes = parseInt(m[1], 10) * 60 + parseInt(m[2], 10)
+  const utcDate = new Date(utcIso)
+  if (Number.isNaN(utcDate.getTime())) return null
+  const utcMinutes = utcDate.getUTCHours() * 60 + utcDate.getUTCMinutes()
+  // Handle day boundary (e.g. local 01:00, UTC 23:00 → +2h)
+  let diff = localMinutes - utcMinutes
+  if (diff < -720) diff += 1440
+  if (diff > 720) diff -= 1440
+  return diff * 60_000
+}
+
+/** Convert a UTC ISO timestamp to local HH:MM using a known offset. */
+function toLocalTime(utcIso: string, offsetMs: number): string {
+  const d = new Date(utcIso)
+  if (Number.isNaN(d.getTime())) return formatTime(utcIso)
+  const local = new Date(d.getTime() + offsetMs)
+  const h = local.getUTCHours()
+  const m = local.getUTCMinutes().toString().padStart(2, '0')
+  return `${h}:${m}`
+}
+
+export function ItemStatusBadge({ itemId, scheduledDeparture, startTs, onStatusUpdate }: ItemStatusBadgeProps) {
   const [status, setStatus] = useState<StatusPayload | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -152,7 +183,10 @@ export function ItemStatusBadge({ itemId, scheduledDeparture, onStatusUpdate }: 
   const effective = status
 
   const baseLabel = STATUS_META[effective.status].label
-  const estimatedTime = effective.estimated_departure ? formatTime(effective.estimated_departure) : null
+  const offsetMs = deriveOffsetMs(scheduledDeparture, startTs)
+  const estimatedTime = effective.estimated_departure
+    ? (offsetMs !== null ? toLocalTime(effective.estimated_departure, offsetMs) : formatTime(effective.estimated_departure))
+    : null
 
   let heading: string
   if (effective.status === 'delayed' && (effective.delay_minutes ?? 0) > 0) {

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -363,6 +363,7 @@ export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, 
                   scheduledDeparture={
                     typeof details?.departure_local_time === 'string' ? details.departure_local_time : undefined
                   }
+                  startTs={item.start_ts}
                   onStatusUpdate={setLiveStatus}
                 />
               )}

--- a/src/lib/flight-status.ts
+++ b/src/lib/flight-status.ts
@@ -92,6 +92,15 @@ function calculateDelayMinutes(flight: Record<string, unknown>): number | null {
     return Math.max(0, Math.round(departureDelaySeconds / 60))
   }
 
+  // Prefer gate times (out) over takeoff times (off) for delay calculation
+  // — passengers care about when they leave the gate, not wheels-up
+  const scheduledOut = toIsoOrNull(flight.scheduled_out)
+  const estimatedOut = toIsoOrNull(flight.estimated_out)
+  if (scheduledOut && estimatedOut) {
+    const diff = diffMinutes(scheduledOut, estimatedOut)
+    if (diff !== null) return diff
+  }
+
   const scheduledOff = toIsoOrNull(flight.scheduled_off)
   const estimatedOff = toIsoOrNull(flight.estimated_off)
   if (scheduledOff && estimatedOff) {
@@ -278,7 +287,10 @@ export async function getFlightStatus(ident: string, date: string): Promise<Flig
       delayMinutes,
       gate: asString(first.gate_origin) ?? null,
       terminal: asString(first.terminal_origin) ?? null,
-      estimatedDeparture: toIsoOrNull(first.estimated_off),
+      // Prefer estimated_out (gate departure — what passengers see) over
+      // estimated_off (wheels-up takeoff time). The booking email shows gate
+      // departure, so the live update should match.
+      estimatedDeparture: toIsoOrNull(first.estimated_out) ?? toIsoOrNull(first.estimated_off),
       estimatedArrival: toIsoOrNull(first.estimated_on),
       actualDeparture: toIsoOrNull(first.actual_off),
       actualArrival: toIsoOrNull(first.actual_on),


### PR DESCRIPTION
Two bugs:

1. **Wrong time source**: Showed `estimated_off` (takeoff/wheels-up) instead of `estimated_out` (gate departure). Gate departure was on time at 10:40 CET, but takeoff was 16 min late — so badge showed 'Delayed' on an on-time departure.

2. **Timezone mismatch**: FlightAware times are UTC. Badge extracted raw HH:MM without converting. Added timezone conversion using the booking's known local time + UTC timestamp to derive offset.

For AA 063 CDG→MIA: `departure_delay=0`, `estimated_out=09:40Z` (10:40 CET, on time), but `estimated_off=10:06Z` (11:06 CET, 16 min late takeoff). We were showing the wrong one.