### PR TITLE
feat(events): add event discovery pipeline (PRD-023 Phase 2)

### DIFF
--- a/scripts/__tests__/discover-events.test.ts
+++ b/scripts/__tests__/discover-events.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { applyQualityThreshold } from '../lib/discover-events-core'
+import { adaptSearchPlan, getPreviousDiary } from '../lib/pipeline-diary'
+import { buildSourceUpdate, shouldSkipSource } from '../lib/source-tracker'
+import type { DiscoveredEventCandidate, PipelineSource } from '../lib/types'
+
+function candidate(overrides: Partial<DiscoveredEventCandidate> = {}): DiscoveredEventCandidate {
+  return {
+    city_id: 'city-1',
+    title: 'City Jazz Night',
+    venue_name: 'Room Example',
+    venue_type: 'club',
+    category: 'music',
+    description: 'Evening set.',
+    start_date: '2026-03-15',
+    end_date: null,
+    time_info: null,
+    source: 'Search',
+    source_url: 'https://example.com/jazz',
+    image_url: null,
+    price_info: null,
+    booking_url: null,
+    tags: [],
+    lineup: null,
+    ...overrides,
+  }
+}
+
+describe('applyQualityThreshold', () => {
+  it('accepts scores >= 60 and rejects lower scores', () => {
+    const result = applyQualityThreshold([
+      { candidate: candidate({ title: 'Major show' }), score: 88, tier: 'major' },
+      { candidate: candidate({ title: 'Tiny meetup' }), score: 35, tier: 'local' },
+    ])
+
+    expect(result.accepted).toHaveLength(1)
+    expect(result.accepted[0]?.candidate.title).toBe('Major show')
+    expect(result.rejected).toHaveLength(1)
+    expect(result.rejected[0]?.score).toBe(35)
+  })
+})
+
+describe('source health tracking', () => {
+  it('marks a source dormant after 10 consecutive failures', () => {
+    const source: PipelineSource = {
+      id: 'src-1',
+      city_id: 'city-1',
+      source_type: 'rss',
+      name: 'Example RSS',
+      url: 'https://example.com/feed.xml',
+      language: 'en',
+      scrape_frequency: 'daily',
+      status: 'active',
+      consecutive_failures: 9,
+      last_scraped_at: null,
+      last_event_count: 1,
+      discovered_via: null,
+      notes: null,
+    }
+
+    const update = buildSourceUpdate(
+      source,
+      {
+        sourceId: source.id,
+        sourceName: source.name,
+        sourceUrl: source.url,
+        status: 'error',
+        eventsFound: 0,
+        durationMs: 25,
+        errorMessage: '403',
+      },
+      '2026-03-09T12:00:00.000Z'
+    )
+
+    expect(update.patch.consecutive_failures).toBe(10)
+    expect(update.patch.status).toBe('dormant')
+    expect(shouldSkipSource({ status: update.patch.status, consecutive_failures: update.patch.consecutive_failures })).toBe(true)
+  })
+})
+
+describe('diary adaptation', () => {
+  it('reads the most recent prior diary and carries over next-day suggestions', () => {
+    const previousDiary = getPreviousDiary(
+      [
+        {
+          run_date: '2026-03-08',
+          diary_text: 'Skip Example RSS tomorrow and try tourism board coverage.',
+          next_day_plan: {
+            summary: 'Shift toward tourism-board searches.',
+            queries: ['city exhibitions march 2026'],
+            sourcesToTry: ['tourism board'],
+            sourcesToSkip: ['Example RSS'],
+          },
+        },
+      ],
+      '2026-03-09'
+    )
+
+    const adapted = adaptSearchPlan({
+      previousDiary,
+      sources: [{ name: 'Dormant Feed', url: 'https://example.com/feed', status: 'dormant' }],
+    })
+
+    expect(previousDiary?.run_date).toBe('2026-03-08')
+    expect(adapted.queries).toContain('city exhibitions march 2026')
+    expect(adapted.sourcesToTry).toContain('tourism board')
+    expect(adapted.sourcesToSkip).toEqual(expect.arrayContaining(['Example RSS', 'Dormant Feed']))
+  })
+})

--- a/scripts/__tests__/event-dedup.test.ts
+++ b/scripts/__tests__/event-dedup.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { dedupeCandidates, findDuplicate, titleSimilarity } from '../lib/event-dedup'
+import type { DiscoveredEventCandidate } from '../lib/types'
+
+function candidate(overrides: Partial<DiscoveredEventCandidate> = {}): DiscoveredEventCandidate {
+  return {
+    city_id: 'city-1',
+    title: 'Monet The Late Years',
+    venue_name: 'Musee Example',
+    venue_type: 'museum',
+    category: 'art',
+    description: 'Large-format retrospective.',
+    start_date: '2026-03-10',
+    end_date: '2026-04-20',
+    time_info: null,
+    source: 'RSS',
+    source_url: 'https://example.com/monet',
+    image_url: null,
+    price_info: null,
+    booking_url: 'https://example.com/monet',
+    tags: [],
+    lineup: null,
+    ...overrides,
+  }
+}
+
+describe('titleSimilarity', () => {
+  it('treats formatting-only title changes as near duplicates', () => {
+    expect(titleSimilarity('Monet: The Late Years', 'MONET - The Late Years')).toBeGreaterThan(0.8)
+  })
+})
+
+describe('findDuplicate', () => {
+  it('matches similar titles with overlapping dates and same venue', () => {
+    const match = findDuplicate(candidate(), [
+      {
+        id: 'evt-1',
+        city_id: 'city-1',
+        title: 'Monet: The Late Years',
+        venue_name: 'Musee Example',
+        description: 'Existing row',
+        start_date: '2026-03-01',
+        end_date: '2026-04-30',
+        time_info: null,
+        significance_score: 80,
+        source: 'Search',
+        source_url: 'https://example.com/existing',
+        image_url: null,
+        booking_url: null,
+        event_tier: 'major',
+      },
+    ])
+
+    expect(match?.existing.id).toBe('evt-1')
+  })
+})
+
+describe('dedupeCandidates', () => {
+  it('keeps the candidate with richer metadata', () => {
+    const sparse = candidate({
+      description: 'Short blurb.',
+      image_url: null,
+      booking_url: null,
+    })
+    const rich = candidate({
+      title: 'Monet: The Late Years',
+      description: 'Detailed exhibition description with curator notes and preview highlights.',
+      image_url: 'https://example.com/image.jpg',
+      booking_url: 'https://example.com/book',
+    })
+
+    const result = dedupeCandidates([sparse, rich])
+    expect(result.unique).toHaveLength(1)
+    expect(result.unique[0]?.image_url).toBe('https://example.com/image.jpg')
+  })
+})

