### PR TITLE
feat: PRD-044 Phase 2c — clipboard paste + multi-image feedback

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
-const ALLOWED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+const ALLOWED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif'])
+const MAX_IMAGES = 3
 
 function normalizeFeedbackType(value: unknown): 'bug' | 'feature' | 'general' {
   if (value === 'bug' || value === 'feature' || value === 'general') return value
@@ -32,7 +33,7 @@ export async function POST(request: NextRequest) {
   const body = (formData.get('body') as string | null)?.trim() ?? ''
   const type = normalizeFeedbackType(formData.get('type'))
   const pageUrl = (formData.get('page_url') as string | null)?.trim() || null
-  const maybeImage = formData.get('image')
+  const imageEntries = formData.getAll('image')
 
   if (!title || !body) {
     return NextResponse.json({ error: 'Title and details are required.' }, { status: 400 })
@@ -49,38 +50,46 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Too many submissions. Please try again later.' }, { status: 429 })
   }
 
-  let imageUrl: string | null = null
-  let imagePath: string | null = null
+  // Process up to MAX_IMAGES images
+  const imageFiles = imageEntries
+    .filter((entry): entry is File => entry instanceof File && entry.size > 0)
+    .slice(0, MAX_IMAGES)
 
-  if (maybeImage instanceof File && maybeImage.size > 0) {
-    if (maybeImage.size > MAX_IMAGE_BYTES) {
-      return NextResponse.json({ error: 'Image must be 5MB or smaller.' }, { status: 400 })
+  const uploadedUrls: string[] = []
+  const uploadedPaths: string[] = []
+
+  for (const file of imageFiles) {
+    if (file.size > MAX_IMAGE_BYTES) {
+      return NextResponse.json({ error: 'Each image must be 5MB or smaller.' }, { status: 400 })
+    }
+    if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+      return NextResponse.json({ error: 'Images must be JPG, PNG, WebP, or GIF.' }, { status: 400 })
     }
 
-    if (!ALLOWED_IMAGE_TYPES.has(maybeImage.type)) {
-      return NextResponse.json({ error: 'Image must be JPG, PNG, or WebP.' }, { status: 400 })
-    }
-
-    const ext = extensionFromMimeType(maybeImage.type)
-    imagePath = `${user.id}/${crypto.randomUUID()}.${ext}`
+    const ext = extensionFromMimeType(file.type)
+    const path = `${user.id}/${crypto.randomUUID()}.${ext}`
 
     const { error: uploadError } = await supabase.storage
       .from('feedback-images')
-      .upload(imagePath, maybeImage, {
-        contentType: maybeImage.type,
-        upsert: false,
-      })
+      .upload(path, file, { contentType: file.type, upsert: false })
 
     if (uploadError) {
+      // Clean up any already-uploaded images
+      if (uploadedPaths.length > 0) {
+        await supabase.storage.from('feedback-images').remove(uploadedPaths)
+      }
       return NextResponse.json({ error: 'Could not upload image.' }, { status: 500 })
     }
 
+    uploadedPaths.push(path)
     const { data: publicUrlData } = supabase.storage
       .from('feedback-images')
-      .getPublicUrl(imagePath)
-
-    imageUrl = publicUrlData.publicUrl
+      .getPublicUrl(path)
+    uploadedUrls.push(publicUrlData.publicUrl)
   }
+
+  // Store first image in image_url for backward compatibility
+  const imageUrl = uploadedUrls[0] ?? null
 
   const { data, error: insertError } = await supabase
     .from('feedback')
@@ -96,8 +105,8 @@ export async function POST(request: NextRequest) {
     .single()
 
   if (insertError || !data) {
-    if (imagePath) {
-      await supabase.storage.from('feedback-images').remove([imagePath])
+    if (uploadedPaths.length > 0) {
+      await supabase.storage.from('feedback-images').remove(uploadedPaths)
     }
     return NextResponse.json({ error: 'Unable to submit feedback right now.' }, { status: 500 })
   }

--- a/src/components/feedback/feedback-board.tsx
+++ b/src/components/feedback/feedback-board.tsx
@@ -79,7 +79,7 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [type, setType] = useState<FeedbackType>('general')
-  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imageFiles, setImageFiles] = useState<File[]>([])
 
   const visibleItems = useMemo(() => {
     const filtered = items.filter((item) => {
@@ -114,15 +114,15 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
     setSaving(true)
     setError(null)
 
-    if (imageFile) {
-      const allowedTypes = new Set(['image/jpeg', 'image/png', 'image/webp'])
-      if (!allowedTypes.has(imageFile.type)) {
-        setError('Image must be JPG, PNG, or WebP.')
+    const allowedTypes = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif'])
+    for (const file of imageFiles) {
+      if (!allowedTypes.has(file.type)) {
+        setError('Images must be JPG, PNG, WebP, or GIF. SVG is not allowed.')
         setSaving(false)
         return
       }
-      if (imageFile.size > 5 * 1024 * 1024) {
-        setError('Image must be 5MB or smaller.')
+      if (file.size > 5 * 1024 * 1024) {
+        setError('Each image must be 5MB or smaller.')
         setSaving(false)
         return
       }
@@ -133,8 +133,8 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
     formData.append('body', trimmedBody)
     formData.append('type', type)
     formData.append('page_url', typeof window !== 'undefined' ? window.location.pathname : '')
-    if (imageFile) {
-      formData.append('image', imageFile)
+    for (const file of imageFiles) {
+      formData.append('image', file)
     }
 
     let data: Omit<FeedbackBoardItem, 'author_name' | 'comment_count' | 'voted_by_me'> | null = null
@@ -175,7 +175,7 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
     setTitle('')
     setBody('')
     setType('general')
-    setImageFile(null)
+    setImageFiles([])
     setOpen(false)
     setSaving(false)
     showToast('Thanks! We read every piece of feedback.')
@@ -429,18 +429,60 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
 
             <div className="space-y-1.5">
               <label className="text-sm font-medium text-gray-700" htmlFor="feedback-image">
-                Screenshot (optional)
+                Screenshots (optional)
               </label>
-              <Input
-                id="feedback-image"
-                type="file"
-                accept="image/jpeg,image/png,image/webp"
-                onChange={(event) => {
-                  const file = event.target.files?.[0] ?? null
-                  setImageFile(file)
+              <div
+                className="rounded-md border-2 border-dashed border-gray-200 p-3 text-center text-sm text-gray-500 transition-colors hover:border-gray-300 focus-within:border-blue-400"
+                onPaste={(e) => {
+                  const items = e.clipboardData.items
+                  const newFiles: File[] = []
+                  for (const item of items) {
+                    if (item.type.startsWith('image/') && item.type !== 'image/svg+xml') {
+                      const file = item.getAsFile()
+                      if (file) newFiles.push(file)
+                    }
+                  }
+                  if (newFiles.length > 0) {
+                    e.preventDefault()
+                    setImageFiles((prev) => [...prev, ...newFiles].slice(0, 3))
+                  }
                 }}
-              />
-              <p className="text-xs text-gray-500">Max 1 image, 5MB, JPG/PNG/WebP.</p>
+                tabIndex={0}
+              >
+                <Input
+                  id="feedback-image"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  multiple
+                  className="mb-2"
+                  onChange={(event) => {
+                    const files = Array.from(event.target.files ?? [])
+                    setImageFiles((prev) => [...prev, ...files].slice(0, 3))
+                    event.target.value = ''
+                  }}
+                />
+                <p className="text-xs text-gray-400">Or paste from clipboard (⌘V / Ctrl+V). Max 3 images, 5MB each.</p>
+              </div>
+              {imageFiles.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {imageFiles.map((file, i) => (
+                    <div key={`${file.name}-${i}`} className="relative group">
+                      <img
+                        src={URL.createObjectURL(file)}
+                        alt={`Screenshot ${i + 1}`}
+                        className="h-16 w-16 rounded border border-gray-200 object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setImageFiles((prev) => prev.filter((_, j) => j !== i))}
+                        className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
             {error && <p className="text-sm text-red-600">{error}</p>}


### PR DESCRIPTION
## PRD-044 Phase 2c: Clipboard Paste + Multi-Image Feedback

Completes the last feedback feature request: clipboard paste for screenshots.

### Changes

**Feedback form:**
- **Clipboard paste** — `onPaste` handler captures images from clipboard (⌘V / Ctrl+V). SVG blocked.
- **Multi-image** — up to 3 images per submission (was 1). File picker accepts multiple.
- **Previews** — thumbnail grid with hover × button to remove individual images.
- **GIF support** — added to allowed types.

**API route (`/api/feedback`):**
- Handles `formData.getAll('image')` for multiple uploads
- Uploads sequentially, stores first URL in `image_url` (backward compatible)
- Cleans up all uploaded images if the feedback insert fails

### Security (PRD-044)
- SVG blocked at paste time AND at API validation
- Max 3 images, 5MB each (enforced client + server)
- Rate limiting from Phase 1 still applies (5/user/hour)
- Image re-encoding (OCR pre-scan before AI processing) is Phase 3

180 tests pass (27 files), TypeScript clean.