### PR TITLE
fix: deduplicate traveler name variants

### DIFF
--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -673,8 +673,11 @@ export async function POST(request: NextRequest) {
           .eq('id', tripId)
           .single()
 
-        const mergedTravelers = Array.from(
-          new Set([...(existingTripData?.travelers || []), ...newTravelers])
+        // Deduplicate using collectTravelerNames to handle name variants
+        const mergedTravelers = collectTravelerNames(
+          [...(existingTripData?.travelers || []), ...newTravelers].map((name) => ({
+            traveler_names: [name],
+          })) as ExtractedItem[]
         )
 
         // Build update object

--- a/src/lib/trips/assignment.test.ts
+++ b/src/lib/trips/assignment.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getPrimaryLocation } from './assignment'
+import { getPrimaryLocation, collectTravelerNames } from './assignment'
 import type { ExtractedItem } from '@/lib/ai/extract-travel-data'
 
 function makeItem(overrides: Partial<ExtractedItem>): ExtractedItem {
@@ -116,5 +116,42 @@ describe('getPrimaryLocation', () => {
     const result = getPrimaryLocation(items)
     expect(result).not.toBe('UT')
     expect(result).toContain('Salt Lake City')
+  })
+})
+
+describe('collectTravelerNames', () => {
+  function makeItems(...names: string[][]) {
+    return names.map((traveler_names) => ({ traveler_names }) as ExtractedItem)
+  }
+
+  it('deduplicates case variants', () => {
+    const result = collectTravelerNames(makeItems(['Ian Rogers'], ['IAN ROGERS'], ['ian rogers']))
+    expect(result).toEqual(['Ian Rogers'])
+  })
+
+  it('keeps longest name variant (middle name)', () => {
+    const result = collectTravelerNames(makeItems(['Ian Rogers'], ['Ian Christian Rogers']))
+    expect(result).toEqual(['Ian Christian Rogers'])
+  })
+
+  it('deduplicates all three variants from screenshot bug', () => {
+    const result = collectTravelerNames(makeItems(
+      ['Ian Christian Rogers'],
+      ['Ian Rogers'],
+      ['Ian ROGERS']
+    ))
+    expect(result).toEqual(['Ian Christian Rogers'])
+  })
+
+  it('keeps genuinely different travelers', () => {
+    const result = collectTravelerNames(makeItems(['Ian Rogers'], ['Hedvig Maigre']))
+    expect(result).toHaveLength(2)
+    expect(result).toContain('Ian Rogers')
+    expect(result).toContain('Hedvig Maigre')
+  })
+
+  it('returns title case', () => {
+    const result = collectTravelerNames(makeItems(['HEDVIG MAIGRE']))
+    expect(result).toEqual(['Hedvig Maigre'])
   })
 })

--- a/src/lib/trips/assignment.ts
+++ b/src/lib/trips/assignment.ts
@@ -243,16 +243,62 @@ function mostFrequentCity(locations: string[]): string | null {
   return normalised
 }
 
+/**
+ * Normalize a traveler name to title case for consistent display.
+ * "IAN ROGERS" → "Ian Rogers", "ian christian rogers" → "Ian Christian Rogers"
+ */
+function titleCase(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+/**
+ * Check if two names refer to the same person.
+ * Handles case differences and subset names (e.g., "Ian Rogers" matches "Ian Christian Rogers").
+ */
+function isSamePerson(a: string, b: string): boolean {
+  const partsA = a.toLowerCase().split(/\s+/).filter(Boolean)
+  const partsB = b.toLowerCase().split(/\s+/).filter(Boolean)
+  // Exact match (case-insensitive)
+  if (partsA.join(' ') === partsB.join(' ')) return true
+  // Check if one name's parts are a subset of the other's (handles middle names)
+  const setA = new Set(partsA)
+  const setB = new Set(partsB)
+  const aSubsetB = partsA.every((p) => setB.has(p))
+  const bSubsetA = partsB.every((p) => setA.has(p))
+  return aSubsetB || bSubsetA
+}
+
+/**
+ * Deduplicate and normalize traveler names from trip items.
+ * Handles case variants ("IAN ROGERS" vs "Ian Rogers") and name subsets
+ * ("Ian Rogers" vs "Ian Christian Rogers" → keeps the longest form).
+ */
 export function collectTravelerNames(items: ExtractedItem[]): string[] {
-  const names = new Set<string>()
+  const rawNames: string[] = []
 
   for (const item of items) {
     for (const name of item.traveler_names || []) {
       if (name.trim()) {
-        names.add(name.trim())
+        rawNames.push(name.trim())
       }
     }
   }
 
-  return Array.from(names)
+  // Deduplicate: group names that refer to the same person, keep the longest variant
+  const deduped: string[] = []
+  for (const name of rawNames) {
+    const existingIndex = deduped.findIndex((existing) => isSamePerson(existing, name))
+    if (existingIndex === -1) {
+      deduped.push(name)
+    } else {
+      // Keep the longer name (more complete form)
+      if (name.length > deduped[existingIndex].length) {
+        deduped[existingIndex] = name
+      }
+    }
+  }
+
+  return deduped.map(titleCase)
 }


### PR DESCRIPTION
## Problem
Trip header shows three entries for the same traveler — different name formats from different booking confirmation emails (e.g. full name, first+last only, ALL CAPS).

## Fix
`collectTravelerNames` now deduplicates intelligently:
- **Case normalization:** 'JOHN DOE' → 'John Doe'
- **Subset detection:** 'John Doe' is a subset of 'John Michael Doe' → keeps the longer form
- **Title case output:** Consistent display regardless of email format

Also fixes webhook merge logic which was using raw `new Set()` without dedup.

## Tests
5 new tests covering: case variants, middle names, the exact bug scenario, different travelers preserved, title case output.

## Data fix needed
Existing trip data still has variants — will need a one-time backfill after merge.