### PR TITLE
perf: parallelize weather fetches — 30s → ~3s page load

### DIFF
--- a/src/lib/weather/service.ts
+++ b/src/lib/weather/service.ts
@@ -188,33 +188,40 @@ export async function buildWeatherPayload(params: {
     }
   }
 
-  const destinations: WeatherDestination[] = []
-  for (const city of cities) {
-    const geocoded = await geocodeCity(city.query)
-    if (!geocoded) continue
+  // Fetch all cities in parallel — sequential was causing 30s+ page loads
+  const results = await Promise.allSettled(
+    cities.map(async (city) => {
+      const geocoded = await geocodeCity(city.query)
+      if (!geocoded) return null
 
-    const daily = await fetchForecast({
-      latitude: geocoded.latitude,
-      longitude: geocoded.longitude,
-      unit: params.unit,
-      dateStart: city.dateStart,
-      dateEnd: city.dateEnd,
+      const daily = await fetchForecast({
+        latitude: geocoded.latitude,
+        longitude: geocoded.longitude,
+        unit: params.unit,
+        dateStart: city.dateStart,
+        dateEnd: city.dateEnd,
+      })
+
+      if (daily.length === 0) return null
+
+      return {
+        city: city.city,
+        latitude: geocoded.latitude,
+        longitude: geocoded.longitude,
+        dates: {
+          start: city.dateStart,
+          end: city.dateEnd,
+        },
+        source: 'forecast' as const,
+        daily,
+      }
     })
+  )
 
-    if (daily.length === 0) continue
-
-    destinations.push({
-      city: city.city,
-      latitude: geocoded.latitude,
-      longitude: geocoded.longitude,
-      dates: {
-        start: city.dateStart,
-        end: city.dateEnd,
-      },
-      source: 'forecast',
-      daily,
-    })
-  }
+  const destinations: WeatherDestination[] = results
+    .filter((r): r is PromiseFulfilledResult<WeatherDestination | null> => r.status === 'fulfilled')
+    .map((r) => r.value)
+    .filter((d): d is WeatherDestination => d !== null)
 
   if (destinations.length === 0) {
     return {


### PR DESCRIPTION
Weather was fetching geocode + forecast sequentially for each city (9 cities × 2 HTTP requests × ~2s each = 36s). Now all cities fetch in parallel with Promise.allSettled.

Build clean, tests pass.