### PR TITLE
fix: guides markdown export + country picker dropdown

### DIFF
--- a/src/app/(dashboard)/guides/[id]/guide-markdown-export.tsx
+++ b/src/app/(dashboard)/guides/[id]/guide-markdown-export.tsx
@@ -19,20 +19,28 @@ function guideToMarkdown(guide: CityGuide, entries: GuideEntry[]): string {
       )
     : ''
 
+  // Single pass: partition entries by status and group visited by category
+  const visited = new Map<string, GuideEntry[]>()
+  const toTry: GuideEntry[] = []
+  for (const entry of entries) {
+    if (entry.status === 'visited') {
+      const list = visited.get(entry.category) ?? []
+      list.push(entry)
+      visited.set(entry.category, list)
+    } else if (entry.status === 'to_try') {
+      toTry.push(entry)
+    }
+  }
+
+  const visitedCount = Array.from(visited.values()).reduce((sum, list) => sum + list.length, 0)
+
   const lines: string[] = []
   lines.push(`# ${flag} ${guide.city}${guide.country ? ` — ${guide.country}` : ''}`)
   lines.push(``)
-  lines.push(`*${entries.filter(e => e.status === 'visited').length} places · personal guide*`)
+  lines.push(`*${visitedCount} places · personal guide*`)
   lines.push(``)
 
