### PR TITLE
feat: cross-trip item search API and CLI

### DIFF
--- a/cli/ubt
+++ b/cli/ubt
@@ -445,52 +445,20 @@ cmd_items_search() {
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --date)
-        date="${2:-}"
-        if [ -z "$date" ]; then
-          echo "Error: --date requires YYYY-MM-DD" >&2
+      --date|--from|--to|--kind|--limit|--offset)
+        local arg_val="${2:-}"
+        if [ -z "$arg_val" ]; then
+          echo "Error: $1 requires an argument" >&2
           exit 1
         fi
-        shift 2
-        ;;
-      --from)
-        from_date="${2:-}"
-        if [ -z "$from_date" ]; then
-          echo "Error: --from requires YYYY-MM-DD" >&2
-          exit 1
-        fi
-        shift 2
-        ;;
-      --to)
-        to_date="${2:-}"
-        if [ -z "$to_date" ]; then
-          echo "Error: --to requires YYYY-MM-DD" >&2
-          exit 1
-        fi
-        shift 2
-        ;;
-      --kind)
-        kind="${2:-}"
-        if [ -z "$kind" ]; then
-          echo "Error: --kind requires a value" >&2
-          exit 1
-        fi
-        shift 2
-        ;;
-      --limit)
-        limit="${2:-}"
-        if [ -z "$limit" ]; then
-          echo "Error: --limit requires a value" >&2
-          exit 1
-        fi
-        shift 2
-        ;;
-      --offset)
-        offset="${2:-}"
-        if [ -z "$offset" ]; then
-          echo "Error: --offset requires a value" >&2
-          exit 1
-        fi
+        case "$1" in
+          --date)   date="$arg_val" ;;
+          --from)   from_date="$arg_val" ;;
+          --to)     to_date="$arg_val" ;;
+          --kind)   kind="$arg_val" ;;
+          --limit)  limit="$arg_val" ;;
+          --offset) offset="$arg_val" ;;
+        esac
         shift 2
         ;;
       *)

--- a/cli/ubt
+++ b/cli/ubt
@@ -273,6 +273,47 @@ for item in data:
 "
 }
 
+_format_item_search_results() {
+  _python3c "
+import json, sys
+
+payload = json.load(sys.stdin)
+if isinstance(payload, dict):
+    if 'error' in payload:
+        print(f\"Error: {payload['error']['message']}\")
+        sys.exit(1)
+    data = payload.get('data', [])
+else:
+    data = payload
+
+if not data:
+    print('No items found.')
+    sys.exit(0)
+
+for item in data:
+    det = item.get('details_json') or {}
+    provider = item.get('provider') or ''
+    date = item.get('start_date') or ''
+    start_loc = item.get('start_location') or ''
+    end_loc = item.get('end_location') or ''
+    trip_title = item.get('trip_title') or '(untitled trip)'
+    kind = item.get('kind') or '?'
+
+    dep_time = det.get('departure_local_time') or ''
+    if not dep_time:
+        start_ts = item.get('start_ts') or ''
+        if isinstance(start_ts, str) and len(start_ts) >= 16:
+            dep_time = start_ts[11:16]
+
+    route = start_loc
+    if end_loc and end_loc != start_loc:
+        route = f'{route} → {end_loc}' if route else end_loc
+
+    print(f\"  {item.get('id','')}  {kind:<10} {provider:<20} {date:<10}  {dep_time:<5}  {route}\")
+    print(f\"             Trip: {trip_title}\")
+"
+}
+
 # Commands
 cmd_trips_list() {
   local user_id="${1:-}"
@@ -391,6 +432,107 @@ cmd_items_list() {
     echo "$items" | _json
   else
     echo "$items" | _format_items
+  fi
+}
+
+cmd_items_search() {
+  local date=""
+  local from_date=""
+  local to_date=""
+  local kind=""
+  local limit=""
+  local offset=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --date)
+        date="${2:-}"
+        if [ -z "$date" ]; then
+          echo "Error: --date requires YYYY-MM-DD" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --from)
+        from_date="${2:-}"
+        if [ -z "$from_date" ]; then
+          echo "Error: --from requires YYYY-MM-DD" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --to)
+        to_date="${2:-}"
+        if [ -z "$to_date" ]; then
+          echo "Error: --to requires YYYY-MM-DD" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --kind)
+        kind="${2:-}"
+        if [ -z "$kind" ]; then
+          echo "Error: --kind requires a value" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --limit)
+        limit="${2:-}"
+        if [ -z "$limit" ]; then
+          echo "Error: --limit requires a value" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      --offset)
+        offset="${2:-}"
+        if [ -z "$offset" ]; then
+          echo "Error: --offset requires a value" >&2
+          exit 1
+        fi
+        shift 2
+        ;;
+      *)
+        echo "Unknown option: $1" >&2
+        echo "Usage: ubt items search [--date YYYY-MM-DD] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--kind flight|hotel|train|...] [--limit N]" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  local query=""
+  if [ -n "$date" ]; then
+    query="date=$(_urlencode "$date")"
+  fi
+  if [ -n "$from_date" ]; then
+    query="${query}${query:+&}from=$(_urlencode "$from_date")"
+  fi
+  if [ -n "$to_date" ]; then
+    query="${query}${query:+&}to=$(_urlencode "$to_date")"
+  fi
+  if [ -n "$kind" ]; then
+    query="${query}${query:+&}kind=$(_urlencode "$kind")"
+  fi
+  if [ -n "$limit" ]; then
+    query="${query}${query:+&}limit=$(_urlencode "$limit")"
+  fi
+  if [ -n "$offset" ]; then
+    query="${query}${query:+&}offset=$(_urlencode "$offset")"
+  fi
+
+  local url="${API_V1}/items"
+  if [ -n "$query" ]; then
+    url="${url}?${query}"
+  fi
+
+  local result
+  result=$(_api "$url")
+
+  if [ "${FORMAT:-pretty}" = "json" ]; then
+    echo "$result" | _json
+  else
+    echo "$result" | _format_item_search_results
   fi
 }
 
