### PR TITLE
perf: parallelize trip page queries for faster load

### DIFF
--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -54,46 +54,53 @@ export default async function TripPage({ params }: TripPageProps) {
     }
   }
 
-  const { data: items } = await supabase
-    .from('trip_items')
-    .select('*')
-    .eq('trip_id', id)
-    .order('start_date', { ascending: true })
-    .order('start_ts', { ascending: true })
-
-  // Get all user's trips for move item dialog
-  const { data: allTrips } = user
-    ? await supabase
-        .from('trips')
-        .select('id, title, start_date')
-        .order('start_date', { ascending: false })
-    : { data: null }
-
-  // Fetch collaborators (owner sees all via collab_owner_select RLS policy)
-  const { data: collaborators } = isOwner
-    ? await supabase
-        .from('trip_collaborators')
-        .select('id, user_id, role, invited_email, accepted_at, created_at')
-        .eq('trip_id', id)
-        .order('created_at', { ascending: true })
-    : { data: [] }
+  // Parallel: fetch items, all trips, collaborators, profile, and temp unit simultaneously
+  const [
+    { data: items },
+    { data: allTrips },
+    { data: collaborators },
+    { data: profileData },
+    userUnit,
+  ] = await Promise.all([
+    supabase
+      .from('trip_items')
+      .select('*')
+      .eq('trip_id', id)
+      .order('start_date', { ascending: true })
+      .order('start_ts', { ascending: true }),
+    user
+      ? supabase
+          .from('trips')
+          .select('id, title, start_date')
+          .order('start_date', { ascending: false })
+      : Promise.resolve({ data: null }),
+    isOwner
+      ? supabase
+          .from('trip_collaborators')
+          .select('id, user_id, role, invited_email, accepted_at, created_at')
+          .eq('trip_id', id)
+          .order('created_at', { ascending: true })
+      : Promise.resolve({ data: [] as never[] }),
+    user
+      ? supabase
+          .from('profiles')
+          .select('subscription_tier')
+          .eq('id', user.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    user
+      ? getTemperatureUnit(user.id, supabase)
+      : Promise.resolve('fahrenheit' as const),
+  ])
 
   const canEdit = isOwner || collabRole === 'editor'
-
-  const { data: profileData } = user
-    ? await supabase
-        .from('profiles')
-        .select('subscription_tier')
-        .eq('id', user.id)
-        .maybeSingle()
-    : { data: null }
   const isPro = profileData?.subscription_tier === 'pro'
   const weather = user
     ? await getTripWeather({
         tripId: trip.id,
         supabase,
         userId: user.id,
-        requestedUnit: await getTemperatureUnit(user.id, supabase),
+        requestedUnit: userUnit,
         includePacking: isPro,
       })
     : null

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -196,10 +196,8 @@ export default async function SharePage({ params }: SharePageProps) {
     )
   }
 
+  // Parallel: auth check runs alongside weather fetch
   const sessionSupabase = await createClient()
-  const {
-    data: { user },
-  } = await sessionSupabase.auth.getUser()
 
   const obfuscatedItems = (items ?? []).map((item) => ({
     ...item,
@@ -209,8 +207,29 @@ export default async function SharePage({ params }: SharePageProps) {
   const travelers = (trip.travelers ?? []).map(obfuscateName)
   const itemCount = obfuscatedItems.length
 
-  let sharedWeather = items
-    ? await buildWeatherPayload({
+  // Start auth check early — don't block on it
+  const userPromise = sessionSupabase.auth.getUser()
+
+  // Build anonymous weather payload while auth resolves
+  const weatherItems = items?.map(
+    (item): WeatherTripItem => ({
+      id: item.id,
+      trip_id: trip.id,
+      kind: item.kind,
+      start_date: item.start_date,
+      end_date: item.end_date,
+      start_ts: item.start_ts,
+      end_ts: item.end_ts,
+      start_location: item.start_location,
+      end_location: item.end_location,
+      provider: item.provider,
+      summary: item.summary,
+      details_json: item.details_json,
+    })
+  )
+
+  const anonWeatherPromise = items
+    ? buildWeatherPayload({
         trip: {
           id: trip.id,
           user_id: '',
@@ -219,34 +238,28 @@ export default async function SharePage({ params }: SharePageProps) {
           end_date: trip.end_date,
           share_enabled: trip.share_enabled ?? false,
         },
-        items: items.map(
-          (item): WeatherTripItem => ({
-            id: item.id,
-            trip_id: trip.id,
-            kind: item.kind,
-            start_date: item.start_date,
-            end_date: item.end_date,
-            start_ts: item.start_ts,
-            end_ts: item.end_ts,
-            start_location: item.start_location,
-            end_location: item.end_location,
-            provider: item.provider,
-            summary: item.summary,
-            details_json: item.details_json,
-          })
-        ),
+        items: weatherItems!,
         unit: 'fahrenheit',
         includePacking: false,
       })
-    : null
+    : Promise.resolve(null)
 
+  // Wait for both in parallel
+  const [{ data: { user } }, anonWeather] = await Promise.all([userPromise, anonWeatherPromise])
+
+  let sharedWeather = anonWeather
   let showPacking = false
+
   if (user) {
-    const { data: accessibleTrip } = await sessionSupabase
-      .from('trips')
-      .select('id, user_id')
-      .eq('id', trip.id)
-      .maybeSingle()
+    // Parallel: trip access check + temperature unit fetch
+    const [{ data: accessibleTrip }, userUnit] = await Promise.all([
+      sessionSupabase
+        .from('trips')
+        .select('id, user_id')
+        .eq('id', trip.id)
+        .maybeSingle(),
+      getTemperatureUnit(user.id, sessionSupabase),
+    ])
 
     if (accessibleTrip) {
       const { data: ownerProfile } = await sessionSupabase
@@ -260,7 +273,7 @@ export default async function SharePage({ params }: SharePageProps) {
         tripId: trip.id,
         supabase: sessionSupabase,
         userId: user.id,
-        requestedUnit: await getTemperatureUnit(user.id, sessionSupabase),
+        requestedUnit: userUnit,
         includePacking: showPacking,
       })
     }


### PR DESCRIPTION
**Problem:** Trip pages take ~4s TTFB for long trips. Multiple Supabase queries run sequentially where they could be parallel.

**Share page fixes:**
- `getUser()` now runs in parallel with `buildWeatherPayload()` (was sequential)
- For authenticated users: trip access check + temperature unit fetch run in parallel

**Dashboard trip page fixes:**
- 5 sequential queries (items, allTrips, collaborators, profile, tempUnit) collapsed into a single `Promise.all`
- Eliminates ~3 sequential round trips to Supabase

**Expected improvement:** For authenticated users viewing a long trip, this should cut ~1-2s off the 4s TTFB by eliminating sequential DB round trips. The remaining time is weather fetch (cache-dependent) and React SSR.