### PR TITLE
feat: add public nav with sign-up CTA to flight status pages

### DIFF
--- a/src/app/flights/[ident]/[date]/page.tsx
+++ b/src/app/flights/[ident]/[date]/page.tsx
@@ -105,7 +105,7 @@ export default async function FlightPage({ params }: FlightPageProps) {
   return (
     <main className="min-h-screen bg-slate-50">
       <PublicNav />
-      <div className="max-w-2xl mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto px-4 pt-20 pb-8">
         {/* Header */}
         <FlightPageHeader
           airline={flight.airline}

--- a/src/app/flights/[ident]/[date]/page.tsx
+++ b/src/app/flights/[ident]/[date]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
+import { PublicNav } from '@/components/public-nav'
 import { FlightPageHeader } from '@/components/flights/flight-page-header'
 import { FlightStatusBlock } from '@/components/flights/flight-status-block'
 import { FlightProgressBar } from '@/components/flights/flight-progress-bar'
@@ -103,6 +104,7 @@ export default async function FlightPage({ params }: FlightPageProps) {
 
   return (
     <main className="min-h-screen bg-slate-50">
+      <PublicNav />
       <div className="max-w-2xl mx-auto px-4 py-8">
         {/* Header */}
         <FlightPageHeader


### PR DESCRIPTION
Adds the PublicNav header (logo + 'Get Started Free' button) to the live flight status pages (`/flights/{ident}/{date}`). These are public, unauthenticated pages — every shared flight link is now a sign-up impression.