### PR TITLE
fix: trip card click feedback — loading state on navigation

### DIFF
--- a/src/components/trips/trip-card.test.ts
+++ b/src/components/trips/trip-card.test.ts
@@ -3,11 +3,15 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/link', () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => React.createElement('a', { href }, children),
+  default: ({ href, children, onClick }: { href: string; children: React.ReactNode; onClick?: (e: React.MouseEvent) => void }) => React.createElement('a', { href, onClick }, children),
 }))
 
 vi.mock('next/image', () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
 }))
 
 import { TripCard, getTripCardPlaceholderLabel } from './trip-card'

--- a/src/components/trips/trip-card.tsx
+++ b/src/components/trips/trip-card.tsx
@@ -1,9 +1,13 @@
+'use client'
+
 import Link from 'next/link'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import { useState, useCallback } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { formatDateRange } from '@/lib/utils'
-import { MapPin, Calendar, AlertCircle, User } from 'lucide-react'
+import { MapPin, Calendar, AlertCircle, User, Loader2 } from 'lucide-react'
 import type { Trip, Json } from '@/types/database'
 import { cn } from '@/lib/utils'
 import { getProviderLogoUrl } from '@/lib/images/provider-logo'
@@ -99,13 +103,25 @@ export function TripCard({ trip, itemCount, needsReview, isPast, ownerName }: Tr
   const airlineLogos = getProviderLogos(trip.trip_items)
   const showStatusSummary = hasFlightWithin48Hours(trip.trip_items)
   const placeholderLabel = getTripCardPlaceholderLabel(trip)
+  const router = useRouter()
+  const [navigating, setNavigating] = useState(false)
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setNavigating(true)
+      router.push(`/trips/${trip.id}`)
+    },
+    [router, trip.id]
+  )
 
   return (
-    <Link href={`/trips/${trip.id}`}>
+    <Link href={`/trips/${trip.id}`} onClick={handleClick}>
       <Card
         className={cn(
           'group cursor-pointer overflow-hidden transition-all hover:shadow-md hover:border-[#cbd5e1]',
-          isPast && 'opacity-75'
+          isPast && 'opacity-75',
+          navigating && 'ring-2 ring-indigo-400 shadow-md'
         )}
       >
         {/* Cover image */}
@@ -148,6 +164,15 @@ export function TripCard({ trip, itemCount, needsReview, isPast, ownerName }: Tr
                 </div>
               </div>
             </>
+          )}
+          {/* Loading overlay */}
+          {navigating && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 backdrop-blur-sm transition-opacity">
+              <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 shadow-sm">
+                <Loader2 className="h-4 w-4 animate-spin text-indigo-600" />
+                <span className="text-sm font-medium text-indigo-600">Loading trip…</span>
+              </div>
+            </div>
           )}
           {/* Provider logos */}
           {airlineLogos.length > 0 && (


### PR DESCRIPTION
## Problem

Clicking a trip card (including the image) navigates to the trip page, but the transition can take several seconds with no visual feedback. Users can't tell if their click registered.

## Fix

- Added `'use client'` to TripCard (was implicitly client-capable via Link)
- On click: show indigo ring around the card + loading overlay on the cover image with spinner and 'Loading trip…' text
- Uses `useRouter().push()` for programmatic navigation with immediate state change
- The card image was already clickable (wrapped in `<Link>`) — this just adds feedback

TypeScript clean.