### PR TITLE
fix: sort city page events chronologically within each tier

### DIFF
--- a/src/lib/events/queries.ts
+++ b/src/lib/events/queries.ts
@@ -109,11 +109,13 @@ function toEvent(row: EventRow): CityEvent {
 
 function sortEvents(events: CityEvent[]): CityEvent[] {
   return [...events].sort((left, right) => {
+    // Chronological first — tonight to future
+    const dateDelta = left.start_date.localeCompare(right.start_date)
+    if (dateDelta !== 0) return dateDelta
+    // Within same date: tier then score
     const tierDelta = tierOrder[left.event_tier] - tierOrder[right.event_tier]
     if (tierDelta !== 0) return tierDelta
-    const scoreDelta = right.significance_score - left.significance_score
-    if (scoreDelta !== 0) return scoreDelta
-    return left.start_date.localeCompare(right.start_date)
+    return right.significance_score - left.significance_score
   })
 }
 


### PR DESCRIPTION
Events were sorted by tier → score → date, causing dates to jump around within sections. Now sorted date → tier → score within each tier section (Major Events, Worth Planning Around, Local Finds).

One-line change in `sortEvents()` — date comparison moved to primary sort key.

143 tests pass, TypeScript clean.