### PR TITLE
fix: auto-refresh flight status on first load

### DIFF
--- a/src/components/trips/item-status-badge.tsx
+++ b/src/components/trips/item-status-badge.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { RefreshCw } from 'lucide-react'
 
@@ -174,8 +174,27 @@ export function ItemStatusBadge({ itemId, scheduledDeparture, startTs, onStatusU
     return () => clearInterval(timer)
   }, [loadStatus])
 
+  // Auto-refresh when there's no cached status — this creates the initial
+  // FlightAware lookup. Without this, the badge never appears because
+  // there's no cached row yet and the refresh button isn't visible.
+  const hasTriggeredAutoRefresh = useRef(false)
+  useEffect(() => {
+    if (!loading && !status && !hasTriggeredAutoRefresh.current) {
+      hasTriggeredAutoRefresh.current = true
+      void refreshStatus()
+    }
+  }, [loading, status, refreshStatus])
+
   // Don't show badge until we have actual status data from FlightAware
-  // (FlightAware only allows queries within 48h of departure)
+  if (loading || refreshing) {
+    return (
+      <div className="mt-2 flex items-center gap-1.5 text-xs text-slate-400">
+        <RefreshCw className="h-3 w-3 animate-spin" />
+        Checking flight status…
+      </div>
+    )
+  }
+
   if (!status || status.status === 'unknown') {
     return null
   }


### PR DESCRIPTION
## The Bug

Flight status badges never appeared because of a chicken-and-egg problem:

1. `ItemStatusBadge` only renders when cached status exists in `trip_item_status`
2. The refresh button (which creates cached status via FlightAware) is inside the badge
3. Badge doesn't render → no refresh button → no FlightAware query → no cached status → badge doesn't render

Flights within 48 hours showed no delay/gate/terminal info even when FlightAware had live data.

## The Fix

When `loadStatus()` returns no cached row, automatically trigger `refreshStatus()` once (guarded by `useRef` to prevent loops). Shows a 'Checking flight status…' spinner while the FlightAware API call runs. After that, the badge renders normally with delay/gate/terminal info and auto-polls every 2 minutes.

## Testing

- 150 tests pass, TypeScript clean
- Verified: Spirit 2893 MIA→EWR today shows 62-min delay via FlightAware AeroAPI (est. departure 1:54 PM, gate F3, arriving B45 Terminal B)