### PR TITLE
fix: hotels on departure day move to destination segment

### DIFF
--- a/src/lib/trips/airport-cities.ts
+++ b/src/lib/trips/airport-cities.ts
@@ -55,6 +55,46 @@ export function resolveAirportCity(code: string): ResolvedAirportCity | null {
   return AIRPORT_CITIES[code.trim().toUpperCase()] ?? null
 }
 
+/**
+ * Metro area aliases: city names / neighborhoods that belong to the same metro.
+ * Used to prevent false-positive hotel reassignment (e.g. Coconut Grove ≠ Miami
+ * by string, but same metro area).
+ */
+const METRO_ALIASES: Record<string, string> = {
+  'newark': 'new york',
+  'jersey city': 'new york',
+  'hoboken': 'new york',
+  'brooklyn': 'new york',
+  'queens': 'new york',
+  'bronx': 'new york',
+  'coconut grove': 'miami',
+  'surfside': 'miami',
+  'miami beach': 'miami',
+  'fort lauderdale': 'miami',
+  'coral gables': 'miami',
+  'orly': 'paris',
+  'roissy': 'paris',
+  'gatwick': 'london',
+  'stansted': 'london',
+  'luton': 'london',
+  'narita': 'tokyo',
+  'haneda': 'tokyo',
+  'san francisco': 'san francisco bay',
+  'oakland': 'san francisco bay',
+  'san jose': 'san francisco bay',
+  'berkeley': 'san francisco bay',
+  'palo alto': 'san francisco bay',
+}
+
+/**
+ * Resolve a city name to its metro canonical name if it's a known alias.
+ * Returns the canonical name (lowercase) or the input key unchanged.
+ */
+export function resolveMetroAlias(cityName: string): string {
+  const key = cityName.toLowerCase().replace(/[^a-z\s]+/g, '').trim()
+  return METRO_ALIASES[key] ?? key
+}
+
 export function isSameMetroArea(code1: string, code2: string): boolean {
   const left = resolveAirportCity(code1)
   const right = resolveAirportCity(code2)

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -391,3 +391,52 @@ describe('hotel segment assignment', () => {
     expect(nycSegment!.segment!.anchorType).toBe('activity')
   })
 })
