### PR TITLE
feat: public avg response time stat on feedback page

### DIFF
--- a/src/app/(dashboard)/feedback/page.tsx
+++ b/src/app/(dashboard)/feedback/page.tsx
@@ -72,11 +72,23 @@ export default async function FeedbackPage() {
     voted_by_me: votedFeedbackIds.has(item.id),
   }))
 
+  // Compute average time-to-address for shipped feedback
+  const shippedItems = feedback.filter((f) => f.status === 'shipped' && f.updated_at && f.created_at)
+  let avgResponseHours: number | null = null
+  if (shippedItems.length > 0) {
+    const totalMs = shippedItems.reduce((sum, f) => {
+      return sum + (new Date(f.updated_at!).getTime() - new Date(f.created_at).getTime())
+    }, 0)
+    avgResponseHours = totalMs / shippedItems.length / (1000 * 60 * 60)
+  }
+
   return (
     <FeedbackBoard
       initialItems={items}
       currentUserId={user.id}
       currentUserName={nameByUserId.get(user.id) ?? null}
+      avgResponseHours={avgResponseHours}
+      shippedCount={shippedItems.length}
     />
   )
 }

--- a/src/components/feedback/feedback-board.tsx
+++ b/src/components/feedback/feedback-board.tsx
@@ -32,6 +32,8 @@ interface FeedbackBoardProps {
   initialItems: FeedbackBoardItem[]
   currentUserId: string
   currentUserName: string | null
+  avgResponseHours?: number | null
+  shippedCount?: number
 }
 
 type SortMode = 'votes' | 'newest'
@@ -52,7 +54,15 @@ const TYPE_FILTERS: Array<{ value: 'all' | FeedbackType; label: string }> = [
   { value: 'general', label: 'General' },
 ]
 
-export function FeedbackBoard({ initialItems, currentUserId, currentUserName }: FeedbackBoardProps) {
+function formatResponseTime(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)}m`
+  if (hours < 24) return `${Math.round(hours)}h`
+  const days = hours / 24
+  if (days < 1.5) return '1 day'
+  return `${Math.round(days)} days`
+}
+
+export function FeedbackBoard({ initialItems, currentUserId, currentUserName, avgResponseHours, shippedCount }: FeedbackBoardProps) {
   const router = useRouter()
   const supabase = createClient()
 
@@ -228,6 +238,12 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName }: 
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Feedback</h1>
           <p className="text-gray-600">Share ideas, vote, and track what ships next.</p>
+          {avgResponseHours != null && shippedCount != null && shippedCount > 0 && (
+            <p className="mt-1 text-sm text-emerald-700">
+              ⚡ Avg. response time: <span className="font-semibold">{formatResponseTime(avgResponseHours)}</span>
+              <span className="text-gray-400"> · {shippedCount} shipped</span>
+            </p>
+          )}
         </div>
         <Button onClick={() => setOpen(true)}>
           <MessageSquarePlus className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## What

Public metric on the feedback page: **⚡ Avg. response time: Xh · N shipped**

Computed server-side from all shipped feedback items (`updated_at - created_at`). Formats adaptively: minutes for <1h, hours for <24h, days for longer.

## Why

Transparency signal for users — shows feedback gets addressed quickly. Also creates an explicit KPI for the feedback pipeline: minimize average response time.

## Details

- Calculated in the feedback page server component (no extra DB query — reuses existing feedback fetch)
- Passed to `FeedbackBoard` client component as `avgResponseHours` + `shippedCount`
- Only renders when at least one item is shipped
- `formatResponseTime()` handles edge cases (rounds to nearest unit)

150 tests pass, TypeScript clean.