@@ -3430,6 +3572,7 @@ Commands:
   trips status <trip_id>                Show live statuses for trip flight/train items *
   trips merge <target> <source>         Merge source trip into target (deletes source) *
   items list <trip_id>                  List items in a trip
+  items search [--date Y-M-D] [--from Y-M-D] [--to Y-M-D] [--kind X] [--limit N]  Search items across all trips *
   items show <item_id>                  Show item details *
   items add <trip_id> --kind <k> --summary <text> [--provider X] [--start-ts X] [--end-ts X] [--start-date Y-M-D] [--end-date Y-M-D] [--start-location X] [--end-location X] [--details-json '{...}']  Add item *
   items update <item_id> [--summary X] [--start-location X] [--end-location X] [--status X]  Update item *
@@ -3507,6 +3650,7 @@ Examples:
   ubt trips rename <trip_id> "NYC + Boston"
   ubt trips status <trip_id>
   ubt trips merge <target_id> <source_id>
+  ubt items search --date 2026-03-13 --kind flight
   ubt items show <item_id>
   ubt items add <trip_id> --kind flight --summary "UA 101 SFO to JFK" --start-ts 2026-04-10T08:30:00Z
   ubt items update <item_id> --status confirmed
@@ -3563,6 +3707,7 @@ case "${1:-}" in
   items)
     case "${2:-}" in
       list) cmd_items_list "${3:?Usage: ubt items list <trip_id>}" ;;
+      search) shift 2; cmd_items_search "$@" ;;
       show) cmd_items_show "${3:?Usage: ubt items show <item_id>}" ;;
       add) shift 2; cmd_items_add "$@" ;;
       update) shift 2; cmd_items_update "$@" ;;