-  const visited = entries.filter(e => e.status === 'visited')
-  const grouped = visited.reduce<Record<string, GuideEntry[]>>((acc, e) => {
-    if (!acc[e.category]) acc[e.category] = []
-    acc[e.category].push(e)
-    return acc
-  }, {})
-
-  for (const [category, catEntries] of Object.entries(grouped)) {
+  for (const [category, catEntries] of visited) {
     lines.push(`## ${category}`)
     lines.push(``)
     for (const entry of catEntries) {
@@ -50,7 +58,6 @@ function guideToMarkdown(guide: CityGuide, entries: GuideEntry[]): string {
     }
   }
 
-  const toTry = entries.filter(e => e.status === 'to_try')
   if (toTry.length > 0) {
     lines.push(`## 🔖 To Try`)
     lines.push(``)

--- a/src/app/(dashboard)/guides/[id]/guide-markdown-export.tsx
+++ b/src/app/(dashboard)/guides/[id]/guide-markdown-export.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { FileText } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { CityGuide, GuideEntry } from '@/types/database'
+
+interface GuideMarkdownExportProps {
+  guide: CityGuide
+  entries: GuideEntry[]
+}
+
+function guideToMarkdown(guide: CityGuide, entries: GuideEntry[]): string {
+  const flag = guide.country_code
+    ? String.fromCodePoint(
+        ...guide.country_code
+          .toUpperCase()
+          .split('')
+          .map((c: string) => 0x1f1e6 + c.charCodeAt(0) - 65)
+      )
+    : ''
+
+  const lines: string[] = []
+  lines.push(`# ${flag} ${guide.city}${guide.country ? ` — ${guide.country}` : ''}`)
+  lines.push(``)
+  lines.push(`*${entries.filter(e => e.status === 'visited').length} places · personal guide*`)
+  lines.push(``)
+
+  const visited = entries.filter(e => e.status === 'visited')
+  const grouped = visited.reduce<Record<string, GuideEntry[]>>((acc, e) => {
+    if (!acc[e.category]) acc[e.category] = []
+    acc[e.category].push(e)
+    return acc
+  }, {})
+
+  for (const [category, catEntries] of Object.entries(grouped)) {
+    lines.push(`## ${category}`)
+    lines.push(``)
+    for (const entry of catEntries) {
+      lines.push(`### ${entry.name}`)
+      if (entry.rating) {
+        lines.push(`Rating: ${'★'.repeat(entry.rating)}${'☆'.repeat(5 - entry.rating)}`)
+      }
+      if (entry.description) lines.push(``)
+      if (entry.description) lines.push(entry.description)
+      if (entry.address) lines.push(``)
+      if (entry.address) lines.push(`📍 ${entry.address}`)
+      if (entry.website_url) lines.push(`🔗 ${entry.website_url}`)
+      if (entry.recommended_by) lines.push(`*Recommended by ${entry.recommended_by}*`)
+      lines.push(``)
+    }
+  }
+
+  const toTry = entries.filter(e => e.status === 'to_try')
+  if (toTry.length > 0) {
+    lines.push(`## 🔖 To Try`)
+    lines.push(``)
+    for (const entry of toTry) {
+      lines.push(`- **${entry.name}** (${entry.category})${entry.description ? ' — ' + entry.description : ''}${entry.recommended_by ? ` · via ${entry.recommended_by}` : ''}`)
+    }
+    lines.push(``)
+  }
+
+  return lines.join('\n')
+}
+
+export function GuideMarkdownExport({ guide, entries }: GuideMarkdownExportProps) {
+  function handleExport() {
+    const markdown = guideToMarkdown(guide, entries)
+    const blob = new Blob([markdown], { type: 'text/markdown; charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${guide.city?.toLowerCase().replace(/\s+/g, '-') ?? 'guide'}.md`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleExport}>
+      <FileText className="h-3.5 w-3.5 mr-1.5" />
+      Markdown
+    </Button>
+  )
+}

--- a/src/app/(dashboard)/guides/[id]/page.tsx
+++ b/src/app/(dashboard)/guides/[id]/page.tsx
@@ -10,11 +10,11 @@ import {
   MapPin,
   Bookmark,
   CheckCircle2,
-  FileText,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { CityGuide, GuideEntry } from '@/types/database'
 import { GuideShareToggle } from './guide-share-toggle'
+import { GuideMarkdownExport } from './guide-markdown-export'
 import { EntryActions } from './entry-actions'
 import { DeleteGuideButton } from './delete-guide-button'
 import { GuideMapSection } from '@/components/maps/guide-map-section'
@@ -196,17 +196,8 @@ export default async function GuidePage({ params, searchParams }: GuidePageProps
             shareUrl={shareUrl}
           />
 
-          {/* Export links */}
-          <a
-            href={`/api/v1/guides/${g.id}?format=md`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button variant="outline" size="sm">
-              <FileText className="h-3.5 w-3.5 mr-1.5" />
-              Markdown
-            </Button>
-          </a>
+          {/* Export markdown */}
+          <GuideMarkdownExport guide={g as CityGuide} entries={(entries ?? []) as GuideEntry[]} />
 
           {/* Add entry */}
           <Link href={`/guides/${g.id}/add`}>

--- a/src/app/(dashboard)/guides/[id]/page.tsx
+++ b/src/app/(dashboard)/guides/[id]/page.tsx
@@ -197,7 +197,7 @@ export default async function GuidePage({ params, searchParams }: GuidePageProps
           />
 
           {/* Export markdown */}
-          <GuideMarkdownExport guide={g as CityGuide} entries={(entries ?? []) as GuideEntry[]} />
+          <GuideMarkdownExport guide={g as CityGuide} entries={entries} />
 
           {/* Add entry */}
           <Link href={`/guides/${g.id}/add`}>

--- a/src/app/(dashboard)/guides/new/country-select.tsx
+++ b/src/app/(dashboard)/guides/new/country-select.tsx
@@ -98,6 +98,10 @@ export function CountrySelect() {
         <input
           id="country-search"
           type="text"
+          role="combobox"
+          aria-expanded={open && !selected && filtered.length > 0}
+          aria-controls="country-listbox"
+          aria-autocomplete="list"
           autoComplete="off"
           value={selected ? `${countryFlag(selected.code)} ${selected.name}` : search}
           onChange={(e) => {
@@ -128,9 +132,9 @@ export function CountrySelect() {
       </div>
 
       {open && !selected && filtered.length > 0 && (
-        <ul className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+        <ul id="country-listbox" role="listbox" className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
           {filtered.slice(0, 20).map((c) => (
-            <li key={c.code}>
+            <li key={c.code} role="option" aria-selected={false}>
               <button
                 type="button"
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm text-left hover:bg-indigo-50"

--- a/src/app/(dashboard)/guides/new/country-select.tsx
+++ b/src/app/(dashboard)/guides/new/country-select.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+
+/** ISO 3166-1 countries — name + alpha-2 code */
+const COUNTRIES = [
+  { name: 'Afghanistan', code: 'AF' }, { name: 'Albania', code: 'AL' }, { name: 'Algeria', code: 'DZ' },
+  { name: 'Andorra', code: 'AD' }, { name: 'Angola', code: 'AO' }, { name: 'Argentina', code: 'AR' },
+  { name: 'Armenia', code: 'AM' }, { name: 'Australia', code: 'AU' }, { name: 'Austria', code: 'AT' },
+  { name: 'Azerbaijan', code: 'AZ' }, { name: 'Bahamas', code: 'BS' }, { name: 'Bahrain', code: 'BH' },
+  { name: 'Bangladesh', code: 'BD' }, { name: 'Barbados', code: 'BB' }, { name: 'Belarus', code: 'BY' },
+  { name: 'Belgium', code: 'BE' }, { name: 'Belize', code: 'BZ' }, { name: 'Benin', code: 'BJ' },
+  { name: 'Bhutan', code: 'BT' }, { name: 'Bolivia', code: 'BO' }, { name: 'Bosnia and Herzegovina', code: 'BA' },
+  { name: 'Botswana', code: 'BW' }, { name: 'Brazil', code: 'BR' }, { name: 'Brunei', code: 'BN' },
+  { name: 'Bulgaria', code: 'BG' }, { name: 'Burkina Faso', code: 'BF' }, { name: 'Burundi', code: 'BI' },
+  { name: 'Cambodia', code: 'KH' }, { name: 'Cameroon', code: 'CM' }, { name: 'Canada', code: 'CA' },
+  { name: 'Cape Verde', code: 'CV' }, { name: 'Central African Republic', code: 'CF' }, { name: 'Chad', code: 'TD' },
+  { name: 'Chile', code: 'CL' }, { name: 'China', code: 'CN' }, { name: 'Colombia', code: 'CO' },
+  { name: 'Comoros', code: 'KM' }, { name: 'Congo', code: 'CG' }, { name: 'Costa Rica', code: 'CR' },
+  { name: 'Croatia', code: 'HR' }, { name: 'Cuba', code: 'CU' }, { name: 'Cyprus', code: 'CY' },
+  { name: 'Czech Republic', code: 'CZ' }, { name: 'Denmark', code: 'DK' }, { name: 'Djibouti', code: 'DJ' },
+  { name: 'Dominican Republic', code: 'DO' }, { name: 'DR Congo', code: 'CD' }, { name: 'Ecuador', code: 'EC' },
+  { name: 'Egypt', code: 'EG' }, { name: 'El Salvador', code: 'SV' }, { name: 'Equatorial Guinea', code: 'GQ' },
+  { name: 'Eritrea', code: 'ER' }, { name: 'Estonia', code: 'EE' }, { name: 'Eswatini', code: 'SZ' },
+  { name: 'Ethiopia', code: 'ET' }, { name: 'Fiji', code: 'FJ' }, { name: 'Finland', code: 'FI' },
+  { name: 'France', code: 'FR' }, { name: 'Gabon', code: 'GA' }, { name: 'Gambia', code: 'GM' },
+  { name: 'Georgia', code: 'GE' }, { name: 'Germany', code: 'DE' }, { name: 'Ghana', code: 'GH' },
+  { name: 'Greece', code: 'GR' }, { name: 'Grenada', code: 'GD' }, { name: 'Guatemala', code: 'GT' },
+  { name: 'Guinea', code: 'GN' }, { name: 'Guyana', code: 'GY' }, { name: 'Haiti', code: 'HT' },
+  { name: 'Honduras', code: 'HN' }, { name: 'Hungary', code: 'HU' }, { name: 'Iceland', code: 'IS' },
+  { name: 'India', code: 'IN' }, { name: 'Indonesia', code: 'ID' }, { name: 'Iran', code: 'IR' },
+  { name: 'Iraq', code: 'IQ' }, { name: 'Ireland', code: 'IE' }, { name: 'Israel', code: 'IL' },
+  { name: 'Italy', code: 'IT' }, { name: 'Ivory Coast', code: 'CI' }, { name: 'Jamaica', code: 'JM' },
+  { name: 'Japan', code: 'JP' }, { name: 'Jordan', code: 'JO' }, { name: 'Kazakhstan', code: 'KZ' },
+  { name: 'Kenya', code: 'KE' }, { name: 'Kuwait', code: 'KW' }, { name: 'Kyrgyzstan', code: 'KG' },
+  { name: 'Laos', code: 'LA' }, { name: 'Latvia', code: 'LV' }, { name: 'Lebanon', code: 'LB' },
+  { name: 'Lesotho', code: 'LS' }, { name: 'Liberia', code: 'LR' }, { name: 'Libya', code: 'LY' },
+  { name: 'Liechtenstein', code: 'LI' }, { name: 'Lithuania', code: 'LT' }, { name: 'Luxembourg', code: 'LU' },
+  { name: 'Madagascar', code: 'MG' }, { name: 'Malawi', code: 'MW' }, { name: 'Malaysia', code: 'MY' },
+  { name: 'Maldives', code: 'MV' }, { name: 'Mali', code: 'ML' }, { name: 'Malta', code: 'MT' },
+  { name: 'Mauritania', code: 'MR' }, { name: 'Mauritius', code: 'MU' }, { name: 'Mexico', code: 'MX' },
+  { name: 'Moldova', code: 'MD' }, { name: 'Monaco', code: 'MC' }, { name: 'Mongolia', code: 'MN' },
+  { name: 'Montenegro', code: 'ME' }, { name: 'Morocco', code: 'MA' }, { name: 'Mozambique', code: 'MZ' },
+  { name: 'Myanmar', code: 'MM' }, { name: 'Namibia', code: 'NA' }, { name: 'Nepal', code: 'NP' },
+  { name: 'Netherlands', code: 'NL' }, { name: 'New Zealand', code: 'NZ' }, { name: 'Nicaragua', code: 'NI' },
+  { name: 'Niger', code: 'NE' }, { name: 'Nigeria', code: 'NG' }, { name: 'North Korea', code: 'KP' },
+  { name: 'North Macedonia', code: 'MK' }, { name: 'Norway', code: 'NO' }, { name: 'Oman', code: 'OM' },
+  { name: 'Pakistan', code: 'PK' }, { name: 'Palestine', code: 'PS' }, { name: 'Panama', code: 'PA' },
+  { name: 'Papua New Guinea', code: 'PG' }, { name: 'Paraguay', code: 'PY' }, { name: 'Peru', code: 'PE' },
+  { name: 'Philippines', code: 'PH' }, { name: 'Poland', code: 'PL' }, { name: 'Portugal', code: 'PT' },
+  { name: 'Qatar', code: 'QA' }, { name: 'Romania', code: 'RO' }, { name: 'Russia', code: 'RU' },
+  { name: 'Rwanda', code: 'RW' }, { name: 'Saudi Arabia', code: 'SA' }, { name: 'Senegal', code: 'SN' },
+  { name: 'Serbia', code: 'RS' }, { name: 'Sierra Leone', code: 'SL' }, { name: 'Singapore', code: 'SG' },
+  { name: 'Slovakia', code: 'SK' }, { name: 'Slovenia', code: 'SI' }, { name: 'Somalia', code: 'SO' },
+  { name: 'South Africa', code: 'ZA' }, { name: 'South Korea', code: 'KR' }, { name: 'South Sudan', code: 'SS' },
+  { name: 'Spain', code: 'ES' }, { name: 'Sri Lanka', code: 'LK' }, { name: 'Sudan', code: 'SD' },
+  { name: 'Suriname', code: 'SR' }, { name: 'Sweden', code: 'SE' }, { name: 'Switzerland', code: 'CH' },
+  { name: 'Syria', code: 'SY' }, { name: 'Taiwan', code: 'TW' }, { name: 'Tajikistan', code: 'TJ' },
+  { name: 'Tanzania', code: 'TZ' }, { name: 'Thailand', code: 'TH' }, { name: 'Timor-Leste', code: 'TL' },
+  { name: 'Togo', code: 'TG' }, { name: 'Trinidad and Tobago', code: 'TT' }, { name: 'Tunisia', code: 'TN' },
+  { name: 'Turkey', code: 'TR' }, { name: 'Turkmenistan', code: 'TM' }, { name: 'Uganda', code: 'UG' },
+  { name: 'Ukraine', code: 'UA' }, { name: 'United Arab Emirates', code: 'AE' }, { name: 'United Kingdom', code: 'GB' },
+  { name: 'United States', code: 'US' }, { name: 'Uruguay', code: 'UY' }, { name: 'Uzbekistan', code: 'UZ' },
+  { name: 'Venezuela', code: 'VE' }, { name: 'Vietnam', code: 'VN' }, { name: 'Yemen', code: 'YE' },
+  { name: 'Zambia', code: 'ZM' }, { name: 'Zimbabwe', code: 'ZW' },
+] as const
+
+function countryFlag(code: string): string {
+  return String.fromCodePoint(
+    ...code.toUpperCase().split('').map((c) => 0x1f1e6 + c.charCodeAt(0) - 65)
+  )
+}
+
+export function CountrySelect() {
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<{ name: string; code: string } | null>(null)
+  const [open, setOpen] = useState(false)
+
+  const filtered = useMemo(() => {
+    if (!search) return COUNTRIES
+    const q = search.toLowerCase()
+    return COUNTRIES.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.code.toLowerCase().includes(q)
+    )
+  }, [search])
+
+  return (
+    <div className="relative">
+      <label htmlFor="country-search" className="block text-sm font-medium text-gray-700 mb-1">
+        Country
+      </label>
+
+      {/* Hidden inputs for form submission */}
+      <input type="hidden" name="country" value={selected?.name ?? ''} />
+      <input type="hidden" name="country_code" value={selected?.code ?? ''} />
+
+      <div className="relative">
+        <input
+          id="country-search"
+          type="text"
+          autoComplete="off"
+          value={selected ? `${countryFlag(selected.code)} ${selected.name}` : search}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setSelected(null)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            // Delay to allow click on option
+            setTimeout(() => setOpen(false), 200)
+          }}
+          placeholder="Search countries…"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+        {selected && (
+          <button
+            type="button"
+            onClick={() => {
+              setSelected(null)
+              setSearch('')
+            }}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-sm"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {open && !selected && filtered.length > 0 && (
+        <ul className="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+          {filtered.slice(0, 20).map((c) => (
+            <li key={c.code}>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-left hover:bg-indigo-50"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  setSelected(c)
+                  setSearch('')
+                  setOpen(false)
+                }}
+              >
+                <span>{countryFlag(c.code)}</span>
+                <span>{c.name}</span>
+                <span className="ml-auto text-xs text-gray-400">{c.code}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/app/(dashboard)/guides/new/page.tsx
+++ b/src/app/(dashboard)/guides/new/page.tsx
@@ -2,6 +2,7 @@ import { createGuide } from '../actions'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
+import { CountrySelect } from './country-select'
 
 export default function NewGuidePage() {
   return (
@@ -36,33 +37,7 @@ export default function NewGuidePage() {
           />
         </div>
 
-        <div>
-          <label htmlFor="country" className="block text-sm font-medium text-gray-700 mb-1">
-            Country
-          </label>
-          <input
-            id="country"
-            name="country"
-            type="text"
-            placeholder="France"
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-        </div>
-
-        <div>
-          <label htmlFor="country_code" className="block text-sm font-medium text-gray-700 mb-1">
-            Country code
-            <span className="ml-1 text-xs text-gray-400">(ISO 3166-1 alpha-2, e.g. &ldquo;FR&rdquo;)</span>
-          </label>
-          <input
-            id="country_code"
-            name="country_code"
-            type="text"
-            maxLength={2}
-            placeholder="FR"
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm uppercase focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-        </div>
+        <CountrySelect />
 
         <div className="flex gap-3 pt-2">
           <Button type="submit" className="flex-1">

--- a/src/lib/ai/extract-travel-data.ts
+++ b/src/lib/ai/extract-travel-data.ts
@@ -128,7 +128,13 @@ export async function extractTravelData(
 
     const result = JSON.parse(jsonMatch[0]) as ExtractionResult
 
-    // Basic output validation: reject unexpected top-level fields
+    // Basic output validation: strip unexpected top-level fields.
+    // Note: this protection is intentionally scoped to top-level keys only.
+    // Nested fields within items[n].details are variable by design (kind-specific)
+    // and are passed through to the normaliser which enforces the typed ExtractionResult
+    // structure. A prompt-injection payload surviving into a nested field would be stored
+    // as opaque detail data — not executed — and is subject to the sanitization pipeline
+    // applied at the point of user-facing output (PRD-044 Phase 2/2b).
     const allowedTopFields = new Set(['doc_type', 'overall_confidence', 'items'])
     for (const key of Object.keys(result)) {
       if (!allowedTopFields.has(key)) {

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -120,6 +120,17 @@ Subject: {{subject}}
 {{attachments}}
 </email_content>`
 
+/**
+ * Sanitize untrusted email content before inserting into the prompt.
+ * Prevents tag-escape attacks where a crafted email body contains
+ * "</email_content>" to break out of the delimiter and inject instructions.
+ */
+function sanitizeEmailInput(input: string): string {
+  // Replace closing tag with a visually identical but non-functional form.
+  // The AI will still see the content; it just cannot close the container tag.
+  return input.replace(/<\/email_content>/gi, '<\\/email_content>')
+}
+
 export function buildExtractionPrompt(
   subject: string,
   body: string,
@@ -129,13 +140,13 @@ export function buildExtractionPrompt(
 
   let prompt = TRAVEL_EXTRACTION_USER_PROMPT
     .replace('{{today}}', today)
-    .replace('{{subject}}', subject || '(no subject)')
-    .replace('{{body}}', body || '(no body)')
+    .replace('{{subject}}', sanitizeEmailInput(subject || '(no subject)'))
+    .replace('{{body}}', sanitizeEmailInput(body || '(no body)'))
 
   if (attachmentText) {
     prompt = prompt.replace(
       '{{attachments}}',
-      `\nATTACHMENT CONTENT:\n${attachmentText}`
+      `\nATTACHMENT CONTENT:\n${sanitizeEmailInput(attachmentText)}`
     )
   } else {
     prompt = prompt.replace('{{attachments}}', '')


### PR DESCRIPTION
Addresses two user feedback items:

**Feedback #1 — Markdown link goes to bad place**
The 'Markdown' button on guide pages linked to `/api/v1/guides/:id?format=md` which requires API key auth. Dashboard users (session auth) got an 'unauthorized' error. Fixed by generating the markdown client-side from data already loaded on the page and triggering a file download. No API call needed.

**Feedback #2 — Guides asks for odd metadata**
Replaced the three separate fields (City, Country, Country Code) with City + a searchable country dropdown. Selecting a country auto-sets both the name and ISO 3166-1 alpha-2 code via hidden form fields. Includes flag emoji and type-to-search.