### PR TITLE
fix: email input cropped by label field on mobile

### DIFF
--- a/src/components/settings/add-sender-form.tsx
+++ b/src/components/settings/add-sender-form.tsx
@@ -77,8 +77,8 @@ export function AddSenderForm() {
         </div>
       )}
 
-      <div className="flex gap-3">
-        <div className="flex-1">
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex-[2] min-w-0">
           <Input
             type="email"
             placeholder="your.email@example.com"
@@ -87,18 +87,20 @@ export function AddSenderForm() {
             required
           />
         </div>
-        <div className="w-40">
-          <Input
-            type="text"
-            placeholder="Label (optional)"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-          />
+        <div className="flex gap-3">
+          <div className="flex-1 sm:w-40 sm:flex-none">
+            <Input
+              type="text"
+              placeholder="Label (optional)"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="shrink-0">
+            <Plus className="mr-2 h-4 w-4" />
+            {loading ? 'Adding...' : 'Add'}
+          </Button>
         </div>
-        <Button type="submit" disabled={loading}>
-          <Plus className="mr-2 h-4 w-4" />
-          {loading ? 'Adding...' : 'Add'}
-        </Button>
       </div>
 
       <p className="text-xs text-gray-500">


### PR DESCRIPTION
**Bug:** On mobile, the email input field was squeezed to ~4 characters by the fixed-width label field and Add button all sharing one flex row.

**Fix:** Stack vertically on mobile (`flex-col`), horizontal on `sm+`. Email field gets `flex-[2]` priority with `min-w-0` to prevent overflow. Label and button grouped together on the second row on mobile.

Feedback from a user.