--- a/e2e/tests/mobile.spec.ts
+++ b/e2e/tests/mobile.spec.ts
@@ -47,6 +47,6 @@ test.describe('Mobile viewport', () => {
     const response = await page.goto('/trips')
     expect(response?.status()).not.toBe(500)
     // Core content should be visible
-    await expect(page.getByRole('heading', { name: /trips/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Your Trips' })).toBeVisible()
   })
 })

--- a/scripts/prompts/items-search-api.md
+++ b/scripts/prompts/items-search-api.md
@@ -1,0 +1,104 @@
+# Build: Cross-Trip Item Search API + CLI
+
+## Problem
+When a user asks "what's my flight tomorrow?", the only way to find it is to list all trips and then fetch items for each one. The `GET /api/v1/trips` endpoint only returns trip-level `start_date`/`end_date`, not individual item dates. There's no way to search items across all trips by date or kind.
+
+## What to Build
+
+### 1. New API Endpoint: `GET /api/v1/items`
+
+Create `src/app/api/v1/items/route.ts` with a GET handler that searches across ALL of the authenticated user's trips.
+
+**Query Parameters:**
+- `date` — Filter items where `start_date <= date AND end_date >= date` (items active on this date)
+- `from` / `to` — Date range filter: `start_date <= to AND end_date >= from`
+- `kind` — Filter by item kind (e.g., `flight`, `hotel`, `train`, `activity`, `car_rental`)
+- `limit` — Max results (default 50, max 200)
+- `offset` — Pagination offset
+
+If no date filters are provided, return items from all trips (ordered by start_date ascending).
+
+**Response shape:**
+```json
+{
+  "data": [
+    {
+      "id": "...",
+      "trip_id": "...",
+      "trip_title": "...",
+      "kind": "flight",
+      "provider": "Spirit Airlines",
+      "summary": "Spirit Airlines flight 457 from Newark to Austin",
+      "start_date": "2026-03-13",
+      "end_date": "2026-03-13",
+      "start_ts": "...",
+      "end_ts": "...",
+      "start_location": "EWR",
+      "end_location": "AUS",
+      "details_json": { ... },
+      "status": "...",
+      "created_at": "...",
+      "updated_at": "..."
+    }
+  ],
+  "meta": { "count": 1, "limit": 50, "offset": 0 }
+}
+```
+
+**Important implementation details:**
+- Use `validateApiKey` + `rateLimitResponse` from `@/lib/api/auth` and `@/lib/api/rate-limit`
+- Use `createUserScopedClient` from `@/lib/supabase/user-scoped`
+- Query owned trips AND shared trips (via trip_collaborators with accepted_at NOT NULL)
+- Join trip_items with trips to get `trip_title`
+- Use `sanitizeItem` from `@/lib/api/sanitize` on each item
+- Follow the exact patterns in `src/app/api/v1/trips/route.ts` for auth/error handling
+- Do NOT use createSecretClient() or service role to bypass RLS. Fix RLS policies instead if needed.
+
+### 2. Update CLI: `ubt items search`
+
+Add a new CLI command in `cli/ubt`:
+
+```
+ubt items search [--date YYYY-MM-DD] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--kind flight|hotel|train|...] [--limit N]
+```
+
+This should call `GET /api/v1/items` with the appropriate query params.
+
+The formatted output should show:
+```
+  <item_id>  flight     Spirit Airlines      2026-03-13  21:00  EWR → AUS
+             Trip: Paris → Miami → Austin → Portland → Charleston
+```
+
+Also add to the help text at the top of the CLI file.
+
+### 3. Update Skill Documentation
+
+Update `skill/SKILL.md` to document the new endpoint under the Items section.
+
+## Files to Modify
+- `src/app/api/v1/items/route.ts` — CREATE new file with GET handler
+- `cli/ubt` — Add `items search` command + help text
+- `skill/SKILL.md` — Document the new endpoint
+
+## Files to Reference (read these first)
+- `src/app/api/v1/trips/route.ts` — Pattern for auth, shared trips, error handling
+- `src/app/api/v1/items/[id]/route.ts` — Existing item endpoint patterns
+- `src/app/api/v1/trips/[id]/items/route.ts` — Item select columns, sanitization
+- `cli/ubt` — CLI structure, command patterns, formatting functions
+- `src/lib/api/auth.ts` — Auth helpers
+- `src/lib/api/sanitize.ts` — Sanitization helpers
+
+## Testing
+After building, verify with:
+```bash
+FORMAT=json cli/ubt items search --date 2026-03-13 --kind flight
+```
+
+This should return flight items for that date across all trips.
+
+## Do NOT
+- Do NOT use createSecretClient() or service role to bypass RLS
+- Do NOT modify existing endpoints
+- Do NOT change the database schema
+- This code will be security-audited monthly

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -144,6 +144,52 @@ Returns weather forecasts for all trip destinations within the 16-day forecast w
 
 ### Items
 
+#### Search Items Across All Trips
+```
+GET /api/v1/items
+GET /api/v1/items?date=2026-03-13
+GET /api/v1/items?from=2026-03-13&to=2026-03-20&kind=flight&limit=25&offset=0
+```
+
+Searches trip items across all trips the authenticated user can access, including owned trips and accepted shared trips.
+
+Query params:
+- `date`: return items active on that date (`start_date <= date` and `end_date >= date`, with single-day items matching on `start_date`)
+- `from` / `to`: return items overlapping that range
+- `kind`: filter by item kind, such as `flight`, `hotel`, `train`, `activity`, `car_rental`, `restaurant`, `ticket`, `other`
+- `limit`: max results, default `50`, max `200`
+- `offset`: pagination offset
+
+Response:
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "trip_id": "uuid",
+      "trip_title": "Paris → Miami → Austin",
+      "kind": "flight",
+      "provider": "Spirit Airlines",
+      "summary": "Spirit Airlines flight 457 from Newark to Austin",
+      "start_date": "2026-03-13",
+      "end_date": "2026-03-13",
+      "start_ts": "2026-03-14T01:00:00Z",
+      "end_ts": "2026-03-14T05:10:00Z",
+      "start_location": "EWR",
+      "end_location": "AUS",
+      "details_json": {
+        "departure_local_time": "21:00",
+        "arrival_local_time": "00:10"
+      },
+      "status": "confirmed",
+      "created_at": "2026-03-01T12:00:00Z",
+      "updated_at": "2026-03-02T09:00:00Z"
+    }
+  ],
+  "meta": { "count": 1, "limit": 50, "offset": 0 }
+}
+```
+
 #### Get Single Item
 ```
 GET /api/v1/items/:id

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -93,6 +93,7 @@ Authorization: Bearer ubt_k1_abc123...
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | /api/v1/items | Search items across all trips |
 | GET | /api/v1/items/:id | Get single item |
 | PATCH | /api/v1/items/:id | Update item |
 | DELETE | /api/v1/items/:id | Delete item |