+
+  it('keeps hotel in same metro area as departure (Coconut Grove / MIA)', () => {
+    // Same-day check-in + departure, but hotel is in departure metro area
+    const items: TripItem[] = [
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_location: 'ATL',
+        end_location: 'MIA',
+        details_json: {
+          departure_airport: 'ATL',
+          arrival_airport: 'MIA',
+          departure_local_time: '06:00',
+          arrival_local_time: '09:00',
+        },
+      }),
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-10',
+        end_date: '2026-03-11',
+        start_location: 'Mr. C Hotel, Coconut Grove, FL',
+        summary: 'Hotel in Coconut Grove',
+      }),
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_location: 'MIA',
+        end_location: 'LAX',
+        details_json: {
+          departure_airport: 'MIA',
+          arrival_airport: 'LAX',
+          departure_local_time: '22:00',
+          arrival_local_time: '01:00',
+        },
+      }),
+    ]
+
+    const timeline = buildTimeline(items)
+    const segments = timeline.filter((e) => e.type === 'segment')
+
+    // Hotel should stay in the Miami/Coconut Grove segment (same metro)
+    const miaSegment = segments.find((e) =>
+      e.segment?.city?.includes('Coconut Grove') || e.segment?.city?.includes('Miami')
+    )
+    expect(miaSegment).toBeDefined()
+    expect(miaSegment!.segment!.items.some((i) => i.kind === 'hotel')).toBe(true)
+  })

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -89,8 +89,8 @@ describe('buildTimeline', () => {
         kind: 'hotel',
         start_date: '2026-03-13',
         end_date: '2026-03-14',
-        start_location: 'Austin, TX',
-        summary: 'The Stephen F Austin Royal Sonesta Hotel',
+        start_location: 'The Stephen F Austin Royal Sonesta Hotel',
+        summary: 'Hotel booking at The Stephen F Austin Royal Sonesta Hotel in Austin, TX',
       }),
       makeItem({
         provider: 'American',
@@ -232,5 +232,162 @@ describe('buildTimeline', () => {
     expect(segments[2].segment?.city).toContain('Austin')
     expect(segments[2].segment?.city).not.toContain('Stephen F Austin')
     expect(segments[5].segment?.durationNights).toBe(0)
+  })
+})
+
+describe('hotel segment assignment', () => {
+  it('moves hotel with check-in on departure day to destination segment', () => {
+    // Scenario: staying in NYC (no hotel), then flying to Austin where you have a hotel
+    // Hotel check-in date == flight departure date
+    const items: TripItem[] = [
+      // Flight arriving in NYC
+      makeItem({
+        provider: 'Spirit',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_location: 'MIA',
+        end_location: 'EWR',
+        details_json: {
+          departure_airport: 'MIA',
+          arrival_airport: 'EWR',
+          departure_local_time: '06:00',
+          arrival_local_time: '09:30',
+        },
+      }),
+      // Hotel in Austin — check-in same day as flight out of NYC
+      // Location is just the hotel name (no city)
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-13',
+        end_date: '2026-03-14',
+        start_location: 'The Stephen F Austin Royal Sonesta Hotel',
+        summary: 'Hotel booking',
+      }),
+      // Flight from NYC to Austin
+      makeItem({
+        provider: 'Spirit',
+        start_date: '2026-03-13',
+        end_date: '2026-03-13',
+        start_location: 'EWR',
+        end_location: 'AUS',
+        details_json: {
+          departure_airport: 'EWR',
+          arrival_airport: 'AUS',
+          departure_local_time: '09:00',
+          arrival_local_time: '12:15',
+        },
+      }),
+    ]
+
+    const timeline = buildTimeline(items)
+    const segments = timeline.filter((e) => e.type === 'segment')
+
+    // NYC segment should NOT contain the Austin hotel
+    const nycSegment = segments.find((e) => e.segment?.city === 'New York')
+    expect(nycSegment).toBeDefined()
+    expect(nycSegment!.segment!.items.some((i) => i.kind === 'hotel')).toBe(false)
+
+    // Austin segment should contain the hotel
+    const austinSegment = segments.find((e) => e.segment?.city?.includes('Austin'))
+    expect(austinSegment).toBeDefined()
+    expect(austinSegment!.segment!.items.some((i) => i.kind === 'hotel')).toBe(true)
+  })
+
+  it('keeps hotel in departure segment when hotel city matches departure city', () => {
+    // Scenario: hotel in NYC with same-day evening flight (rare but valid)
+    const items: TripItem[] = [
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_location: 'LAX',
+        end_location: 'JFK',
+        details_json: {
+          departure_airport: 'LAX',
+          arrival_airport: 'JFK',
+          departure_local_time: '06:00',
+          arrival_local_time: '14:30',
+        },
+      }),
+      // Hotel in NYC — check-in same day as flight out, but hotel IS in NYC
+      makeItem({
+        kind: 'hotel',
+        start_date: '2026-03-12',
+        end_date: '2026-03-13',
+        start_location: 'The Plaza Hotel, New York, NY',
+        summary: 'Hotel in NYC',
+      }),
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-12',
+        end_date: '2026-03-12',
+        start_location: 'JFK',
+        end_location: 'ORD',
+        details_json: {
+          departure_airport: 'JFK',
+          arrival_airport: 'ORD',
+          departure_local_time: '20:00',
+          arrival_local_time: '22:00',
+        },
+      }),
+    ]
+
+    const timeline = buildTimeline(items)
+    const segments = timeline.filter((e) => e.type === 'segment')
+
+    // NYC segment should keep the hotel (it's clearly a NYC hotel)
+    const nycSegment = segments.find((e) => e.segment?.city?.includes('New York'))
+    expect(nycSegment).toBeDefined()
+    expect(nycSegment!.segment!.items.some((i) => i.kind === 'hotel')).toBe(true)
+  })
+
+  it('works when traveler has no hotels (staying with friends)', () => {
+    const items: TripItem[] = [
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-10',
+        end_date: '2026-03-10',
+        start_location: 'CDG',
+        end_location: 'JFK',
+        details_json: {
+          departure_airport: 'CDG',
+          arrival_airport: 'JFK',
+          departure_local_time: '10:00',
+          arrival_local_time: '13:00',
+        },
+      }),
+      // No hotel — staying with friends in NYC
+      // Just an activity
+      makeItem({
+        kind: 'activity',
+        start_date: '2026-03-11',
+        end_date: '2026-03-11',
+        start_location: 'Brooklyn, NY',
+        summary: 'Dinner with friends',
+      }),
+      makeItem({
+        provider: 'Delta',
+        start_date: '2026-03-14',
+        end_date: '2026-03-14',
+        start_location: 'JFK',
+        end_location: 'CDG',
+        details_json: {
+          departure_airport: 'JFK',
+          arrival_airport: 'CDG',
+          departure_local_time: '18:00',
+          arrival_local_time: '07:00',
+        },
+      }),
+    ]
+
+    const timeline = buildTimeline(items)
+    const segments = timeline.filter((e) => e.type === 'segment')
+
+    // Segment should exist with activity-derived city, even without hotel
+    // Brooklyn is a valid city from the activity location
+    const nycSegment = segments.find((e) => e.segment?.city?.includes('Brooklyn'))
+    expect(nycSegment).toBeDefined()
+    expect(nycSegment!.segment!.items).toHaveLength(1) // just the activity
+    expect(nycSegment!.segment!.anchorType).toBe('activity')
   })
 })

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -2,7 +2,7 @@ import type { TripItem, Json } from '@/types/database'
 import type { WeatherDestination } from '@/lib/weather/types'
 import { weatherCodeToEmoji, type TimelineWeatherDay } from '@/lib/weather/item-weather'
 import { looksLikeVenueName, normaliseToCity } from './assignment'
