### PR TITLE
fix: kill background FlightAware polling, add 5-min staleness cache

### DIFF
--- a/src/app/api/v1/items/[id]/status/refresh/route.ts
+++ b/src/app/api/v1/items/[id]/status/refresh/route.ts
@@ -145,6 +145,9 @@ export async function POST(
   if (existingStatus?.last_checked_at) {
     const checkedAt = new Date(existingStatus.last_checked_at as string).getTime()
     if (!Number.isNaN(checkedAt) && Date.now() - checkedAt < STALENESS_MS) {
+      const cachedStatus = normalizeStatusRow(itemId, existingStatus as Record<string, unknown>)
+      // Strip raw_response — internal FA payload, never sent to clients
+      delete cachedStatus.raw_response
       return NextResponse.json({
         data: {
           item: {
@@ -158,7 +161,7 @@ export async function POST(
             end_ts: flightItem.end_ts,
             flight_number: extractFlightIdentFromDetails(flightItem.details_json),
           },
-          status: normalizeStatusRow(itemId, existingStatus as Record<string, unknown>),
+          status: cachedStatus,
         },
         meta: {
           cached: true,
@@ -246,6 +249,10 @@ export async function POST(
     }
   }
 
+  const freshStatus = normalizeStatusRow(itemId, savedStatus as Record<string, unknown>)
+  // Strip raw_response — internal FA payload, never sent to clients
+  delete freshStatus.raw_response
+
   return NextResponse.json({
     data: {
       item: {
@@ -259,7 +266,7 @@ export async function POST(
         end_ts: flightItem.end_ts,
         flight_number: extractFlightIdentFromDetails(flightItem.details_json),
       },
-      status: normalizeStatusRow(itemId, savedStatus as Record<string, unknown>),
+      status: freshStatus,
     },
     meta: {
       subscription_tier: isPro ? 'pro' : 'free',

--- a/src/app/api/v1/items/[id]/status/refresh/route.ts
+++ b/src/app/api/v1/items/[id]/status/refresh/route.ts
@@ -13,6 +13,7 @@ import { isValidUUID } from '@/lib/validation'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
 
 const FREE_DAILY_REFRESH_LIMIT = 3
+const STALENESS_MS = 5 * 60 * 1000 // 5 minutes — don't call FlightAware if data is fresher
 
 interface FlightItemRow {
   id: string
@@ -136,9 +137,39 @@ export async function POST(
 
   const { data: existingStatus } = await auth.supabase
     .from('trip_item_status')
-    .select('status, previous_status, status_changed_at')
+    .select('item_id, status, delay_minutes, gate, terminal, platform, estimated_departure, estimated_arrival, actual_departure, actual_arrival, source, last_checked_at, status_changed_at, previous_status, raw_response')
     .eq('item_id', itemId)
     .maybeSingle()
+
+  // Return cached data if checked within the last 5 minutes — avoid unnecessary FA API calls
+  if (existingStatus?.last_checked_at) {
+    const checkedAt = new Date(existingStatus.last_checked_at as string).getTime()
+    if (!Number.isNaN(checkedAt) && Date.now() - checkedAt < STALENESS_MS) {
+      return NextResponse.json({
+        data: {
+          item: {
+            id: flightItem.id,
+            trip_id: flightItem.trip_id,
+            provider: flightItem.provider,
+            summary: flightItem.summary,
+            start_date: flightItem.start_date,
+            end_date: flightItem.end_date,
+            start_ts: flightItem.start_ts,
+            end_ts: flightItem.end_ts,
+            flight_number: extractFlightIdentFromDetails(flightItem.details_json),
+          },
+          status: normalizeStatusRow(itemId, existingStatus as Record<string, unknown>),
+        },
+        meta: {
+          cached: true,
+          last_checked_at: existingStatus.last_checked_at,
+          subscription_tier: isPro ? 'pro' : 'free',
+          refreshes_today: isPro ? null : usedToday,
+          remaining_today: isPro ? null : Math.max(0, FREE_DAILY_REFRESH_LIMIT - usedToday),
+        },
+      })
+    }
+  }
 
   const latest = await getFlightStatus(lookup.ident, lookup.date)
   if (!latest) {

--- a/src/components/trips/item-status-badge.tsx
+++ b/src/components/trips/item-status-badge.tsx
@@ -164,15 +164,9 @@ export function ItemStatusBadge({ itemId, scheduledDeparture, startTs, onStatusU
     if (status && onStatusUpdate) onStatusUpdate(status)
   }, [status, onStatusUpdate])
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      if (document.visibilityState === 'visible') {
-        void loadStatus()
-      }
-    }, 2 * 60 * 1000)
-
-    return () => clearInterval(timer)
-  }, [loadStatus])
+  // No automatic polling — data refreshes only on page load or manual refresh.
+  // Background FlightAware calls are eliminated; the refresh endpoint returns
+  // cached data if checked within the last 5 minutes.
 
   // Auto-refresh when there's no cached status — this creates the initial
   // FlightAware lookup. Without this, the badge never appears because

--- a/src/components/trips/trip-card.test.ts
+++ b/src/components/trips/trip-card.test.ts
@@ -3,11 +3,15 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/link', () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => React.createElement('a', { href }, children),
+  default: ({ href, children, onClick }: { href: string; children: React.ReactNode; onClick?: (e: React.MouseEvent) => void }) => React.createElement('a', { href, onClick }, children),
 }))
 
 vi.mock('next/image', () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
 }))
 
 import { TripCard, getTripCardPlaceholderLabel } from './trip-card'

--- a/src/components/trips/trip-card.tsx
+++ b/src/components/trips/trip-card.tsx
@@ -1,9 +1,13 @@
+'use client'
+
 import Link from 'next/link'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+import { useState, useCallback } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { formatDateRange } from '@/lib/utils'
-import { MapPin, Calendar, AlertCircle, User } from 'lucide-react'
+import { MapPin, Calendar, AlertCircle, User, Loader2 } from 'lucide-react'
 import type { Trip, Json } from '@/types/database'
 import { cn } from '@/lib/utils'
 import { getProviderLogoUrl } from '@/lib/images/provider-logo'
@@ -99,13 +103,25 @@ export function TripCard({ trip, itemCount, needsReview, isPast, ownerName }: Tr
   const airlineLogos = getProviderLogos(trip.trip_items)
   const showStatusSummary = hasFlightWithin48Hours(trip.trip_items)
   const placeholderLabel = getTripCardPlaceholderLabel(trip)
+  const router = useRouter()
+  const [navigating, setNavigating] = useState(false)
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setNavigating(true)
+      router.push(`/trips/${trip.id}`)
+    },
+    [router, trip.id]
+  )
 
   return (
-    <Link href={`/trips/${trip.id}`}>
+    <Link href={`/trips/${trip.id}`} onClick={handleClick}>
       <Card
         className={cn(
           'group cursor-pointer overflow-hidden transition-all hover:shadow-md hover:border-[#cbd5e1]',
-          isPast && 'opacity-75'
+          isPast && 'opacity-75',
+          navigating && 'ring-2 ring-indigo-400 shadow-md'
         )}
       >
         {/* Cover image */}
@@ -148,6 +164,15 @@ export function TripCard({ trip, itemCount, needsReview, isPast, ownerName }: Tr
                 </div>
               </div>
             </>
+          )}
+          {/* Loading overlay */}
+          {navigating && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 backdrop-blur-sm transition-opacity">
+              <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 shadow-sm">
+                <Loader2 className="h-4 w-4 animate-spin text-indigo-600" />
+                <span className="text-sm font-medium text-indigo-600">Loading trip…</span>
+              </div>
+            </div>
           )}
           {/* Provider logos */}
           {airlineLogos.length > 0 && (

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "crons": [
     {
-      "path": "/api/internal/status-check",
-      "schedule": "*/15 * * * *"
-    },
-    {
       "path": "/api/cron/cleanup-ticket-pdfs",
       "schedule": "0 3 * * *"
     },


### PR DESCRIPTION
## What

Eliminates all background FlightAware API calls. FA is now called **only** when a human loads a page and cached data is older than 5 minutes.

## Changes

1. **Removed `/api/internal/status-check` from `vercel.json`** — this cron ran every 15 minutes and called FlightAware for every user's flights within a ±48 hour window. At scale, this is the primary cost driver.

2. **Added 5-minute staleness guard to `/api/v1/items/:id/status/refresh`** — if `last_checked_at` is less than 5 minutes ago, returns cached data immediately without calling FlightAware. Response includes `meta.cached: true` so the client knows.

3. **Removed 2-minute client-side polling from `ItemStatusBadge`** — the component no longer auto-polls the database on an interval. Status loads once on page view, and users can manually refresh.

## Result

- FA calls happen when someone views their trip or clicks refresh
- No FA calls happen on timers, crons, or in the background
- Cached responses are free (no FA call, no rate limit decrement)
- The `/api/internal/status-check` route still exists in code (for potential future opt-in use) but is no longer triggered

## Cost impact

March so far: 377 calls, $1.77. This change prevents that from scaling linearly with user count × flight count × time.