--- a/scripts/discover-events.ts
+++ b/scripts/discover-events.ts
@@ -1,0 +1,101 @@
+/**
+ * Example daily cron:
+ * 15 5 * * * cd /home/iancr/ubtrippin && npx tsx scripts/discover-events.ts --all >> /tmp/ubtrippin-event-pipeline.log 2>&1
+ */
+
+import { createSecretClient } from '@/lib/supabase/service'
+import { runCityDiscovery } from './lib/discover-events-core'
+import type { PipelineCity } from './lib/types'
+
+interface CliOptions {
+  citySlug: string | null
+  all: boolean
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let citySlug: string | null = null
+  let all = false
+  let dryRun = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (token === '--city') {
+      citySlug = argv[index + 1] ?? null
+      index += 1
+      continue
+    }
+    if (token === '--all') {
+      all = true
+      continue
+    }
+    if (token === '--dry-run') {
+      dryRun = true
+    }
+  }
+
+  if ((!citySlug && !all) || (citySlug && all)) {
+    throw new Error('Usage: npx tsx scripts/discover-events.ts --city <slug> [--dry-run] | --all [--dry-run]')
+  }
+
+  return { citySlug, all, dryRun }
+}
+
+async function loadCities(citySlug: string | null): Promise<PipelineCity[]> {
+  const supabase = createSecretClient()
+  let query = supabase
+    .from('tracked_cities')
+    .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
+    .order('city', { ascending: true })
+
+  if (citySlug) {
+    query = query.eq('slug', citySlug)
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(`Failed to load tracked cities: ${error.message}`)
+  const cities = (data ?? []) as PipelineCity[]
+  if (cities.length === 0) throw new Error(citySlug ? `No tracked city found for slug "${citySlug}".` : 'No tracked cities found.')
+  return cities
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const supabase = createSecretClient()
+  const cities = await loadCities(options.citySlug)
+
+  for (const city of cities) {
+    console.log(`[${city.city}] Reading yesterday's diary...`)
+    const summary = await runCityDiscovery({
+      supabase,
+      city,
+      dryRun: options.dryRun,
+    })
+
+    console.log(`[${city.city}] Sources checked: ${summary.sourcesChecked}`)
+    for (const report of summary.reports) {
+      const marker = report.status === 'success' ? '✓' : report.status === 'skipped' ? '→' : '✗'
+      const detail = report.status === 'error' ? ` (${report.errorMessage})` : ''
+      console.log(`  ${marker} ${report.sourceName}: ${report.eventsFound} events${detail}`)
+    }
+
+    if (options.dryRun) {
+      console.log(
+        `[${city.city}] DRY RUN — would insert ${summary.inserted} events, update ${summary.updated}, skip ${summary.duplicates} duplicates, filter ${summary.belowThreshold}`
+      )
+    } else {
+      console.log(
+        `[${city.city}] Inserted ${summary.inserted} events, updated ${summary.updated}, skipped ${summary.duplicates} duplicates, filtered ${summary.belowThreshold}`
+      )
+    }
+
+    console.log(`[${city.city}] Diary:`)
+    console.log(`  ${summary.diaryText}`)
+    console.log(`[${city.city}] Next-day plan: ${summary.nextDayPlan.summary}`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/scripts/discover-events.ts
+++ b/scripts/discover-events.ts
@@ -41,8 +41,7 @@ function parseArgs(argv: string[]): CliOptions {
   return { citySlug, all, dryRun }
 }
 
-async function loadCities(citySlug: string | null): Promise<PipelineCity[]> {
-  const supabase = createSecretClient()
+async function loadCities(citySlug: string | null, supabase: ReturnType<typeof createSecretClient>): Promise<PipelineCity[]> {
   let query = supabase
     .from('tracked_cities')
     .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
@@ -62,7 +61,7 @@ async function loadCities(citySlug: string | null): Promise<PipelineCity[]> {
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const supabase = createSecretClient()
-  const cities = await loadCities(options.citySlug)
+  const cities = await loadCities(options.citySlug, supabase)
 
   for (const city of cities) {
     console.log(`[${city.city}] Reading yesterday's diary...`)

--- a/scripts/discover-sources.ts
+++ b/scripts/discover-sources.ts
@@ -1,0 +1,233 @@
+import { createSecretClient } from '@/lib/supabase/service'
+import { searchBraveWeb } from './lib/brave-search'
+import { discoverFeedsFromPage } from './lib/rss-fetcher'
+import type { PipelineCity, PipelineSource } from './lib/types'
+
+interface CandidateSource {
+  source_type: string
+  name: string
+  url: string
+  language: string
+  status: string
+  discovered_via: string
+  notes: string | null
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function languageForCity(city: PipelineCity): string {
+  switch (city.country_code) {
+    case 'FR':
+      return 'fr'
+    case 'IT':
+      return 'it'
+    case 'JP':
+      return 'ja'
+    case 'ES':
+      return 'es'
+    case 'NL':
+      return 'nl'
+    case 'DE':
+      return 'de'
+    case 'EE':
+      return 'et'
+    default:
+      return 'en'
+  }
+}
+
+function knownPatternUrls(city: PipelineCity): CandidateSource[] {
+  const citySlug = slugify(city.city)
+  const countryCode = (city.country_code ?? 'us').toLowerCase()
+
+  return [
+    {
+      source_type: 'tourism_board',
+      name: `Visit ${city.city}`,
+      url: `https://visit${citySlug}.com`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'known-pattern',
+      notes: 'Tourism-board style hostname guess.',
+    },
+    {
+      source_type: 'tourism_board',
+      name: `${city.city} tourism`,
+      url: `https://${citySlug}tourism.com`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'known-pattern',
+      notes: 'Tourism domain guess.',
+    },
+    {
+      source_type: 'website',
+      name: `Time Out ${city.city}`,
+      url: `https://www.timeout.com/${citySlug}`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'known-pattern',
+      notes: null,
+    },
+    {
+      source_type: 'website',
+      name: `Eventbrite ${city.city}`,
+      url: `https://www.eventbrite.com/d/${countryCode}--${citySlug}/${citySlug}-events/`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'global-aggregator',
+      notes: 'Global event aggregator.',
+    },
+    {
+      source_type: 'website',
+      name: `Bandsintown ${city.city}`,
+      url: `https://www.bandsintown.com/c/${citySlug}-${countryCode}`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'global-aggregator',
+      notes: 'Global live music aggregator.',
+    },
+    {
+      source_type: 'website',
+      name: `Songkick ${city.city}`,
+      url: `https://www.songkick.com/metro-areas/${citySlug}`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'global-aggregator',
+      notes: 'Global concert aggregator.',
+    },
+    {
+      source_type: 'website',
+      name: `Music Festival Wizard ${city.city}`,
+      url: `https://www.musicfestivalwizard.com/festival-guide/${citySlug}/`,
+      language: languageForCity(city),
+      status: 'candidate',
+      discovered_via: 'global-aggregator',
+      notes: 'Global festival aggregator.',
+    },
+  ]
+}
+
+async function loadCity(citySlug: string): Promise<PipelineCity> {
+  const supabase = createSecretClient()
+  const { data, error } = await supabase
+    .from('tracked_cities')
+    .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
+    .eq('slug', citySlug)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to load city "${citySlug}": ${error.message}`)
+  if (!data) throw new Error(`Tracked city "${citySlug}" was not found.`)
+  return data as PipelineCity
+}
+
+async function loadExistingSources(cityId: string): Promise<PipelineSource[]> {
+  const supabase = createSecretClient()
+  const { data, error } = await supabase
+    .from('city_sources')
+    .select('id, city_id, source_type, name, url, language, scrape_frequency, status, consecutive_failures, last_scraped_at, last_event_count, discovered_via, notes')
+    .eq('city_id', cityId)
+
+  if (error) throw new Error(`Failed to load existing sources: ${error.message}`)
+  return (data ?? []) as PipelineSource[]
+}
+
+async function probeFeedCandidates(url: string): Promise<string[]> {
+  try {
+    return await discoverFeedsFromPage(url)
+  } catch {
+    return []
+  }
+}
+
+async function searchCitySources(city: PipelineCity): Promise<CandidateSource[]> {
+  const language = languageForCity(city)
+  const queries = [
+    `${city.city} events RSS`,
+    `${city.city} tourism board`,
+    `${city.city} what's on calendar`,
+  ]
+
+  const candidates: CandidateSource[] = []
+
+  for (const query of queries) {
+    const results = await searchBraveWeb(query, { count: 8 })
+    for (const result of results) {
+      candidates.push({
+        source_type: /tourism|visit/i.test(result.title) ? 'tourism_board' : 'website',
+        name: result.title.slice(0, 120),
+        url: result.url,
+        language,
+        status: 'candidate',
+        discovered_via: `brave:${query}`,
+        notes: result.description.slice(0, 300),
+      })
+
+      const feedUrls = await probeFeedCandidates(result.url)
+      for (const feedUrl of feedUrls) {
+        candidates.push({
+          source_type: 'rss',
+          name: `${result.title.slice(0, 80)} feed`,
+          url: feedUrl,
+          language,
+          status: 'candidate',
+          discovered_via: `autodiscovery:${result.url}`,
+          notes: 'Auto-discovered via rel=alternate.',
+        })
+      }
+    }
+  }
+
+  return candidates
+}
+
+async function main() {
+  const citySlug = process.argv[2]?.trim()
+  if (!citySlug) {
+    throw new Error('Usage: npx tsx scripts/discover-sources.ts <city-slug>')
+  }
+
+  const supabase = createSecretClient()
+  const city = await loadCity(citySlug)
+  const existing = await loadExistingSources(city.id)
+  const existingUrls = new Set(existing.map((source) => source.url))
+  const candidates = [...knownPatternUrls(city), ...(await searchCitySources(city))]
+  const deduped = Array.from(
+    new Map(candidates.map((candidate) => [candidate.url, candidate])).values()
+  ).filter((candidate) => !existingUrls.has(candidate.url))
+
+  if (deduped.length === 0) {
+    console.log(`[${city.city}] No new sources discovered.`)
+    return
+  }
+
+  const rows = deduped.map((candidate) => ({
+    city_id: city.id,
+    source_type: candidate.source_type,
+    name: candidate.name,
+    url: candidate.url,
+    language: candidate.language,
+    status: candidate.status,
+    discovered_via: candidate.discovered_via,
+    notes: candidate.notes,
+  }))
+
+  const { error } = await supabase.from('city_sources').insert(rows)
+  if (error) throw new Error(`Failed to insert discovered sources: ${error.message}`)
+
+  console.log(`[${city.city}] Added ${rows.length} candidate sources.`)
+  for (const row of rows) {
+    console.log(`  + ${row.name} (${row.source_type})`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/scripts/lib/brave-search.ts
+++ b/scripts/lib/brave-search.ts
@@ -1,0 +1,118 @@
+import type { PipelineCity, SearchResult } from './types'
+
+const BRAVE_API_KEY = process.env.BRAVE_SEARCH_API_KEY ?? process.env.BRAVE_API_KEY
+const BRAVE_SEARCH_URL = 'https://api.search.brave.com/res/v1/web/search'
+let lastRequestAt = 0
+
+interface BraveWebApiResult {
+  title?: string
+  url?: string
+  description?: string
+  age?: string
+  meta_url?: {
+    hostname?: string
+  }
+  language?: string
+}
+
+interface BraveWebApiResponse {
+  web?: {
+    results?: BraveWebApiResult[]
+  }
+}
+
+function cityLocale(city: PipelineCity): string {
+  switch (city.country_code) {
+    case 'FR':
+      return 'fr-FR'
+    case 'IT':
+      return 'it-IT'
+    case 'JP':
+      return 'ja-JP'
+    case 'ES':
+      return 'es-ES'
+    case 'NL':
+      return 'nl-NL'
+    case 'DE':
+      return 'de-DE'
+    case 'EE':
+      return 'et-EE'
+    default:
+      return 'en-US'
+  }
+}
+
+export function formatSearchMonth(date: Date, city: PipelineCity): { month: string; year: string } {
+  const locale = cityLocale(city)
+  return {
+    month: new Intl.DateTimeFormat(locale, { month: 'long' }).format(date),
+    year: String(date.getFullYear()),
+  }
+}
+
+export function buildSearchQueries(city: PipelineCity, date: Date, extras: string[] = []): string[] {
+  const { month, year } = formatSearchMonth(date, city)
+  const base = `${city.city} ${month} ${year}`
+  const localized = cityLocale(city)
+  const templates = localized.startsWith('fr')
+    ? [`${city.city} expositions ${month} ${year}`, `${city.city} concerts ${month} ${year}`, `${city.city} festivals ${month} ${year}`]
+    : localized.startsWith('it')
+      ? [`${city.city} mostre ${month} ${year}`, `${city.city} concerti ${month} ${year}`, `${city.city} festival ${month} ${year}`]
+      : localized.startsWith('ja')
+        ? [`${city.city} events ${month} ${year}`, `${city.city} exhibitions ${month} ${year}`, `${city.city} concerts ${month} ${year}`]
+        : [`${base} events`, `${base} exhibitions`, `${base} concerts`, `${base} festivals`]
+
+  return Array.from(new Set([...templates, ...extras]))
+}
+
+async function rateLimitDelay() {
+  const elapsed = Date.now() - lastRequestAt
+  if (elapsed < 1000) {
+    await new Promise((resolve) => setTimeout(resolve, 1000 - elapsed))
+  }
+  lastRequestAt = Date.now()
+}
+
+export async function searchBraveWeb(
+  query: string,
+  options?: { count?: number; site?: string }
+): Promise<SearchResult[]> {
+  if (!BRAVE_API_KEY) {
+    throw new Error('BRAVE_SEARCH_API_KEY or BRAVE_API_KEY is not configured.')
+  }
+
+  await rateLimitDelay()
+
+  const params = new URLSearchParams({
+    q: options?.site ? `site:${options.site} ${query}` : query,
+    count: String(options?.count ?? 10),
+    text_decorations: 'false',
+    result_filter: 'web',
+    extra_snippets: 'true',
+  })
+
+  const response = await fetch(`${BRAVE_SEARCH_URL}?${params.toString()}`, {
+    headers: {
+      Accept: 'application/json',
+      'X-Subscription-Token': BRAVE_API_KEY,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Brave search failed: ${response.status} ${response.statusText}`)
+  }
+
+  const data = (await response.json()) as BraveWebApiResponse
+  return (data.web?.results ?? [])
+    .filter((result): result is Required<Pick<BraveWebApiResult, 'title' | 'url' | 'description'>> & BraveWebApiResult => {
+      return Boolean(result.title && result.url && result.description)
+    })
+    .map((result) => ({
+      title: result.title,
+      url: result.url,
+      description: result.description,
+      pageAge: result.age ?? null,
+      sourceName: result.meta_url?.hostname ?? null,
+      language: result.language ?? null,
+    }))
+}

--- a/scripts/lib/discover-events-core.ts
+++ b/scripts/lib/discover-events-core.ts
@@ -1,0 +1,533 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { addDays } from 'date-fns'
+import { buildSearchQueries, searchBraveWeb } from './brave-search'
+import { choosePreferredEvent, dedupeCandidates, findDuplicate } from './event-dedup'
+import { adaptSearchPlan, getPreviousDiary, type DiaryRowLike } from './pipeline-diary'
+import { draftDiaryFromAi, extractEventFromText, scoreEventQuality } from './quality-scorer'
+import { fetchFeedItems } from './rss-fetcher'
+import { buildSourceUpdate, shouldSkipSource } from './source-tracker'
+import type {
+  CityRunSummary,
+  DiscoveredEventCandidate,
+  DiscoverySourceResult,
+  ExistingEventRecord,
+  PipelineCity,
+  PipelineSource,
+  PipelineVenue,
+  SearchResult,
+} from './types'
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10)
+}
+
+function clampText(value: string | null | undefined, max = 2000): string | null {
+  if (!value) return null
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  return normalized ? normalized.slice(0, max) : null
+}
+
+function classifyCategory(text: string): DiscoveredEventCandidate['category'] {
+  if (/\b(exhibit|museum|gallery|retrospective|biennale)\b/i.test(text)) return 'art'
+  if (/\b(concert|music|orchestra|jazz|dj|opera)\b/i.test(text)) return 'music'
+  if (/\b(theater|theatre|play|ballet)\b/i.test(text)) return 'theater'
+  if (/\b(food|wine|tasting|restaurant)\b/i.test(text)) return 'food'
+  if (/\b(festival|carnival|parade)\b/i.test(text)) return 'festival'
+  if (/\b(match|game|race|grand prix|tournament)\b/i.test(text)) return 'sports'
+  if (/\b(architecture|design week)\b/i.test(text)) return 'architecture'
+  if (/\b(cathedral|church|basilica|temple)\b/i.test(text)) return 'sacred'
+  if (/\b(market|fair)\b/i.test(text)) return 'market'
+  return 'other'
+}
+
+function classifyVenueType(text: string): DiscoveredEventCandidate['venue_type'] {
+  if (/\bmuseum\b/i.test(text)) return 'museum'
+  if (/\btheat(re|er)\b/i.test(text)) return 'theater'
+  if (/\bgallery\b/i.test(text)) return 'gallery'
+  if (/\bstadium|arena\b/i.test(text)) return 'stadium'
+  if (/\bchurch|cathedral|temple|basilica\b/i.test(text)) return 'sacred_venue'
+  if (/\bclub\b/i.test(text)) return 'club'
+  return null
+}
+
+function parseDateText(value: string | null | undefined): string | null {
+  if (!value) return null
+  const normalized = value.trim()
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return normalized
+  const parsed = Date.parse(normalized)
+  if (Number.isNaN(parsed)) return null
+  return new Date(parsed).toISOString().slice(0, 10)
+}
+
+function buildCandidate(args: {
+  city: PipelineCity
+  sourceName: string
+  sourceUrl: string | null
+  title: string
+  description: string | null
+  startDate: string
+  endDate?: string | null
+  bookingUrl?: string | null
+  imageUrl?: string | null
+  venueName?: string | null
+  tags?: string[]
+}): DiscoveredEventCandidate {
+  const combined = `${args.title} ${args.description ?? ''} ${args.venueName ?? ''}`
+  return {
+    city_id: args.city.id,
+    title: args.title.trim(),
+    venue_name: args.venueName ?? null,
+    venue_type: classifyVenueType(combined),
+    category: classifyCategory(combined),
+    description: clampText(args.description, 4000),
+    start_date: args.startDate,
+    end_date: args.endDate ?? null,
+    time_info: null,
+    source: args.sourceName,
+    source_url: args.sourceUrl,
+    image_url: args.imageUrl ?? null,
+    price_info: null,
+    booking_url: args.bookingUrl ?? args.sourceUrl,
+    tags: args.tags ?? [],
+    lineup: null,
+  }
+}
+
+function sourceDuration(startedAt: number): number {
+  return Math.max(1, Date.now() - startedAt)
+}
+
+function extractFallbackDate(result: SearchResult): string | null {
+  return parseDateText(result.pageAge)
+}
+
+function resolveVenue(candidate: DiscoveredEventCandidate, venues: PipelineVenue[]): PipelineVenue | null {
+  const normalized = (candidate.venue_name ?? '').toLowerCase().trim()
+  if (!normalized) return null
+  return (
+    venues.find((venue) => venue.name.toLowerCase().trim() === normalized) ??
+    venues.find((venue) => normalized.includes(venue.name.toLowerCase().trim()))
+  ) ?? null
+}
+
+async function sourceToCandidatesFromFeed(args: {
+  city: PipelineCity
+  source: PipelineSource
+}): Promise<DiscoveredEventCandidate[]> {
+  const items = await fetchFeedItems(args.source.url)
+  const candidates: DiscoveredEventCandidate[] = []
+
+  for (const item of items) {
+    const fallbackDate = parseDateText(item.publishedAt)
+    const extracted = await extractEventFromText({
+      city: args.city,
+      sourceName: args.source.name,
+      sourceUrl: item.link ?? args.source.url,
+      text: [item.title, item.summary, item.content].filter(Boolean).join('\n'),
+      fallbackDate,
+    })
+
+    const title = clampText(extracted.title ?? item.title, 200)
+    const startDate = parseDateText(extracted.start_date) ?? fallbackDate
+    if (!extracted.isEvent || !title || !startDate) continue
+
+    candidates.push(
+      buildCandidate({
+        city: args.city,
+        sourceName: args.source.name,
+        sourceUrl: item.link ?? args.source.url,
+        title,
+        description: extracted.description ?? item.summary ?? item.content,
+        startDate,
+        endDate: parseDateText(extracted.end_date),
+        bookingUrl: extracted.booking_url ?? item.link,
+        imageUrl: extracted.image_url ?? item.imageUrl,
+        venueName: extracted.venue_name ?? null,
+        tags: extracted.tags ?? [],
+      })
+    )
+  }
+
+  return candidates
+}
+
+async function sourceToCandidatesFromSearch(args: {
+  city: PipelineCity
+  query: string
+  sourceName: string
+  site?: string
+}): Promise<DiscoveredEventCandidate[]> {
+  const results = await searchBraveWeb(args.query, { count: 10, site: args.site })
+  const candidates: DiscoveredEventCandidate[] = []
+
+  for (const result of results) {
+    const extracted = await extractEventFromText({
+      city: args.city,
+      sourceName: args.sourceName,
+      sourceUrl: result.url,
+      text: [result.title, result.description].join('\n'),
+      fallbackDate: extractFallbackDate(result),
+    })
+
+    const title = clampText(extracted.title ?? result.title, 200)
+    const startDate = parseDateText(extracted.start_date) ?? extractFallbackDate(result)
+    if (!extracted.isEvent || !title || !startDate) continue
+
+    candidates.push(
+      buildCandidate({
+        city: args.city,
+        sourceName: args.sourceName,
+        sourceUrl: result.url,
+        title,
+        description: extracted.description ?? result.description,
+        startDate,
+        endDate: parseDateText(extracted.end_date),
+        bookingUrl: extracted.booking_url ?? result.url,
+        imageUrl: extracted.image_url ?? null,
+        venueName: extracted.venue_name ?? null,
+        tags: extracted.tags ?? [],
+      })
+    )
+  }
+
+  return candidates
+}
+
+export function applyQualityThreshold(scored: Array<{
+  candidate: DiscoveredEventCandidate
+  score: number
+  tier: 'major' | 'medium' | 'local'
+}>): {
+  accepted: Array<{ candidate: DiscoveredEventCandidate; score: number; tier: 'major' | 'medium' | 'local' }>
+  rejected: Array<{ candidate: DiscoveredEventCandidate; score: number }>
+} {
+  const accepted: Array<{ candidate: DiscoveredEventCandidate; score: number; tier: 'major' | 'medium' | 'local' }> = []
+  const rejected: Array<{ candidate: DiscoveredEventCandidate; score: number }> = []
+
+  for (const item of scored) {
+    if (item.score >= 60) {
+      accepted.push(item)
+    } else {
+      rejected.push({ candidate: item.candidate, score: item.score })
+    }
+  }
+
+  return { accepted, rejected }
+}
+
+export async function runCityDiscovery(args: {
+  supabase: SupabaseClient
+  city: PipelineCity
+  dryRun?: boolean
+  now?: Date
+}): Promise<CityRunSummary> {
+  const now = args.now ?? new Date()
+  const runDate = isoDate(now)
+  const nowIso = now.toISOString()
+  const dryRun = Boolean(args.dryRun)
+
+  const [{ data: sourcesData, error: sourcesError }, { data: venuesData, error: venuesError }, { data: diariesData, error: diariesError }] =
+    await Promise.all([
+      args.supabase
+        .from('city_sources')
+        .select('id, city_id, source_type, name, url, language, scrape_frequency, status, consecutive_failures, last_scraped_at, last_event_count, discovered_via, notes')
+        .eq('city_id', args.city.id)
+        .order('created_at', { ascending: true }),
+      args.supabase
+        .from('tracked_venues')
+        .select('id, city_id, name, venue_type, tier')
+        .eq('city_id', args.city.id),
+      args.supabase
+        .from('event_pipeline_diary')
+        .select('run_date, diary_text, next_day_plan')
+        .eq('city_id', args.city.id)
+        .order('run_date', { ascending: false })
+        .limit(5),
+    ])
+
+  if (sourcesError) throw new Error(`Failed to load sources for ${args.city.slug}: ${sourcesError.message}`)
+  if (venuesError) throw new Error(`Failed to load venues for ${args.city.slug}: ${venuesError.message}`)
+  if (diariesError) throw new Error(`Failed to load diaries for ${args.city.slug}: ${diariesError.message}`)
+
+  const sources = (sourcesData ?? []) as PipelineSource[]
+  const venues = (venuesData ?? []) as PipelineVenue[]
+  const previousDiary = getPreviousDiary((diariesData ?? []) as DiaryRowLike[], runDate)
+  const adaptedPlan = adaptSearchPlan({
+    previousDiary,
+    sources,
+  })
+
+  const searchQueries = buildSearchQueries(args.city, now, adaptedPlan.queries)
+  const reports: DiscoverySourceResult[] = []
+  const rawCandidates: DiscoveredEventCandidate[] = []
+
+  for (const source of sources) {
+    const startedAt = Date.now()
+    if (shouldSkipSource(source) || adaptedPlan.sourcesToSkip.some((entry) => source.name.includes(entry) || source.url.includes(entry))) {
+      reports.push({
+        sourceId: source.id,
+        sourceName: source.name,
+        sourceUrl: source.url,
+        status: 'skipped',
+        eventsFound: 0,
+        durationMs: sourceDuration(startedAt),
+        errorMessage: null,
+      })
+      continue
+    }
+
+    if (source.source_type !== 'rss') continue
+
+    try {
+      const candidates = await sourceToCandidatesFromFeed({
+        city: args.city,
+        source,
+      })
+      rawCandidates.push(...candidates)
+      reports.push({
+        sourceId: source.id,
+        sourceName: source.name,
+        sourceUrl: source.url,
+        status: 'success',
+        eventsFound: candidates.length,
+        durationMs: sourceDuration(startedAt),
+        errorMessage: null,
+      })
+    } catch (error) {
+      reports.push({
+        sourceId: source.id,
+        sourceName: source.name,
+        sourceUrl: source.url,
+        status: 'error',
+        eventsFound: 0,
+        durationMs: sourceDuration(startedAt),
+        errorMessage: error instanceof Error ? error.message : 'Unknown RSS error',
+      })
+    }
+  }
+
+  const querySpecs: Array<{ sourceName: string; query: string; site?: string }> = [
+    ...searchQueries.map((query) => ({ sourceName: 'Brave Search', query })),
+    ...['eventbrite.com', 'bandsintown.com', 'songkick.com', 'musicfestivalwizard.com'].flatMap((site) =>
+      searchQueries.slice(0, 2).map((query) => ({
+        sourceName: site.replace('.com', ''),
+        query,
+        site,
+      }))
+    ),
+  ]
+
+  for (const spec of querySpecs) {
+    const startedAt = Date.now()
+    try {
+      const candidates = await sourceToCandidatesFromSearch({
+        city: args.city,
+        query: spec.query,
+        sourceName: spec.sourceName,
+        site: spec.site,
+      })
+      rawCandidates.push(...candidates)
+      reports.push({
+        sourceName: spec.sourceName,
+        sourceUrl: spec.site ? `https://${spec.site}` : null,
+        status: 'success',
+        eventsFound: candidates.length,
+        durationMs: sourceDuration(startedAt),
+        errorMessage: null,
+      })
+    } catch (error) {
+      reports.push({
+        sourceName: spec.sourceName,
+        sourceUrl: spec.site ? `https://${spec.site}` : null,
+        status: 'error',
+        eventsFound: 0,
+        durationMs: sourceDuration(startedAt),
+        errorMessage: error instanceof Error ? error.message : 'Unknown search error',
+      })
+    }
+  }
+
+  const { unique } = dedupeCandidates(rawCandidates)
+  const minExistingDate = isoDate(addDays(now, -30))
+  const maxExistingDate = isoDate(addDays(now, 120))
+  const { data: existingData, error: existingError } = await args.supabase
+    .from('city_events')
+    .select('id, city_id, title, venue_name, description, start_date, end_date, time_info, significance_score, source, source_url, image_url, booking_url, event_tier')
+    .eq('city_id', args.city.id)
+    .gte('start_date', minExistingDate)
+    .lte('start_date', maxExistingDate)
+
+  if (existingError) throw new Error(`Failed to load existing events for ${args.city.slug}: ${existingError.message}`)
+  const existingEvents = (existingData ?? []) as ExistingEventRecord[]
+  const scored: Array<{ candidate: DiscoveredEventCandidate; score: number; tier: 'major' | 'medium' | 'local' }> = []
+  let duplicateCount = rawCandidates.length - unique.length
+  let updated = 0
+
+  for (const candidate of unique) {
+    const match = findDuplicate(candidate, existingEvents)
+    if (match) {
+      duplicateCount += 1
+      if (choosePreferredEvent(candidate, match.existing) === 'candidate' && !dryRun) {
+        const venue = resolveVenue(candidate, venues)
+        const quality = await scoreEventQuality({
+          city: args.city,
+          candidate,
+          trackedVenue: venue,
+        })
+        if (quality.shouldInsert) {
+          const patch = {
+            title: candidate.title,
+            venue_name: candidate.venue_name,
+            venue_id: venue?.id ?? null,
+            venue_type: candidate.venue_type,
+            category: candidate.category,
+            description: candidate.description,
+            start_date: candidate.start_date,
+            end_date: candidate.end_date,
+            time_info: candidate.time_info,
+            significance_score: quality.score,
+            source: candidate.source,
+            source_url: candidate.source_url,
+            image_url: candidate.image_url,
+            price_info: candidate.price_info,
+            booking_url: candidate.booking_url,
+            tags: candidate.tags,
+            lineup: candidate.lineup,
+            event_tier: quality.tier,
+            last_verified_at: nowIso,
+            expires_at: isoDate(addDays(new Date(`${candidate.end_date ?? candidate.start_date}T00:00:00Z`), 1)),
+          }
+
+          const { error } = await args.supabase.from('city_events').update(patch).eq('id', match.existing.id)
+          if (!error) updated += 1
+        }
+      }
+      continue
+    }
+
+    const venue = resolveVenue(candidate, venues)
+    const quality = await scoreEventQuality({
+      city: args.city,
+      candidate,
+      trackedVenue: venue,
+    })
+    scored.push({
+      candidate,
+      score: quality.score,
+      tier: quality.tier,
+    })
+  }
+
+  const { accepted, rejected } = applyQualityThreshold(scored)
+  const rowsToInsert = accepted.map(({ candidate, score, tier }) => ({
+    city_id: args.city.id,
+    venue_id: resolveVenue(candidate, venues)?.id ?? null,
+    title: candidate.title,
+    venue_name: candidate.venue_name,
+    venue_type: candidate.venue_type,
+    category: candidate.category,
+    event_tier: tier,
+    description: candidate.description,
+    start_date: candidate.start_date,
+    end_date: candidate.end_date,
+    time_info: candidate.time_info,
+    significance_score: score,
+    source: candidate.source,
+    source_url: candidate.source_url,
+    image_url: candidate.image_url,
+    price_info: candidate.price_info,
+    booking_url: candidate.booking_url,
+    tags: candidate.tags,
+    lineup: candidate.lineup,
+    last_verified_at: nowIso,
+    expires_at: isoDate(addDays(new Date(`${candidate.end_date ?? candidate.start_date}T00:00:00Z`), 1)),
+  }))
+
+  if (!dryRun && rowsToInsert.length > 0) {
+    const { error } = await args.supabase.from('city_events').insert(rowsToInsert)
+    if (error) throw new Error(`Failed to insert events for ${args.city.slug}: ${error.message}`)
+  }
+
+  if (!dryRun) {
+    for (const source of sources) {
+      const report = reports.find((entry) => entry.sourceId === source.id)
+      if (!report) continue
+      const update = buildSourceUpdate(source, report, nowIso)
+      await args.supabase.from('city_sources').update(update.patch).eq('id', source.id)
+      await args.supabase.from('event_source_reports').insert(update.report)
+    }
+
+    const extraReports = reports.filter((report) => !report.sourceId)
+    if (extraReports.length > 0) {
+      await args.supabase.from('event_source_reports').insert(
+        extraReports.map((report) => ({
+          city_id: args.city.id,
+          source_name: report.sourceName,
+          source_url: report.sourceUrl,
+          run_date: runDate,
+          status: report.status,
+          events_found: report.eventsFound,
+          error_message: report.errorMessage,
+          duration_ms: report.durationMs,
+        }))
+      )
+    }
+  }
+
+  const sourceFailures = reports.filter((report) => report.status === 'error').map((report) => report.sourceName)
+  const sourceWins = reports.filter((report) => report.status === 'success' && report.eventsFound > 0).map((report) => report.sourceName)
+  const diary = await draftDiaryFromAi({
+    city: args.city,
+    previousDiaryText: previousDiary?.diary_text ?? null,
+    summary: {
+      sourcesChecked: reports.filter((report) => report.status !== 'skipped').length,
+      candidatesFound: rawCandidates.length,
+      duplicates: duplicateCount,
+      inserted: rowsToInsert.length,
+      belowThreshold: rejected.length,
+      sourceFailures,
+      sourceWins,
+    },
+  })
+
+  if (!dryRun) {
+    await args.supabase
+      .from('event_pipeline_diary')
+      .upsert({
+        city_id: args.city.id,
+        run_date: runDate,
+        diary_text: diary.diaryText,
+        run_metadata: {
+          sources_checked: reports.filter((report) => report.status !== 'skipped').length,
+          rss_count: reports.filter((report) => report.sourceId).length,
+          web_count: reports.filter((report) => !report.sourceId).length,
+          ai_count: scored.length,
+          events_found: rawCandidates.length,
+          duplicates: duplicateCount,
+          below_threshold: rejected.length,
+          new_events: rowsToInsert.length,
+          duplicate_rate: rawCandidates.length ? Number((duplicateCount / rawCandidates.length).toFixed(2)) : 0,
+        },
+        next_day_plan: diary.nextDayPlan,
+      })
+
+    await args.supabase
+      .from('tracked_cities')
+      .update({ last_refreshed_at: nowIso })
+      .eq('id', args.city.id)
+  }
+
+  return {
+    city: args.city,
+    dryRun,
+    sourcesChecked: reports.filter((report) => report.status !== 'skipped').length,
+    candidatesFound: rawCandidates.length,
+    duplicates: duplicateCount,
+    inserted: rowsToInsert.length,
+    updated,
+    belowThreshold: rejected.length,
+    reports,
+    diaryText: diary.diaryText,
+    nextDayPlan: diary.nextDayPlan,
+  }
+}

--- a/scripts/lib/discover-events-core.ts
+++ b/scripts/lib/discover-events-core.ts
@@ -367,7 +367,7 @@ export async function runCityDiscovery(args: {
     const match = findDuplicate(candidate, existingEvents)
     if (match) {
       duplicateCount += 1
-      if (choosePreferredEvent(candidate, match.existing) === 'candidate' && !dryRun) {
+      if (choosePreferredEvent(candidate, match.existing) === 'candidate') {
         const venue = resolveVenue(candidate, venues)
         const quality = await scoreEventQuality({
           city: args.city,
@@ -375,31 +375,36 @@ export async function runCityDiscovery(args: {
           trackedVenue: venue,
         })
         if (quality.shouldInsert) {
-          const patch = {
-            title: candidate.title,
-            venue_name: candidate.venue_name,
-            venue_id: venue?.id ?? null,
-            venue_type: candidate.venue_type,
-            category: candidate.category,
-            description: candidate.description,
-            start_date: candidate.start_date,
-            end_date: candidate.end_date,
-            time_info: candidate.time_info,
-            significance_score: quality.score,
-            source: candidate.source,
-            source_url: candidate.source_url,
-            image_url: candidate.image_url,
-            price_info: candidate.price_info,
-            booking_url: candidate.booking_url,
-            tags: candidate.tags,
-            lineup: candidate.lineup,
-            event_tier: quality.tier,
-            last_verified_at: nowIso,
-            expires_at: isoDate(addDays(new Date(`${candidate.end_date ?? candidate.start_date}T00:00:00Z`), 1)),
-          }
+          if (dryRun) {
+            // Dry-run: count what would have been updated without writing anything
+            updated += 1
+          } else {
+            const patch = {
+              title: candidate.title,
+              venue_name: candidate.venue_name,
+              venue_id: venue?.id ?? null,
+              venue_type: candidate.venue_type,
+              category: candidate.category,
+              description: candidate.description,
+              start_date: candidate.start_date,
+              end_date: candidate.end_date,
+              time_info: candidate.time_info,
+              significance_score: quality.score,
+              source: candidate.source,
+              source_url: candidate.source_url,
+              image_url: candidate.image_url,
+              price_info: candidate.price_info,
+              booking_url: candidate.booking_url,
+              tags: candidate.tags,
+              lineup: candidate.lineup,
+              event_tier: quality.tier,
+              last_verified_at: nowIso,
+              expires_at: isoDate(addDays(new Date(`${candidate.end_date ?? candidate.start_date}T00:00:00Z`), 1)),
+            }
 
-          const { error } = await args.supabase.from('city_events').update(patch).eq('id', match.existing.id)
-          if (!error) updated += 1
+            const { error } = await args.supabase.from('city_events').update(patch).eq('id', match.existing.id)
+            if (!error) updated += 1
+          }
         }
       }
       continue

--- a/scripts/lib/event-dedup.ts
+++ b/scripts/lib/event-dedup.ts
@@ -1,0 +1,153 @@
+import type { DiscoveredEventCandidate, ExistingEventRecord } from './types'
+
+export interface DuplicateMatch<TExisting> {
+  existing: TExisting
+  similarity: number
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\b(the|a|an|live|official|tour|show|event)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function levenshtein(left: string, right: string): number {
+  if (left === right) return 0
+  if (!left.length) return right.length
+  if (!right.length) return left.length
+
+  const rows = Array.from({ length: left.length + 1 }, () => new Array<number>(right.length + 1).fill(0))
+
+  for (let i = 0; i <= left.length; i += 1) rows[i][0] = i
+  for (let j = 0; j <= right.length; j += 1) rows[0][j] = j
+
+  for (let i = 1; i <= left.length; i += 1) {
+    for (let j = 1; j <= right.length; j += 1) {
+      const cost = left[i - 1] === right[j - 1] ? 0 : 1
+      rows[i][j] = Math.min(
+        rows[i - 1][j] + 1,
+        rows[i][j - 1] + 1,
+        rows[i - 1][j - 1] + cost
+      )
+    }
+  }
+
+  return rows[left.length][right.length]
+}
+
+function tokenOverlap(left: string, right: string): number {
+  const leftTokens = new Set(left.split(' ').filter(Boolean))
+  const rightTokens = new Set(right.split(' ').filter(Boolean))
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0
+
+  let overlap = 0
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) overlap += 1
+  }
+
+  return overlap / Math.max(leftTokens.size, rightTokens.size)
+}
+
+export function titleSimilarity(left: string, right: string): number {
+  const normalizedLeft = normalizeText(left)
+  const normalizedRight = normalizeText(right)
+  if (!normalizedLeft || !normalizedRight) return 0
+  if (normalizedLeft === normalizedRight) return 1
+
+  const lev = levenshtein(normalizedLeft, normalizedRight)
+  const levScore = 1 - lev / Math.max(normalizedLeft.length, normalizedRight.length)
+  const overlapScore = tokenOverlap(normalizedLeft, normalizedRight)
+  return Number((((levScore * 0.65) + (overlapScore * 0.35)) * 100).toFixed(2)) / 100
+}
+
+export function datesOverlap(
+  leftStart: string,
+  leftEnd: string | null | undefined,
+  rightStart: string,
+  rightEnd: string | null | undefined
+): boolean {
+  const leftFinal = leftEnd ?? leftStart
+  const rightFinal = rightEnd ?? rightStart
+  return !(leftFinal < rightStart || rightFinal < leftStart)
+}
+
+function sameVenue(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeText(left)
+  const normalizedRight = normalizeText(right)
+  if (!normalizedLeft || !normalizedRight) return true
+  return normalizedLeft === normalizedRight
+}
+
+function informationScore(event: Pick<
+  DiscoveredEventCandidate | ExistingEventRecord,
+  'description' | 'image_url' | 'booking_url' | 'time_info'
+>): number {
+  let score = 0
+  if (event.description) score += Math.min(event.description.length, 500)
+  if (event.image_url) score += 120
+  if (event.booking_url) score += 120
+  if (event.time_info) score += 40
+  return score
+}
+
+export function findDuplicate<TExisting extends Pick<
+  ExistingEventRecord,
+  'title' | 'venue_name' | 'start_date' | 'end_date'
+>>(
+  candidate: Pick<DiscoveredEventCandidate, 'title' | 'venue_name' | 'start_date' | 'end_date'>,
+  existingEvents: TExisting[]
+): DuplicateMatch<TExisting> | null {
+  let best: DuplicateMatch<TExisting> | null = null
+
+  for (const existing of existingEvents) {
+    const similarity = titleSimilarity(candidate.title, existing.title)
+    if (similarity < 0.8) continue
+    if (!datesOverlap(candidate.start_date, candidate.end_date, existing.start_date, existing.end_date)) continue
+    if (!sameVenue(candidate.venue_name, existing.venue_name)) continue
+    if (!best || similarity > best.similarity) {
+      best = { existing, similarity }
+    }
+  }
+
+  return best
+}
+
+export function choosePreferredEvent<TExisting extends ExistingEventRecord>(
+  candidate: DiscoveredEventCandidate,
+  existing: TExisting
+): 'candidate' | 'existing' {
+  return informationScore(candidate) > informationScore(existing) ? 'candidate' : 'existing'
+}
+
+export function dedupeCandidates(candidates: DiscoveredEventCandidate[]): {
+  unique: DiscoveredEventCandidate[]
+  duplicates: Array<{ kept: DiscoveredEventCandidate; skipped: DiscoveredEventCandidate }>
+} {
+  const unique: DiscoveredEventCandidate[] = []
+  const duplicates: Array<{ kept: DiscoveredEventCandidate; skipped: DiscoveredEventCandidate }> = []
+
+  for (const candidate of candidates) {
+    const match = findDuplicate(candidate, unique)
+    if (!match) {
+      unique.push(candidate)
+      continue
+    }
+
+    const keepCandidate = informationScore(candidate) > informationScore(match.existing)
+    if (keepCandidate) {
+      const index = unique.findIndex((event) => event === match.existing)
+      if (index >= 0) unique[index] = candidate
+      duplicates.push({ kept: candidate, skipped: match.existing })
+    } else {
+      duplicates.push({ kept: match.existing, skipped: candidate })
+    }
+  }
+
+  return { unique, duplicates }
+}

--- a/scripts/lib/pipeline-diary.ts
+++ b/scripts/lib/pipeline-diary.ts
@@ -1,0 +1,54 @@
+import type { DiaryPlan, PipelineSource } from './types'
+
+export interface DiaryRowLike {
+  run_date: string
+  diary_text: string
+  next_day_plan: unknown
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+export function getPreviousDiary<TDiary extends DiaryRowLike>(diaries: TDiary[], runDate: string): TDiary | null {
+  return [...diaries]
+    .filter((diary) => diary.run_date < runDate)
+    .sort((left, right) => right.run_date.localeCompare(left.run_date))[0] ?? null
+}
+
+export function adaptSearchPlan(args: {
+  previousDiary: DiaryRowLike | null
+  sources: Array<Pick<PipelineSource, 'name' | 'url' | 'status'>>
+}): DiaryPlan {
+  const base: DiaryPlan = {
+    summary: 'No previous diary. Start with balanced RSS, venue, and search coverage.',
+    queries: [],
+    sourcesToTry: [],
+    sourcesToSkip: [],
+  }
+
+  if (!args.previousDiary) return base
+
+  const rawPlan =
+    args.previousDiary.next_day_plan && typeof args.previousDiary.next_day_plan === 'object'
+      ? (args.previousDiary.next_day_plan as Record<string, unknown>)
+      : {}
+
+  const queries = toStringArray(rawPlan.queries)
+  const sourcesToTry = toStringArray(rawPlan.sourcesToTry)
+  const sourcesToSkip = toStringArray(rawPlan.sourcesToSkip)
+
+  const knownDormant = args.sources
+    .filter((source) => source.status === 'dormant')
+    .map((source) => source.name)
+
+  return {
+    summary:
+      typeof rawPlan.summary === 'string' && rawPlan.summary.trim()
+        ? rawPlan.summary
+        : args.previousDiary.diary_text,
+    queries,
+    sourcesToTry,
+    sourcesToSkip: Array.from(new Set([...sourcesToSkip, ...knownDormant])),
+  }
+}

--- a/scripts/lib/quality-scorer.ts
+++ b/scripts/lib/quality-scorer.ts
@@ -1,0 +1,324 @@
+import type { DiaryPlan, DiscoveredEventCandidate, PipelineCity, PipelineVenue, QualityAssessment } from './types'
+
+interface AiMessage {
+  role: 'system' | 'user'
+  content: string
+}
+
+async function importOptionalModule(moduleName: string): Promise<unknown | null> {
+  try {
+    return await new Function(`return import(${JSON.stringify(moduleName)})`)()
+  } catch {
+    return null
+  }
+}
+
+function extractJsonObject(payload: string): string {
+  const trimmed = payload.trim()
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return trimmed
+  const start = trimmed.indexOf('{')
+  const end = trimmed.lastIndexOf('}')
+  if (start >= 0 && end > start) return trimmed.slice(start, end + 1)
+  throw new Error('AI response did not contain a JSON object.')
+}
+
+async function generateJsonWithOpenAi<T>(messages: AiMessage[]): Promise<T> {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OPENAI_API_KEY is not configured.')
+
+  try {
+    const imported = await importOptionalModule('openai')
+    if (imported && typeof imported === 'object' && 'default' in imported) {
+      const OpenAI = (imported as { default: new (options: { apiKey: string }) => {
+        chat: {
+          completions: {
+            create: (payload: unknown) => Promise<{
+              choices?: Array<{ message?: { content?: string | null } }>
+            }>
+          }
+        }
+      } }).default
+
+      const client = new OpenAI({ apiKey })
+      const response = await client.chat.completions.create({
+        model: 'gpt-4o',
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+        messages,
+      })
+
+      const content = response.choices?.[0]?.message?.content
+      if (!content) throw new Error('OpenAI returned an empty response.')
+      return JSON.parse(extractJsonObject(content)) as T
+    }
+    throw new Error('OpenAI SDK is unavailable.')
+  } catch (error) {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+        messages,
+      }),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`OpenAI request failed: ${response.status} ${text || response.statusText}; ${String(error)}`)
+    }
+
+    const payload = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>
+    }
+    const content = payload.choices?.[0]?.message?.content
+    if (!content) throw new Error('OpenAI fallback returned an empty response.')
+    return JSON.parse(extractJsonObject(content)) as T
+  }
+}
+
+async function generateJsonWithGemini<T>(messages: AiMessage[]): Promise<T> {
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) throw new Error('GEMINI_API_KEY is not configured.')
+
+  const prompt = messages.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join('\n\n')
+
+  try {
+    const imported = await importOptionalModule('@google/generative-ai')
+    if (imported && typeof imported === 'object' && 'GoogleGenerativeAI' in imported) {
+      const GoogleGenerativeAI = (imported as {
+        GoogleGenerativeAI: new (key: string) => {
+          getGenerativeModel: (input: { model: string }) => {
+            generateContent: (prompt: string) => Promise<{ response: { text: () => string } }>
+          }
+        }
+      }).GoogleGenerativeAI
+
+      const client = new GoogleGenerativeAI(apiKey)
+      const model = client.getGenerativeModel({ model: 'gemini-1.5-pro' })
+      const response = await model.generateContent(`${prompt}\n\nReturn only valid JSON.`)
+      const text = response.response.text()
+      return JSON.parse(extractJsonObject(text)) as T
+    }
+    throw new Error('Gemini SDK is unavailable.')
+  } catch (error) {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: `${prompt}\n\nReturn only valid JSON.` }] }],
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Gemini request failed: ${response.status} ${text || response.statusText}; ${String(error)}`)
+    }
+
+    const payload = (await response.json()) as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    }
+    const text = payload.candidates?.[0]?.content?.parts?.map((part) => part.text ?? '').join('') ?? ''
+    if (!text) throw new Error('Gemini fallback returned an empty response.')
+    return JSON.parse(extractJsonObject(text)) as T
+  }
+}
+
+export async function generateJson<T>(messages: AiMessage[]): Promise<T> {
+  if (process.env.OPENAI_API_KEY) return generateJsonWithOpenAi<T>(messages)
+  if (process.env.GEMINI_API_KEY) return generateJsonWithGemini<T>(messages)
+  throw new Error('Neither OPENAI_API_KEY nor GEMINI_API_KEY is configured.')
+}
+
+function heuristicScore(candidate: DiscoveredEventCandidate, trackedVenue: PipelineVenue | null): QualityAssessment {
+  const text = `${candidate.title} ${candidate.description ?? ''}`.toLowerCase()
+  let score = trackedVenue?.tier ?? 45
+
+  if (candidate.category === 'festival') score += 18
+  if (candidate.category === 'art') score += 12
+  if (candidate.category === 'music') score += 8
+  if (candidate.image_url) score += 5
+  if (candidate.booking_url) score += 5
+  if (/\b(retrospective|biennale|festival|orchestra|museum|philharmonic|fashion week)\b/.test(text)) score += 20
+  if (/\b(open mic|meetup|networking|karaoke|weekly|every week)\b/.test(text)) score -= 35
+  if (candidate.source?.match(/eventbrite|songkick|bandsintown|timeout|visit/i)) score += 8
+
+  const bounded = Math.max(0, Math.min(100, score))
+  return {
+    score: bounded,
+    tier: bounded >= 80 ? 'major' : bounded >= 60 ? 'medium' : 'local',
+    reasoning: 'Heuristic fallback used because no AI response was available.',
+    shouldInsert: bounded >= 60,
+  }
+}
+
+export async function scoreEventQuality(args: {
+  city: PipelineCity
+  candidate: DiscoveredEventCandidate
+  trackedVenue: PipelineVenue | null
+}): Promise<QualityAssessment> {
+  const fallback = heuristicScore(args.candidate, args.trackedVenue)
+
+  try {
+    const result = await generateJson<{
+      score: number
+      tier: 'major' | 'medium' | 'local'
+      reasoning: string
+    }>([
+      {
+        role: 'system',
+        content:
+          'You score travel-worthy city events. Return only JSON with score (0-100), tier (major|medium|local), and reasoning.',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          city: `${args.city.city}, ${args.city.country}`,
+          candidate: args.candidate,
+          trackedVenueTier: args.trackedVenue?.tier ?? null,
+          rubric: [
+            'Would a well-traveled person be disappointed to miss this?',
+            'Venue significance matters.',
+            'Performer recognition matters.',
+            'Uniqueness and cultural importance matter.',
+            'Multi-day or large-scale events score higher.',
+            'Events below 60 should be rejected.',
+          ],
+        }),
+      },
+    ])
+
+    const score = Math.max(0, Math.min(100, Math.round(result.score)))
+    const tier = score >= 80 ? 'major' : score >= 60 ? 'medium' : 'local'
+    return {
+      score,
+      tier,
+      reasoning: result.reasoning,
+      shouldInsert: score >= 60,
+    }
+  } catch {
+    return fallback
+  }
+}
+
+export async function extractEventFromText(args: {
+  city: PipelineCity
+  sourceName: string
+  sourceUrl: string | null
+  text: string
+  fallbackDate: string | null
+}): Promise<Partial<DiscoveredEventCandidate> & { isEvent: boolean }> {
+  const normalizedText = args.text.trim()
+  if (!normalizedText) return { isEvent: false }
+
+  try {
+    return await generateJson<Partial<DiscoveredEventCandidate> & { isEvent: boolean }>([
+      {
+        role: 'system',
+        content:
+          'Extract one event from the input. Return only JSON. If the input is not a specific event, set isEvent to false. Dates must be YYYY-MM-DD. category must be one of art,music,theater,food,festival,sports,architecture,sacred,market,other.',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          city: `${args.city.city}, ${args.city.country}`,
+          sourceName: args.sourceName,
+          sourceUrl: args.sourceUrl,
+          fallbackDate: args.fallbackDate,
+          text: normalizedText.slice(0, 6000),
+        }),
+      },
+    ])
+  } catch {
+    const lines = normalizedText.split(/\n+/).map((line) => line.trim()).filter(Boolean)
+    const title = lines[0]?.slice(0, 180) ?? ''
+    if (!title) return { isEvent: false }
+
+    return {
+      isEvent: true,
+      title,
+      description: lines.slice(1).join(' ').slice(0, 600),
+      start_date: args.fallbackDate ?? undefined,
+      end_date: args.fallbackDate ?? undefined,
+      category: /museum|gallery|exhibit|expo/i.test(normalizedText)
+        ? 'art'
+        : /concert|orchestra|jazz|music/i.test(normalizedText)
+          ? 'music'
+          : /festival/i.test(normalizedText)
+            ? 'festival'
+            : 'other',
+      venue_name: null,
+      venue_type: null,
+      time_info: null,
+      image_url: null,
+      price_info: null,
+      booking_url: args.sourceUrl,
+      tags: [],
+      lineup: null,
+      source: args.sourceName,
+      source_url: args.sourceUrl,
+    }
+  }
+}
+
+export async function draftDiaryFromAi(input: {
+  city: PipelineCity
+  previousDiaryText: string | null
+  summary: {
+    sourcesChecked: number
+    candidatesFound: number
+    duplicates: number
+    inserted: number
+    belowThreshold: number
+    sourceFailures: string[]
+    sourceWins: string[]
+  }
+}): Promise<{ diaryText: string; nextDayPlan: DiaryPlan }> {
+  const fallback: { diaryText: string; nextDayPlan: DiaryPlan } = {
+    diaryText: `${input.city.city}: checked ${input.summary.sourcesChecked} sources, found ${input.summary.candidatesFound} candidates, inserted ${input.summary.inserted}, skipped ${input.summary.duplicates} duplicates, and filtered ${input.summary.belowThreshold} low-quality items.`,
+    nextDayPlan: {
+      summary: `Keep strong sources, retry weak coverage gaps tomorrow in ${input.city.city}.`,
+      queries: [],
+      sourcesToTry: [],
+      sourcesToSkip: input.summary.sourceFailures,
+    },
+  }
+
+  try {
+    const result = await generateJson<{
+      diaryText: string
+      nextDayPlan: DiaryPlan
+    }>([
+      {
+        role: 'system',
+        content:
+          'You write concise event-pipeline diary entries. Return JSON with diaryText and nextDayPlan {summary, queries, sourcesToTry, sourcesToSkip}.',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(input),
+      },
+    ])
+
+    return {
+      diaryText: result.diaryText,
+      nextDayPlan: {
+        summary: result.nextDayPlan?.summary ?? fallback.nextDayPlan.summary,
+        queries: result.nextDayPlan?.queries ?? [],
+        sourcesToTry: result.nextDayPlan?.sourcesToTry ?? [],
+        sourcesToSkip: result.nextDayPlan?.sourcesToSkip ?? [],
+      },
+    }
+  } catch {
+    return fallback
+  }
+}

--- a/scripts/lib/rss-fetcher.ts
+++ b/scripts/lib/rss-fetcher.ts
@@ -1,5 +1,40 @@
 import type { FeedItem } from './types'
 
+/**
+ * Validate that a URL is safe to fetch: must be https and must resolve to a
+ * public hostname (not loopback/RFC-1918/metadata ranges).
+ * Throws if the URL is not acceptable.
+ */
+function assertSafeUrl(url: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Invalid URL: ${url}`)
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Unsafe URL scheme "${parsed.protocol}" — only https:// is allowed: ${url}`)
+  }
+  const host = parsed.hostname.toLowerCase()
+  // Block loopback, link-local, and cloud metadata endpoints
+  const blocked = [
+    /^localhost$/,
+    /^127\./,
+    /^::1$/,
+    /^0\.0\.0\.0$/,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,   // link-local / AWS metadata
+    /^fd[0-9a-f]{2}:/i, // ULA IPv6
+  ]
+  for (const pattern of blocked) {
+    if (pattern.test(host)) {
+      throw new Error(`Blocked private/metadata host: ${host}`)
+    }
+  }
+}
+
 interface ParsedFeedLike {
   items?: Array<Record<string, unknown>>
 }
@@ -67,6 +102,8 @@ function parseXmlItems(xml: string): FeedItem[] {
 }
 
 async function parseWithDependency(url: string): Promise<FeedItem[] | null> {
+  // URL safety already validated by the public callers; assert here as defence-in-depth.
+  assertSafeUrl(url)
   try {
     const imported = await importOptionalModule('rss-parser')
     if (!imported || typeof imported !== 'object' || !('default' in imported)) return null
@@ -100,6 +137,8 @@ async function parseWithDependency(url: string): Promise<FeedItem[] | null> {
 }
 
 export async function fetchFeedItems(url: string): Promise<FeedItem[]> {
+  assertSafeUrl(url)
+
   const parsed = await parseWithDependency(url)
   if (parsed) return parsed
 
@@ -119,6 +158,8 @@ export async function fetchFeedItems(url: string): Promise<FeedItem[]> {
 }
 
 export async function discoverFeedsFromPage(url: string): Promise<string[]> {
+  assertSafeUrl(url)
+
   const response = await fetch(url, {
     headers: {
       Accept: 'text/html,application/xhtml+xml',

--- a/scripts/lib/rss-fetcher.ts
+++ b/scripts/lib/rss-fetcher.ts
@@ -1,0 +1,146 @@
+import type { FeedItem } from './types'
+
+interface ParsedFeedLike {
+  items?: Array<Record<string, unknown>>
+}
+
+async function importOptionalModule(moduleName: string): Promise<unknown | null> {
+  try {
+    return await new Function(`return import(${JSON.stringify(moduleName)})`)()
+  } catch {
+    return null
+  }
+}
+
+function stripHtml(value: string): string {
+  return value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function absolutizeUrl(baseUrl: string, maybeRelative: string): string {
+  try {
+    return new URL(maybeRelative, baseUrl).toString()
+  } catch {
+    return maybeRelative
+  }
+}
+
+function matchFirst(value: string, pattern: RegExp): string | null {
+  const match = value.match(pattern)
+  return match?.[1]?.trim() ?? null
+}
+
+function parseXmlItems(xml: string): FeedItem[] {
+  const blocks = xml.match(/<(item|entry)\b[\s\S]*?<\/(item|entry)>/gi) ?? []
+
+  return blocks
+    .map((block) => {
+      const title = stripHtml(matchFirst(block, /<title[^>]*>([\s\S]*?)<\/title>/i) ?? '')
+      if (!title) return null
+
+      const link =
+        matchFirst(block, /<link[^>]*href="([^"]+)"[^>]*\/?>/i) ??
+        matchFirst(block, /<link[^>]*>([\s\S]*?)<\/link>/i)
+      const summary =
+        stripHtml(matchFirst(block, /<description[^>]*>([\s\S]*?)<\/description>/i) ?? '') ||
+        stripHtml(matchFirst(block, /<summary[^>]*>([\s\S]*?)<\/summary>/i) ?? '') ||
+        stripHtml(matchFirst(block, /<content:encoded[^>]*>([\s\S]*?)<\/content:encoded>/i) ?? '')
+      const content = stripHtml(matchFirst(block, /<content[^>]*>([\s\S]*?)<\/content>/i) ?? summary)
+      const publishedAt =
+        matchFirst(block, /<pubDate[^>]*>([\s\S]*?)<\/pubDate>/i) ??
+        matchFirst(block, /<published[^>]*>([\s\S]*?)<\/published>/i) ??
+        matchFirst(block, /<updated[^>]*>([\s\S]*?)<\/updated>/i) ??
+        null
+      const imageUrl =
+        matchFirst(block, /<media:content[^>]*url="([^"]+)"/i) ??
+        matchFirst(block, /<enclosure[^>]*url="([^"]+)"/i)
+
+      return {
+        title,
+        link,
+        summary,
+        content,
+        publishedAt,
+        imageUrl,
+      } satisfies FeedItem
+    })
+    .filter((item): item is FeedItem => Boolean(item))
+}
+
+async function parseWithDependency(url: string): Promise<FeedItem[] | null> {
+  try {
+    const imported = await importOptionalModule('rss-parser')
+    if (!imported || typeof imported !== 'object' || !('default' in imported)) return null
+
+    const ParserCtor = (imported as {
+      default: new () => {
+        parseURL: (feedUrl: string) => Promise<ParsedFeedLike>
+      }
+    }).default
+    const parser = new ParserCtor()
+    const parsed = (await parser.parseURL(url)) as ParsedFeedLike
+    return (parsed.items ?? [])
+      .map((item) => {
+        const title = String(item.title ?? '').trim()
+        if (!title) return null
+        const enclosure =
+          item.enclosure && typeof item.enclosure === 'object' ? (item.enclosure as { url?: unknown }) : null
+        return {
+          title,
+          link: typeof item.link === 'string' ? item.link : null,
+          summary: stripHtml(String(item.contentSnippet ?? item.summary ?? '')),
+          content: stripHtml(String(item['content:encoded'] ?? item.content ?? item.summary ?? '')),
+          publishedAt: typeof item.isoDate === 'string' ? item.isoDate : typeof item.pubDate === 'string' ? item.pubDate : null,
+          imageUrl: typeof enclosure?.url === 'string' ? enclosure.url : null,
+        } satisfies FeedItem
+      })
+      .filter((item): item is FeedItem => Boolean(item))
+  } catch {
+    return null
+  }
+}
+
+export async function fetchFeedItems(url: string): Promise<FeedItem[]> {
+  const parsed = await parseWithDependency(url)
+  if (parsed) return parsed
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml',
+      'User-Agent': 'ubtrippin-event-pipeline/1.0',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Feed request failed: ${response.status} ${response.statusText}`)
+  }
+
+  const xml = await response.text()
+  return parseXmlItems(xml)
+}
+
+export async function discoverFeedsFromPage(url: string): Promise<string[]> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'text/html,application/xhtml+xml',
+      'User-Agent': 'ubtrippin-event-pipeline/1.0',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Page request failed: ${response.status} ${response.statusText}`)
+  }
+
+  const html = await response.text()
+  const matches = Array.from(
+    html.matchAll(/<link[^>]+rel=["'][^"']*alternate[^"']*["'][^>]+type=["']application\/(rss\+xml|atom\+xml|xml)["'][^>]+href=["']([^"']+)["'][^>]*>/gi)
+  )
+
+  return Array.from(
+    new Set(
+      matches
+        .map((match) => match[2])
+        .filter(Boolean)
+        .map((href) => absolutizeUrl(url, href))
+    )
+  )
+}

--- a/scripts/lib/source-tracker.ts
+++ b/scripts/lib/source-tracker.ts
@@ -1,0 +1,50 @@
+import type { DiscoverySourceResult, PipelineSource } from './types'
+
+export function shouldSkipSource(source: Pick<PipelineSource, 'status' | 'consecutive_failures'>): boolean {
+  return source.status === 'dormant' || (source.consecutive_failures ?? 0) >= 10
+}
+
+export function buildSourceUpdate(
+  source: PipelineSource,
+  result: DiscoverySourceResult,
+  nowIso: string
+): {
+  patch: {
+    consecutive_failures: number
+    last_scraped_at: string
+    last_event_count: number
+    status: string
+  }
+  report: {
+    city_id: string
+    source_name: string
+    source_url: string | null
+    run_date: string
+    status: string
+    events_found: number
+    error_message: string | null
+    duration_ms: number
+  }
+} {
+  const nextFailures = result.status === 'error' ? (source.consecutive_failures ?? 0) + 1 : 0
+  const status = nextFailures >= 10 ? 'dormant' : result.status === 'success' ? 'active' : source.status ?? 'candidate'
+
+  return {
+    patch: {
+      consecutive_failures: nextFailures,
+      last_scraped_at: nowIso,
+      last_event_count: result.eventsFound,
+      status,
+    },
+    report: {
+      city_id: source.city_id,
+      source_name: result.sourceName,
+      source_url: result.sourceUrl,
+      run_date: nowIso.slice(0, 10),
+      status: result.status,
+      events_found: result.eventsFound,
+      error_message: result.errorMessage,
+      duration_ms: result.durationMs,
+    },
+  }
+}

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -1,0 +1,132 @@
+import type { EventCategory, EventTier, VenueType } from '@/types/events'
+
+export interface PipelineCity {
+  id: string
+  city: string
+  country: string
+  country_code: string | null
+  slug: string
+  timezone: string | null
+  last_refreshed_at: string | null
+}
+
+export interface PipelineVenue {
+  id: string
+  city_id: string
+  name: string
+  venue_type: string | null
+  tier: number | null
+}
+
+export interface PipelineSource {
+  id: string
+  city_id: string
+  source_type: string | null
+  name: string
+  url: string
+  language: string | null
+  scrape_frequency: string | null
+  status: string | null
+  consecutive_failures: number | null
+  last_scraped_at: string | null
+  last_event_count: number | null
+  discovered_via: string | null
+  notes: string | null
+}
+
+export interface ExistingEventRecord {
+  id: string
+  city_id: string
+  title: string
+  venue_name: string | null
+  description: string | null
+  start_date: string
+  end_date: string | null
+  time_info: string | null
+  significance_score: number | null
+  source: string | null
+  source_url: string | null
+  image_url: string | null
+  booking_url: string | null
+  event_tier: string
+}
+
+export interface SearchResult {
+  title: string
+  url: string
+  description: string
+  pageAge: string | null
+  sourceName: string | null
+  language: string | null
+}
+
+export interface FeedItem {
+  title: string
+  link: string | null
+  summary: string
+  content: string
+  publishedAt: string | null
+  imageUrl: string | null
+}
+
+export interface DiscoveredEventCandidate {
+  city_id: string
+  title: string
+  venue_name: string | null
+  venue_id?: string | null
+  venue_type: VenueType | null
+  category: EventCategory
+  description: string | null
+  start_date: string
+  end_date: string | null
+  time_info: string | null
+  significance_score?: number
+  source: string | null
+  source_url: string | null
+  image_url: string | null
+  price_info: string | null
+  booking_url: string | null
+  tags: string[]
+  lineup: Array<{ name: string; url?: string }> | null
+  event_tier?: EventTier
+  last_verified_at?: string | null
+  expires_at?: string | null
+}
+
+export interface QualityAssessment {
+  score: number
+  tier: EventTier
+  reasoning: string
+  shouldInsert: boolean
+}
+
+export interface DiaryPlan {
+  summary: string
+  queries: string[]
+  sourcesToTry: string[]
+  sourcesToSkip: string[]
+}
+
+export interface DiscoverySourceResult {
+  sourceName: string
+  sourceUrl: string | null
+  status: 'success' | 'error' | 'skipped'
+  eventsFound: number
+  durationMs: number
+  errorMessage: string | null
+  sourceId?: string
+}
+
+export interface CityRunSummary {
+  city: PipelineCity
+  dryRun: boolean
+  sourcesChecked: number
+  candidatesFound: number
+  duplicates: number
+  inserted: number
+  updated: number
+  belowThreshold: number
+  reports: DiscoverySourceResult[]
+  diaryText: string
+  nextDayPlan: DiaryPlan
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -637,6 +637,41 @@ GET /api/v1/events?city=paris&tier=major&category=art
 - Rate-limited: 10 requests/minute per IP
 - Events are curated by the UB Trippin editorial pipeline — not real-time scraped
 
+#### Trigger Event Pipeline Refresh (Admin Only)
+```
+POST /api/v1/events/refresh
+```
+
+Triggers an asynchronous re-discovery run for a given city. Spawns the event pipeline in the background and returns immediately. Only users whose email is listed in `EVENT_PIPELINE_ADMIN_EMAILS` (server env var) are permitted.
+
+**Request body:**
+```json
+{ "citySlug": "paris" }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| citySlug | string | ✅ | City slug to refresh (e.g. `paris`, `new-york`). Must match `^[a-z0-9-]+$`. |
+
+**Response (202 Accepted):**
+```json
+{ "ok": true, "queued": true, "citySlug": "paris" }
+```
+
+**Errors:**
+
+| Status | Code | Meaning |
+|--------|------|---------|
+| 400 | `invalid_request` | `citySlug` missing or not a valid slug |
+| 403 | `forbidden` | Caller's email not in the admin allowlist |
+| 500 | `server_misconfigured` | `EVENT_PIPELINE_ADMIN_EMAILS` env var not set |
+| 500 | `launch_failed` | Pipeline process failed to start |
+
+**Notes:**
+- Requires session auth (Bearer token) — this is **not** a public endpoint
+- The pipeline runs asynchronously; poll `GET /api/v1/events?city=<slug>` to see updated results
+- Admin allowlist is set via the `EVENT_PIPELINE_ADMIN_EMAILS` environment variable (comma-separated emails)
+
 ---
 
 ### City Guides

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -431,7 +431,8 @@ Discover curated events, exhibitions, festivals, and performances by city. No au
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | /api/v1/events | Get events for a city |
+| GET | /api/v1/events | Get events for a city (public, no auth) |
+| POST | /api/v1/events/refresh | Trigger pipeline refresh for a city (admin only) |
 
 ### Query Parameters
 
@@ -468,6 +469,25 @@ GET /api/v1/events?city=paris&from=2026-04-01&to=2026-04-07
 \`\`\`
 
 Rate limit: 10 req/min per IP (no auth required).
+
+### POST /api/v1/events/refresh (Admin Only)
+
+Triggers an asynchronous event re-discovery run for a given city. Returns 202 immediately; pipeline runs in background.
+
+\`\`\`
+POST /api/v1/events/refresh
+Authorization: Bearer ubt_k1_abc123...
+Content-Type: application/json
+
+{ "citySlug": "paris" }
+
+202 Accepted
+{ "ok": true, "queued": true, "citySlug": "paris" }
+\`\`\`
+
+**Errors:** 400 (invalid slug), 403 (not in admin allowlist), 500 (misconfigured / launch failed).
+
+Admin allowlist is set via the \`EVENT_PIPELINE_ADMIN_EMAILS\` environment variable (comma-separated).
 
 ---
 

--- a/src/app/api/v1/events/refresh/route.ts
+++ b/src/app/api/v1/events/refresh/route.ts
@@ -1,0 +1,96 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { NextRequest, NextResponse } from 'next/server'
+import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function getAllowedAdminEmails(): Set<string> {
+  const raw = process.env.EVENT_PIPELINE_ADMIN_EMAILS ?? process.env.ADMIN_EMAILS ?? ''
+  return new Set(
+    raw
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean)
+  )
+}
+
+function launchRefresh(citySlug: string) {
+  const repoRoot = process.cwd()
+  const tsxBin = path.join(repoRoot, 'node_modules', '.bin', 'tsx')
+  const args = [path.join(repoRoot, 'scripts', 'discover-events.ts'), '--city', citySlug]
+  const child = existsSync(tsxBin)
+    ? spawn(tsxBin, args, {
+        cwd: repoRoot,
+        detached: true,
+        stdio: 'ignore',
+        env: process.env,
+      })
+    : spawn(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['tsx', ...args], {
+        cwd: repoRoot,
+        detached: true,
+        stdio: 'ignore',
+        env: process.env,
+      })
+  child.unref()
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  const allowedEmails = getAllowedAdminEmails()
+  if (allowedEmails.size === 0) {
+    return NextResponse.json(
+      { error: { code: 'server_misconfigured', message: 'EVENT_PIPELINE_ADMIN_EMAILS is not configured.' } },
+      { status: 500 }
+    )
+  }
+
+  const { data: profile, error: profileError } = await auth.supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', auth.userId)
+    .maybeSingle()
+
+  if (profileError) {
+    return NextResponse.json(
+      { error: { code: 'profile_lookup_failed', message: profileError.message } },
+      { status: 500 }
+    )
+  }
+
+  const email = profile?.email?.toLowerCase().trim()
+  if (!email || !allowedEmails.has(email)) {
+    return NextResponse.json(
+      { error: { code: 'forbidden', message: 'Only event pipeline admins can trigger a refresh.' } },
+      { status: 403 }
+    )
+  }
+
+  const body = (await request.json().catch(() => null)) as { citySlug?: string } | null
+  const citySlug = body?.citySlug?.trim()
+  if (!citySlug || !/^[a-z0-9-]+$/.test(citySlug)) {
+    return NextResponse.json(
+      { error: { code: 'invalid_request', message: 'citySlug is required and must be a slug.' } },
+      { status: 400 }
+    )
+  }
+
+  try {
+    launchRefresh(citySlug)
+    return NextResponse.json({
+      ok: true,
+      queued: true,
+      citySlug,
+    }, { status: 202 })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to launch refresh.'
+    return NextResponse.json(
+      { error: { code: 'launch_failed', message } },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/v1/events/refresh/route.ts
+++ b/src/app/api/v1/events/refresh/route.ts
@@ -17,22 +17,48 @@ function getAllowedAdminEmails(): Set<string> {
   )
 }
 
+/**
+ * Build a minimal env for the discovery script — only the vars it actually needs.
+ * Never forward the full process.env to avoid leaking secrets the script doesn't use.
+ */
+function buildScriptEnv(): Record<string, string | undefined> {
+  const pick = (key: string): string | undefined => process.env[key]
+  return {
+    // Runtime essentials
+    PATH: pick('PATH'),
+    NODE_PATH: pick('NODE_PATH'),
+    HOME: pick('HOME'),
+    // Supabase (createSecretClient)
+    NEXT_PUBLIC_SUPABASE_URL: pick('NEXT_PUBLIC_SUPABASE_URL'),
+    SUPABASE_SECRET_KEY: pick('SUPABASE_SECRET_KEY'),
+    // AI quality scoring
+    OPENAI_API_KEY: pick('OPENAI_API_KEY'),
+    GEMINI_API_KEY: pick('GEMINI_API_KEY'),
+    // Web search
+    BRAVE_SEARCH_API_KEY: pick('BRAVE_SEARCH_API_KEY'),
+    BRAVE_API_KEY: pick('BRAVE_API_KEY'),
+  }
+}
+
 function launchRefresh(citySlug: string) {
   const repoRoot = process.cwd()
   const tsxBin = path.join(repoRoot, 'node_modules', '.bin', 'tsx')
   const args = [path.join(repoRoot, 'scripts', 'discover-events.ts'), '--city', citySlug]
+  // Cast required: spawn's env type demands ProcessEnv but we intentionally omit most vars.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const scriptEnv = buildScriptEnv() as any
   const child = existsSync(tsxBin)
     ? spawn(tsxBin, args, {
         cwd: repoRoot,
         detached: true,
         stdio: 'ignore',
-        env: process.env,
+        env: scriptEnv,
       })
     : spawn(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['tsx', ...args], {
         cwd: repoRoot,
         detached: true,
         stdio: 'ignore',
-        env: process.env,
+        env: scriptEnv,
       })
   child.unref()
 }
@@ -49,20 +75,18 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const { data: profile, error: profileError } = await auth.supabase
-    .from('profiles')
-    .select('email')
-    .eq('id', auth.userId)
-    .maybeSingle()
+  // Use the JWT/session email — not the user-writable profiles table — to prevent
+  // privilege escalation via a crafted profiles.email value.
+  const { data: { user }, error: userError } = await auth.supabase.auth.getUser()
 
-  if (profileError) {
+  if (userError || !user) {
     return NextResponse.json(
-      { error: { code: 'profile_lookup_failed', message: profileError.message } },
+      { error: { code: 'session_lookup_failed', message: userError?.message ?? 'Could not resolve authenticated user.' } },
       { status: 500 }
     )
   }
 
-  const email = profile?.email?.toLowerCase().trim()
+  const email = user.email?.toLowerCase().trim()
   if (!email || !allowedEmails.has(email)) {
     return NextResponse.json(
       { error: { code: 'forbidden', message: 'Only event pipeline admins can trigger a refresh.' } },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      include: ['src/lib/**/*.ts'],
+      include: ['src/lib/**/*.ts', 'scripts/lib/**/*.ts'],
       exclude: ['src/lib/supabase/**'],
     },
   },


### PR DESCRIPTION
## Summary

Implements the event discovery pipeline for PRD-023 Phase 2.

## Changes

- **Discovery core** (`scripts/lib/discover-events-core.ts`): Main pipeline orchestrating source fetching, deduplication, quality scoring, and persistence
- **Brave Search integration** (`scripts/lib/brave-search.ts`): Web search adapter for event discovery
- **RSS fetcher** (`scripts/lib/rss-fetcher.ts`): RSS/Atom feed ingestion for event sources
- **Event deduplication** (`scripts/lib/event-dedup.ts`): Fingerprint-based dedup to avoid duplicate events
- **Quality scorer** (`scripts/lib/quality-scorer.ts`): Ranks events by relevance, completeness, and source reliability
- **Source tracker** (`scripts/lib/source-tracker.ts`): Tracks discovery sources and their health
- **Pipeline diary** (`scripts/lib/pipeline-diary.ts`): Logging/audit trail for pipeline runs
- **CLI scripts**: `discover-events.ts` and `discover-sources.ts` for manual runs
- **Manual refresh API** (`src/app/api/v1/events/refresh/route.ts`): POST endpoint to trigger pipeline refresh
- **Tests**: 185 lines of tests covering discovery and dedup logic

## Test Coverage

- `scripts/__tests__/discover-events.test.ts` — pipeline integration tests
- `scripts/__tests__/event-dedup.test.ts` — deduplication unit tests

## Notes

- Uses generic test data (no real user PII in tests)
- All API keys sourced from environment variables