-import { isSameMetroArea, resolveAirportCity } from './airport-cities'
+import { isSameMetroArea, resolveAirportCity, resolveMetroAlias } from './airport-cities'
 
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1000
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -359,12 +359,29 @@ function reassignDepartureDayHotels(rawSegments: RawSegment[]): void {
       const hotelLocation = item.start_location ?? item.end_location
       const hotelCity = hotelLocation ? deriveDisplayLocation(hotelLocation) : null
 
-      if (hotelCity && !looksLikeVenueName(hotelCity) && departureCity) {
-        // Hotel has a resolvable city — check if it matches the departure city
+      if (hotelCity && !looksLikeVenueName(hotelCity)) {
+        // Hotel has a resolvable city — check if it matches the segment's location
+        // Compare against both the departure airport AND the arrival airport
+        // (the segment could be "at" either city)
         const hotelKey = cityKey(hotelCity)
-        const depKey = cityKey(departureCity.city)
-        if (hotelKey === depKey || hotelKey.startsWith(depKey) || depKey.startsWith(hotelKey)) {
-          // Hotel is at the departure city (same-day checkout scenario?) — keep it
+        const segmentCities: string[] = []
+        if (departureCity) segmentCities.push(cityKey(departureCity.city))
+        if (segment.incoming) {
+          const arrivalCity = resolveAirportCity(segment.incoming.arrival.code)
+          if (arrivalCity) segmentCities.push(cityKey(arrivalCity.city))
+        }
+
+        // For metro alias matching, use just the city name (strip region like ", FL")
+        const hotelCityName = hotelCity.split(',')[0].trim()
+        const hotelMatchesSegment = segmentCities.some((segKey) => {
+          if (hotelKey === segKey || hotelKey.startsWith(segKey) || segKey.startsWith(hotelKey)) return true
+          // Metro alias: "Coconut Grove" → "miami", "Miami, FL" → "miami"
+          const segCityName = segKey.replace(/\s+[a-z]{2}$/, '') // strip state codes like " fl"
+          return resolveMetroAlias(hotelCityName) === resolveMetroAlias(segCityName)
+        })
+
+        if (hotelMatchesSegment) {
+          // Hotel is at or near the segment's city — keep it
           continue
         }
       }

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -374,7 +374,7 @@ function reassignDepartureDayHotels(rawSegments: RawSegment[]): void {
         // For metro alias matching, use just the city name (strip region like ", FL")
         const hotelCityName = hotelCity.split(',')[0].trim()
         const hotelMatchesSegment = segmentCities.some((segKey) => {
-          if (hotelKey === segKey || hotelKey.startsWith(segKey) || segKey.startsWith(hotelKey)) return true
+          if (hotelKey === segKey) return true
           // Metro alias: "Coconut Grove" → "miami", "Miami, FL" → "miami"
           const segCityName = segKey.replace(/\s+[a-z]{2}$/, '') // strip state codes like " fl"
           return resolveMetroAlias(hotelCityName) === resolveMetroAlias(segCityName)
@@ -391,9 +391,12 @@ function reassignDepartureDayHotels(rawSegments: RawSegment[]): void {
     }
 
     if (movedIndices.length > 0) {
-      const movedItems = movedIndices.map((idx) => segment.items[idx])
-      segment.items = segment.items.filter((_, idx) => !movedIndices.includes(idx))
-      nextSegment.items.unshift(...movedItems)
+      const movedSet = new Set(movedIndices)
+      const movedItems = segment.items.filter((_, idx) => movedSet.has(idx))
+      segment.items = segment.items.filter((_, idx) => !movedSet.has(idx))
+      nextSegment.items.push(...movedItems)
+      // Re-sort to maintain chronological order after insertion
+      nextSegment.items.sort((a, b) => (a.start_date ?? '').localeCompare(b.start_date ?? ''))
     }
   }
 }

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -331,6 +331,56 @@ export function attachWeatherToTimeline(entries: TimelineEntry[], destinations: 
   })
 }
 
+/**
+ * A hotel's start_date is check-in day. If check-in falls on the same day as
+ * an outbound flight, the hotel almost certainly belongs at the destination,
+ * not the departure city (you check in after arriving, not before flying out).
+ *
+ * Exception: if the hotel's location clearly resolves to the departure city,
+ * keep it in the current segment (rare: same-day hotel + evening flight).
+ */
+function reassignDepartureDayHotels(rawSegments: RawSegment[]): void {
+  for (let i = 0; i < rawSegments.length; i++) {
+    const segment = rawSegments[i]
+    if (!segment.outgoing) continue
+    const nextSegment = rawSegments[i + 1]
+    if (!nextSegment) continue
+
+    const departureDate = segment.outgoing.date
+    const departureCity = resolveAirportCity(segment.outgoing.departure.code)
+    const movedIndices: number[] = []
+
+    for (let j = 0; j < segment.items.length; j++) {
+      const item = segment.items[j]
+      if (item.kind !== 'hotel') continue
+      if (item.start_date !== departureDate) continue
+
+      // Try to resolve the hotel's city
+      const hotelLocation = item.start_location ?? item.end_location
+      const hotelCity = hotelLocation ? deriveDisplayLocation(hotelLocation) : null
+
+      if (hotelCity && !looksLikeVenueName(hotelCity) && departureCity) {
+        // Hotel has a resolvable city — check if it matches the departure city
+        const hotelKey = cityKey(hotelCity)
+        const depKey = cityKey(departureCity.city)
+        if (hotelKey === depKey || hotelKey.startsWith(depKey) || depKey.startsWith(hotelKey)) {
+          // Hotel is at the departure city (same-day checkout scenario?) — keep it
+          continue
+        }
+      }
+
+      // Hotel is unresolvable or at the destination — move it to the next segment
+      movedIndices.push(j)
+    }
+
+    if (movedIndices.length > 0) {
+      const movedItems = movedIndices.map((idx) => segment.items[idx])
+      segment.items = segment.items.filter((_, idx) => !movedIndices.includes(idx))
+      nextSegment.items.unshift(...movedItems)
+    }
+  }
+}
+
 export function buildTimeline(items: TripItem[]): TimelineEntry[] {
   const processed = firstPass(items)
   const rawSegments: RawSegment[] = []
@@ -355,6 +405,9 @@ export function buildTimeline(items: TripItem[]): TimelineEntry[] {
   if (incoming || currentItems.length > 0) {
     rawSegments.push({ incoming, outgoing: null, items: currentItems })
   }
+
+  // Post-process: move hotels that check in on departure day to the next segment
+  reassignDepartureDayHotels(rawSegments)
 
   const segments = rawSegments.map(buildSegment)
   const timeline: TimelineEntry[] = []


### PR DESCRIPTION
**Bug:** A hotel booking was showing under the wrong City Stay card because its check-in date matched the outbound flight departure date, placing it in the pre-flight segment.

**Root cause:** The timeline builder assigns items to segments sequentially between flights. Items before an outbound flight go to the departure segment. But hotel check-in happens AFTER arrival, not before departure.

**Fix:** New `reassignDepartureDayHotels()` post-processing pass after raw segments are built:
- For each hotel where `start_date == outgoing flight date`:
  - If hotel city resolves and matches the departure city → keep it
  - If hotel city is unresolvable or matches destination → move to next segment

**Safeguards:**
- Hotels with clear departure-city locations stay put
- Uses metro alias resolution to prevent false matches
- Works correctly when travelers have no hotels

**Tests:** 3 new tests covering: hotel reassignment, departure-city retention, no-hotel segments.