### PR TITLE
fix: show flight details by default — remove double-toggle UX

### DIFF
--- a/src/components/trips/item-details/flight-details.tsx
+++ b/src/components/trips/item-details/flight-details.tsx
@@ -49,11 +49,6 @@ export function FlightDetailsView({ details, liveOverrides }: FlightDetailsViewP
   const seatInfo = [cabin_class, seat].filter(Boolean).join(' · ')
   const logoUrl = airline ? getProviderLogoUrl(airline, 'flight') : null
 
-  // Debug logging
-  if (typeof window !== 'undefined') {
-    console.log('Flight details - airline:', airline, 'logoUrl:', logoUrl)
-  }
-
   return (
     <div className="rounded-lg border border-gray-200 bg-gradient-to-br from-slate-50 to-gray-100 p-4">
       {/* Header row */}

--- a/src/components/trips/transition-card.tsx
+++ b/src/components/trips/transition-card.tsx
@@ -1,7 +1,4 @@
-'use client'
-
-import { useState } from 'react'
-import { ChevronDown, ChevronUp, Clock, Plane } from 'lucide-react'
+import { Clock, Plane } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import type { Trip } from '@/types/database'
 import type { FlightJourney } from '@/lib/trips/city-segments'
@@ -29,8 +26,6 @@ export function TransitionCard({
   currentUserId,
   readOnly = false,
 }: TransitionCardProps) {
-  const [expanded, setExpanded] = useState(false)
-
   return (
     <Card className="border-dashed border-sky-200 bg-sky-50/70">
       <CardContent className="p-4">
@@ -62,28 +57,18 @@ export function TransitionCard({
 
         </div>
 
-        <button
-          type="button"
-          onClick={() => setExpanded((value) => !value)}
-          className="mt-4 flex items-center gap-1 text-sm font-medium text-sky-700 hover:text-sky-800"
-        >
-          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-          More info
-        </button>
-
-        {expanded ? (
-          <div className="mt-4 space-y-3">
-            {journey.legs.map((leg) => (
-              <TripItemCard
-                key={leg.id}
-                item={leg}
-                allTrips={allTrips}
-                currentUserId={currentUserId}
-                readOnly={readOnly}
-              />
-            ))}
-          </div>
-        ) : null}
+        <div className="mt-4 space-y-3">
+          {journey.legs.map((leg) => (
+            <TripItemCard
+              key={leg.id}
+              item={leg}
+              allTrips={allTrips}
+              currentUserId={currentUserId}
+              readOnly={readOnly}
+              defaultExpanded
+            />
+          ))}
+        </div>
       </CardContent>
     </Card>
   )

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -56,6 +56,8 @@ interface TripItemCardProps {
   currentUserId?: string
   readOnly?: boolean
   metaChips?: ReactNode
+  /** Start with details expanded (used for flight cards in transition view) */
+  defaultExpanded?: boolean
 }
 
 function loyaltyChip(loyaltyFlag: unknown): { text: string; className: string } | null {
@@ -137,9 +139,9 @@ function isWithin48Hours(item: { start_ts?: string | null; start_date?: string |
   return now >= dep - h48 && now <= endTime
 }
 
-export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, metaChips }: TripItemCardProps) {
+export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, metaChips, defaultExpanded }: TripItemCardProps) {
   const router = useRouter()
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(defaultExpanded ?? false)
   const [liveStatus, setLiveStatus] = useState<StatusPayload | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [moveOpen, setMoveOpen] = useState(false)


### PR DESCRIPTION
## Problem

Flight info (terminal, gate, delay status, seat, airline logo) was hidden behind TWO toggles:
1. **More info** on TransitionCard → reveals TripItemCard
2. **Show details** on TripItemCard → reveals FlightDetailsView

Users couldn't see critical info without two clicks.

## Fix

- **TransitionCard:** Removed the 'More info' toggle entirely. Flight leg cards always render.
- **TripItemCard:** New `defaultExpanded` prop. When passed (from transition cards), details show by default.
- **FlightDetailsView:** Already shows terminal, gate, seat, airline logo — now visible immediately.
- Removed stale `console.log` debug line.

Standalone flight cards (not in transitions) still have the toggle, starting collapsed.

## Result

One-click access to flight details. Terminal and gate visible at a glance. Live delay status from FlightAware (PR #71) renders immediately without digging.

150 tests pass, TypeScript clean.