@@ -120,6 +121,28 @@ Authorization: Bearer ubt_k1_abc123...
 | traveler_names | string[] | Up to 20 names, each max 200 chars |
 | details_json | object | Freeform metadata — seat, gate, room type, etc. (max 10KB) |
 | notes | string | User notes |
+
+### Search Items Across Trips
+
+\`\`\`
+GET /api/v1/items?date=2026-04-01&kind=flight
+Authorization: Bearer ubt_k1_abc123...
+
+200 OK
+{
+  "data": [
+    { "id": "uuid", "trip_id": "uuid", "kind": "flight", "summary": "AF276 CDG→NRT", "start_date": "2026-04-01", "trip_title": "Tokyo Trip", ... }
+  ],
+  "meta": { "count": 1, "limit": 50, "offset": 0 }
+}
+\`\`\`
+
+**Query parameters:**
+- \`date\` — Items active on this date (YYYY-MM-DD)
+- \`from\` / \`to\` — Date range (cannot combine with \`date\`)
+- \`kind\` — Filter by item kind (flight, hotel, train, etc.)
+- \`limit\` — Results per page (1–200, default 50)
+- \`offset\` — Pagination offset (default 0)
 
 ### Example: Add a Flight
 

--- a/src/app/api/v1/items/route.ts
+++ b/src/app/api/v1/items/route.ts
@@ -1,0 +1,273 @@
+/**
+ * GET /api/v1/items — Search trip items across all accessible trips
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { validateApiKey, isAuthError } from '@/lib/api/auth'
+import { rateLimitResponse } from '@/lib/api/rate-limit'
+import { sanitizeItem } from '@/lib/api/sanitize'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
+
+const ITEM_SELECT = `id,
+       trip_id,
+       kind,
+       provider,
+       summary,
+       start_date,
+       end_date,
+       start_ts,
+       end_ts,
+       start_location,
+       end_location,
+       details_json,
+       status,
+       created_at,
+       updated_at,
+       trip:trips!inner(title)`
+
+const VALID_ITEM_KINDS = new Set([
+  'flight',
+  'hotel',
+  'car_rental',
+  'train',
+  'activity',
+  'restaurant',
+  'ticket',
+  'other',
+])
+
+function isValidIsoDate(value: string | null): value is string {
+  return value !== null && /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(value))
+}
+
+function parsePositiveInt(
+  rawValue: string | null,
+  field: 'limit' | 'offset',
+  defaultValue: number
+): { value: number } | { error: NextResponse } {
+  if (rawValue === null) return { value: defaultValue }
+  if (!/^\d+$/.test(rawValue)) {
+    return {
+      error: NextResponse.json(
+        { error: { code: 'invalid_param', message: `"${field}" must be a non-negative integer.` } },
+        { status: 400 }
+      ),
+    }
+  }
+
+  const value = Number.parseInt(rawValue, 10)
+  if (!Number.isSafeInteger(value) || value < 0) {
+    return {
+      error: NextResponse.json(
+        { error: { code: 'invalid_param', message: `"${field}" must be a non-negative integer.` } },
+        { status: 400 }
+      ),
+    }
+  }
+
+  return { value }
+}
+
+type SharedTripRow = {
+  trip: Array<{
+    id: string
+    title: string
+  }>
+}
+
+type ItemRow = Record<string, unknown> & {
+  trip: Array<{
+    title: string
+  }>
+}
+
+export async function GET(request: NextRequest) {
+  // 1. Authenticate
+  const auth = await validateApiKey(request)
+  if (isAuthError(auth)) return auth
+
+  // 2. Rate limit
+  const limited = rateLimitResponse(auth.keyHash)
+  if (limited) return limited
+
+  const searchParams = request.nextUrl.searchParams
+  const date = searchParams.get('date')
+  const from = searchParams.get('from')
+  const to = searchParams.get('to')
+  const kind = searchParams.get('kind')
+
+  if (date && (from || to)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'invalid_param',
+          message: 'Use either "date" or "from"/"to", not both.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  for (const [field, value] of [
+    ['date', date],
+    ['from', from],
+    ['to', to],
+  ] as const) {
+    if (value !== null && !isValidIsoDate(value)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'invalid_param',
+            message: `"${field}" must be a valid ISO date (YYYY-MM-DD).`,
+          },
+        },
+        { status: 400 }
+      )
+    }
+  }
+
+  if (from && to && from > to) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'invalid_param',
+          message: '"from" must be less than or equal to "to".',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (kind !== null && !VALID_ITEM_KINDS.has(kind)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'invalid_param',
+          message:
+            '"kind" must be one of: flight, hotel, car_rental, train, activity, restaurant, ticket, other.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const parsedLimit = parsePositiveInt(searchParams.get('limit'), 'limit', 50)
+  if ('error' in parsedLimit) return parsedLimit.error
+  if (parsedLimit.value < 1 || parsedLimit.value > 200) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'invalid_param',
+          message: '"limit" must be between 1 and 200.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+  const limit = parsedLimit.value
+
+  const parsedOffset = parsePositiveInt(searchParams.get('offset'), 'offset', 0)
+  if ('error' in parsedOffset) return parsedOffset.error
+  const offset = parsedOffset.value
+
+  const supabase = await createUserScopedClient(auth.userId)
+
+  // 3a. Fetch owned trips
+  const { data: ownedTrips, error: ownedError } = await supabase
+    .from('trips')
+    .select('id, title')
+    .eq('user_id', auth.userId)
+
+  if (ownedError) {
+    console.error('[v1/items] Supabase error (owned trips):', ownedError)
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'Failed to fetch items.' } },
+      { status: 500 }
+    )
+  }
+
+  // 3b. Fetch shared trips (collaborator, accepted)
+  const { data: sharedCollabs, error: sharedError } = await supabase
+    .from('trip_collaborators')
+    .select('trip:trips!inner(id, title)')
+    .eq('user_id', auth.userId)
+    .not('accepted_at', 'is', null)
+
+  if (sharedError) {
+    console.error('[v1/items] Supabase error (shared trips):', sharedError)
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'Failed to fetch items.' } },
+      { status: 500 }
+    )
+  }
+
+  const tripMap = new Map<string, string>()
+  for (const trip of ownedTrips ?? []) {
+    tripMap.set(trip.id, trip.title)
+  }
+  for (const collab of (sharedCollabs ?? []) as SharedTripRow[]) {
+    const trip = collab.trip[0]
+    if (trip) {
+      tripMap.set(trip.id, trip.title)
+    }
+  }
+
+  const tripIds = [...tripMap.keys()]
+  if (tripIds.length === 0) {
+    return NextResponse.json({
+      data: [],
+      meta: { count: 0, limit, offset },
+    })
+  }
+
+  // 4. Fetch filtered items
+  let query = supabase
+    .from('trip_items')
+    .select(ITEM_SELECT, { count: 'exact' })
+    .in('trip_id', tripIds)
+    .order('start_date', { ascending: true, nullsFirst: false })
+    .order('start_ts', { ascending: true, nullsFirst: false })
+    .range(offset, offset + limit - 1)
+
+  if (kind) {
+    query = query.eq('kind', kind)
+  }
+
+  if (date) {
+    query = query
+      .lte('start_date', date)
+      .or(`end_date.gte.${date},and(end_date.is.null,start_date.eq.${date})`)
+  } else {
+    if (to) {
+      query = query.lte('start_date', to)
+    }
+    if (from) {
+      query = query.or(`end_date.gte.${from},and(end_date.is.null,start_date.gte.${from})`)
+    }
+  }
+
+  const { data: items, error: itemsError, count } = await query
+
+  if (itemsError) {
+    console.error('[v1/items] Supabase error (items):', itemsError)
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'Failed to fetch items.' } },
+      { status: 500 }
+    )
+  }
+
+  const sanitized = (items ?? []).map((item) => {
+    const row = item as ItemRow
+    const { trip, ...flat } = row
+    const tripRow = trip[0]
+    return sanitizeItem({
+      ...flat,
+      trip_title: tripRow?.title ?? tripMap.get(String(row.trip_id ?? '')) ?? null,
+    })
+  })
+
+  return NextResponse.json({
+    data: sanitized,
+    meta: { count: count ?? 0, limit, offset },
+  })
+}


### PR DESCRIPTION
## Summary
Adds the ability to search for items (flights, hotels, etc.) across ALL trips by date and kind.

## Problem
When a user asked "what's my flight tomorrow?", the only way to find it was to list all trips and fetch items for each one. The trips list only returned trip-level dates, not individual item dates.

## Solution
- **New API endpoint:** 
- **New CLI command:** 
- Supports date range filtering with  and  params
- Returns items with  for context

## Changes
-  — new endpoint
- ubt — UB Trippin CLI

Usage: ubt <command> [args]

  version                               Print CLI version
  login                                 Authenticate with your API key
  whoami                                Show current authenticated user
  selftest                              Test API connectivity

Commands:
  trips list [user_id]                  List all trips (owned + shared)
  trips search <query>                  Search trips by title/location
  trips show <trip_id>                  Show trip details + items
  trips create <title> [--start Y-M-D] [--end Y-M-D]  Create a trip *
  trips update <trip_id> [--title X] [--notes X] [--start X] [--end X]  Update a trip *
  trips rename <trip_id> <new_title>    Rename a trip *
  trips delete <trip_id>                Delete a trip *
  trips status <trip_id>                Show live statuses for trip flight/train items *
  trips merge <target> <source>         Merge source trip into target (deletes source) *
  items list <trip_id>                  List items in a trip
  items search [--date Y-M-D] [--from Y-M-D] [--to Y-M-D] [--kind X] [--limit N]  Search items across all trips *
  items show <item_id>                  Show item details *
  items add <trip_id> --kind <k> --summary <text> [--provider X] [--start-ts X] [--end-ts X] [--start-date Y-M-D] [--end-date Y-M-D] [--start-location X] [--end-location X] [--details-json '{...}']  Add item *
  items update <item_id> [--summary X] [--start-location X] [--end-location X] [--status X]  Update item *
  items delete <item_id>                Delete an item *
  items status <item_id>                Show item live status *
  items refresh <item_id>               Refresh item live status *
  items move <item_id> <trip_id>        Move item to another trip *
  tickets list [trip_id]                List all tickets/events (alias: events)
  tickets add <trip_id> --event <name> --date <Y-M-D> [--venue X] [--performer X] [--time HH:MM] [--doors HH:MM] [--section X] [--row X] [--seat X] [--tickets N] [--provider X]
  tickets show <item_id>                Show ticket details
  guides list                           List city guides *
  guides create <city> [--country X] [--country-code XX]  Create guide *
  guides show <guide_id>                Show guide + entries *
  guides delete <guide_id>              Delete guide *
  guides entry add <guide_id> --name <name> --category <cat> [--description X] [--url X] [--tags tag1,tag2] [--status visited|to_try]  Add guide entry *
  guides entry update <guide_id> <entry_id> [--name X] [--category X] [--description X]  Update guide entry *
  guides entry delete <guide_id> <entry_id>  Delete guide entry *
  guides nearby --lat X --lng Y         Find nearby guide entries *
  trains status <train_number>          Show train status (uses today's UTC date unless --date) *
  billing show                          Show current billing subscription details *
  billing portal                        Get Stripe billing portal URL *
  activation status                     Show activation/onboarding status *
  calendar get                          Get your iCal feed URL *
  calendar regen                        Regenerate calendar token (invalidates old URL) *
  image search <query>                  Search Unsplash for cover images *
  senders list                          List allowed email senders *
  senders add <email> [label]           Add an allowed sender *
  senders remove <id>                   Remove an allowed sender *
  webhooks list                         List registered webhooks *
  webhooks add <url> [--events a,b] [--secret s] [--description text]  Add webhook *
  webhooks show <id>                    Show webhook details *
  webhooks delete <id>                  Delete a webhook *
  webhooks test <id>                    Send test ping *
  webhooks deliveries <id>              List delivery logs *
  collab list <trip_id>                 List collaborators on a trip you own *
  collab invite <trip_id> <email> [role] Invite a collaborator (editor or viewer) *
  collab remove <trip_id> <collab_id>   Remove a collaborator *
  family list                           List families *
  family create <name>                  Create a family (Pro) *
  family show <family_id>               Show family details + members *
  family invite <family_id> <email>     Invite a family member (Pro) *
  family remove <family_id> <user_id>   Remove family member by user_id/member_id *
  family leave <family_id>              Leave a family *
  family loyalty <family_id>            List family loyalty programs *
  family loyalty lookup <family_id> <provider> Lookup provider across family members *
  family profiles <family_id>           List family profiles *
  family trips <family_id> [scope]      List family trips (scope: all/current/upcoming/past) *
  family guides <family_id>             List family guides *
  notifications list [--unread]         List notifications *
  notifications read <id>               Mark a notification as read *
  profile show                          Show traveler profile + loyalty vault *
  profile set <field> <value>           Update one traveler profile field *
  profile loyalty list                  List loyalty programs (masked) *
  profile loyalty add                   Add a loyalty program (interactive) *
  profile loyalty edit <id>             Edit a loyalty program (interactive) *
  profile loyalty delete <id>           Delete a loyalty program *
  profile loyalty lookup <provider_key> Lookup by provider (alliance fallback aware) *
  profile loyalty export                Export loyalty vault JSON *
  users                                 List all users (admin)
  health                                Check service health
  rls-check                             Verify RLS policies

Commands marked * require UBT_API_KEY in ~/.ubt/config or env.

Options:
  FORMAT=json ubt ...      Output raw JSON instead of formatted text
  UBT_API_URL=...          Override API base URL (default: https://www.ubtrippin.xyz/api/v1)

Examples:
  ubt trips list
  ubt trips show 58bd2048-607c-4afc-a915-2edb6a9f6c54
  ubt trips search paris
  ubt trips create "Paris Weekend" --start 2026-04-10 --end 2026-04-14
  ubt trips update <trip_id> --notes "Bring passports"
  ubt trips rename <trip_id> "NYC + Boston"
  ubt trips status <trip_id>
  ubt trips merge <target_id> <source_id>
  ubt items search --date 2026-03-13 --kind flight
  ubt items show <item_id>
  ubt items add <trip_id> --kind flight --summary "UA 101 SFO to JFK" --start-ts 2026-04-10T08:30:00Z
  ubt items update <item_id> --status confirmed
  ubt items status <item_id>
  ubt items refresh <item_id>
  ubt items move <item_id> <target_trip_id>
  ubt guides list
  ubt guides create "Tokyo" --country Japan --country-code JP
  ubt guides entry add <guide_id> --name "Sushi Dai" --category Food --status to_try
  ubt guides nearby --lat 35.6762 --lng 139.6503
  ubt trains status TGV1234 --date 2026-06-01
  ubt billing show
  ubt activation status
  ubt calendar get
  ubt senders list
  ubt webhooks list
  ubt webhooks add https://example.com/webhooks/ubt --events item.created,item.updated
  ubt image search "paris eiffel tower"
  FORMAT=json ubt items list <trip_id>
  ubt collab list <trip_id>
  ubt collab invite <trip_id> friend@example.com editor
  ubt collab remove <trip_id> <collab_id>
  ubt family list
  ubt family create "Rogers Family"
  ubt family show <family_id>
  ubt family invite <family_id> parent@example.com
  ubt family loyalty lookup <family_id> united
  ubt notifications list --unread
  ubt notifications read <notification_id>
  ubt trips weather <trip_id> [--refresh] [--celsius]
  ubt profile show
  ubt profile set seat window
  ubt profile loyalty lookup united — new  command
-  — documentation

## Testing


## Security
- Uses existing auth/RLS patterns
- No service role bypass
- Rate limited
