### PR TITLE
fix: weather only on City Stay cards

### DIFF
--- a/src/components/trips/city-segment-block.tsx
+++ b/src/components/trips/city-segment-block.tsx
@@ -3,7 +3,7 @@
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { formatDate, formatDateRange } from '@/lib/utils'
-import { weatherForItem, type CitySegment } from '@/lib/trips/city-segments'
+import type { CitySegment } from '@/lib/trips/city-segments'
 import type { Trip } from '@/types/database'
 import { TripItemCard } from './trip-item-card'
 
@@ -66,25 +66,15 @@ export function CitySegmentBlock({
           ) : null}
 
           <div className="space-y-3">
-            {segment.items.map((item) => {
-              const itemWeather = weatherForItem(segment, item)
-              return (
+            {segment.items.map((item) => (
                 <TripItemCard
                   key={item.id}
                   item={item}
                   allTrips={allTrips}
                   currentUserId={currentUserId}
                   readOnly={readOnly}
-                  metaChips={
-                    itemWeather ? (
-                      <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
-                        {itemWeather.emoji} {Math.round(itemWeather.high)}° / {Math.round(itemWeather.low)}°
-                      </span>
-                    ) : null
-                  }
                 />
-              )
-            })}
+            ))}
           </div>
         </div>
       </CardContent>

--- a/src/components/trips/movement-timeline.tsx
+++ b/src/components/trips/movement-timeline.tsx
@@ -2,7 +2,7 @@
 
 import type { Trip } from '@/types/database'
 import type { TimelineEntry } from '@/lib/trips/city-segments'
-import { getWeatherForDate } from '@/lib/weather/item-weather'
+
 import { CitySegmentBlock } from './city-segment-block'
 import { TransitionCard } from './transition-card'
 
@@ -26,13 +26,11 @@ export function MovementTimeline({
       {entries.map((entry, index) => {
         if (entry.type === 'transition' && entry.transition) {
           const nextSegment = entries.slice(index + 1).find((candidate) => candidate.type === 'segment')?.segment
-          const weather = nextSegment ? getWeatherForDate(nextSegment.weather?.daily, nextSegment.startDate) : null
           return (
             <TransitionCard
               key={`${entry.transition.date}-${entry.transition.departure.code}-${entry.transition.arrival.code}-${index}`}
               journey={entry.transition}
               nextSegmentCity={entry.nextSegmentCity ?? nextSegment?.city ?? entry.transition.arrival.city}
-              weather={weather}
               allTrips={allTrips}
               currentUserId={currentUserId}
               readOnly={readOnly}

--- a/src/components/trips/transition-card.tsx
+++ b/src/components/trips/transition-card.tsx
@@ -5,13 +5,12 @@ import { ChevronDown, ChevronUp, Clock, Plane } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import type { Trip } from '@/types/database'
 import type { FlightJourney } from '@/lib/trips/city-segments'
-import type { TimelineWeatherDay } from '@/lib/weather/item-weather'
+
 import { TripItemCard } from './trip-item-card'
 
 interface TransitionCardProps {
   journey: FlightJourney
   nextSegmentCity: string
-  weather?: TimelineWeatherDay | null
   allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
   currentUserId?: string
   readOnly?: boolean
@@ -26,7 +25,6 @@ function stopLabel(journey: FlightJourney) {
 export function TransitionCard({
   journey,
   nextSegmentCity,
-  weather,
   allTrips,
   currentUserId,
   readOnly = false,
@@ -62,11 +60,6 @@ export function TransitionCard({
             </div>
           </div>
 
-          {weather ? (
-            <div className="rounded-full bg-white px-3 py-1 text-sm font-medium text-slate-700 shadow-sm">
-              {weather.emoji} {Math.round(weather.high)}° / {Math.round(weather.low)}°
-            </div>
-          ) : null}
         </div>
 
         <button

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -1,6 +1,6 @@
 import type { TripItem, Json } from '@/types/database'
 import type { WeatherDestination } from '@/lib/weather/types'
-import { getWeatherForDate, weatherCodeToEmoji, type TimelineWeatherDay } from '@/lib/weather/item-weather'
+import { weatherCodeToEmoji, type TimelineWeatherDay } from '@/lib/weather/item-weather'
 import { looksLikeVenueName, normaliseToCity } from './assignment'
 import { isSameMetroArea, resolveAirportCity } from './airport-cities'
 
@@ -329,10 +329,6 @@ export function attachWeatherToTimeline(entries: TimelineEntry[], destinations: 
       },
     }
   })
-}
-
-export function weatherForItem(segment: CitySegment, item: TripItem): TimelineWeatherDay | null {
-  return getWeatherForDate(segment.weather?.daily, item.start_date)
 }
 
 export function buildTimeline(items: TripItem[]): TimelineEntry[] {


### PR DESCRIPTION
Weather was appearing on transition cards (flights), hotel cards, AND city stay headers. Now it only appears on City Stay headers and the weather section at the bottom.

Removes weather prop from TransitionCard and metaChips from TripItemCard inside CitySegmentBlock.