### PR TITLE
fix: force Google account picker on login

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -62,6 +62,9 @@ function LoginContent() {
       provider: 'google',
       options: {
         redirectTo: buildOAuthCallbackUrl(window.location.origin, redirectPath),
+        queryParams: {
+          prompt: 'select_account',
+        },
       },
     })
 

--- a/src/app/invite/[token]/accept-button.tsx
+++ b/src/app/invite/[token]/accept-button.tsx
@@ -58,6 +58,7 @@ export function AcceptInviteButton({
       options: {
         redirectTo: buildOAuthCallbackUrl(window.location.origin, redirectTo),
         queryParams: {
+          prompt: 'select_account',
           login_hint: invitedEmail,
         },
       },


### PR DESCRIPTION
**Bug:** After logging in with the wrong Google account and signing out, clicking 'Sign in with Google' auto-selects the previous account with no chance to switch.

**Fix:** Add `prompt: 'select_account'` to the Google OAuth `queryParams`. This forces Google to show the account picker every time, even if there's an existing Google session.

Applied to both the main login page and the invite accept flow.