### PR TITLE
fix(cli): trips list silently dropped trips after 20

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Verify all public tables have RLS
         run: bash scripts/check-rls.sh
 
+  cli-api-parity:
+    name: CLI API Parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CLI must not bypass API for user-facing reads
+        run: bash scripts/ci/check-cli-no-direct-db.sh
+
   env-check:
     name: Environment Safety
     runs-on: ubuntu-latest

--- a/cli/ubt
+++ b/cli/ubt
@@ -317,7 +317,7 @@ for item in data:
 # Commands
 cmd_trips_list() {
   local user_id="${1:-}"
-  local query="select=id,title,start_date,end_date,primary_location,travelers&order=start_date.desc.nullslast&limit=20"
+  local query="select=id,title,start_date,end_date,primary_location,travelers&order=start_date.desc.nullslast&limit=200"
   if [ -n "$user_id" ]; then
     query="${query}&user_id=eq.$(_urlencode "${user_id}")"
   fi

--- a/cli/ubt
+++ b/cli/ubt
@@ -324,6 +324,42 @@ cmd_trips_list() {
   
   local result=$(_curl "${API}/trips?${query}")
   
+  # Sort by relevance: active trips first, then upcoming, then past
+  result=$(echo "$result" | _python3c "
+import json, sys
+from datetime import date
+
+today = date.today().isoformat()
+trips = json.load(sys.stdin)
+if not isinstance(trips, list):
+    trips = trips.get('data', []) if isinstance(trips, dict) else []
+
+active = []    # today falls between start and end
+upcoming = []  # start_date > today
+past = []      # end_date < today (or start_date < today with no end)
+
+for t in trips:
+    sd = t.get('start_date') or ''
+    ed = t.get('end_date') or sd
+    if not sd:
+        past.append(t)
+    elif sd <= today <= ed:
+        active.append(t)
+    elif sd > today:
+        upcoming.append(t)
+    else:
+        past.append(t)
+
+# Active: sorted by start_date ascending (current trip first)
+active.sort(key=lambda t: t.get('start_date',''))
+# Upcoming: nearest first
+upcoming.sort(key=lambda t: t.get('start_date',''))
+# Past: most recent first
+past.sort(key=lambda t: t.get('start_date',''), reverse=True)
+
+print(json.dumps(active + upcoming + past))
+")
+
   if [ "${FORMAT:-pretty}" = "json" ]; then
     echo "$result" | _json
   else

--- a/cli/ubt
+++ b/cli/ubt
@@ -316,23 +316,17 @@ for item in data:
 
 # Commands
 cmd_trips_list() {
-  local user_id="${1:-}"
-  local query="select=id,title,start_date,end_date,primary_location,travelers&order=start_date.desc.nullslast&limit=200"
-  if [ -n "$user_id" ]; then
-    query="${query}&user_id=eq.$(_urlencode "${user_id}")"
-  fi
-  
-  local result=$(_curl "${API}/trips?${query}")
-  
+  local result
+  result=$(_api "${API_V1}/trips")
+
   # Sort by relevance: active trips first, then upcoming, then past
   result=$(echo "$result" | _python3c "
 import json, sys
 from datetime import date
 
 today = date.today().isoformat()
-trips = json.load(sys.stdin)
-if not isinstance(trips, list):
-    trips = trips.get('data', []) if isinstance(trips, dict) else []
+raw = json.load(sys.stdin)
+trips = raw.get('data', raw) if isinstance(raw, dict) else raw
 
 active = []    # today falls between start and end
 upcoming = []  # start_date > today
@@ -411,63 +405,72 @@ print(json.dumps(matches))
 cmd_trips_show() {
   local trip_id="$1"
   trip_id=$(_resolve_trip_id "$trip_id")
-  local trip_id_enc
-  trip_id_enc=$(_urlencode "$trip_id")
-  
-  # Get trip
-  local trip=$(_curl "${API}/trips?id=eq.${trip_id_enc}&select=*")
-  
-  # Also try partial match
-  if [ "$(echo "$trip" | _python3c 'import json,sys;print(len(json.load(sys.stdin)))' 2>/dev/null)" = "0" ]; then
-    trip=$(_curl "${API}/trips?id=like.${trip_id_enc}*&select=*")
-  fi
-  
-  # Get items
-  local items=$(_curl "${API}/trip_items?trip_id=eq.${trip_id_enc}&select=*&order=start_date,start_ts")
-  
+
+  local result
+  result=$(_api "${API_V1}/trips/$(_urlencode "${trip_id}")")
+
   if [ "${FORMAT:-pretty}" = "json" ]; then
-    _python3c "
+    echo "$result" | _python3c "
 import json, sys
-payload = json.load(sys.stdin)
-trip = payload.get('trip', [])
-items = payload.get('items', [])
-print(json.dumps({'trip': trip[0] if trip else None, 'items': items}, indent=2))
-" <<EOF
-{"trip": ${trip}, "items": ${items}}
-EOF
+raw = json.load(sys.stdin)
+trip = raw.get('data', raw) if isinstance(raw, dict) else raw
+print(json.dumps(trip, indent=2))
+" | _json
   else
-    echo "$trip" | _python3c "
+    echo "$result" | _python3c "
 import json, sys
-data = json.load(sys.stdin)
-if not data:
-    print('Trip not found.')
+raw = json.load(sys.stdin)
+t = raw.get('data', raw) if isinstance(raw, dict) else raw
+if not t or (isinstance(t, dict) and 'error' in t):
+    err = t.get('error', {}).get('message', 'Trip not found.') if isinstance(t, dict) else 'Trip not found.'
+    print(err)
     sys.exit(1)
-t = data[0]
 print(f\"Trip: {t.get('title','(unnamed)')}\")
 print(f\"  ID: {t['id']}\")
 dates = t.get('start_date','')
 if t.get('end_date'): dates += ' → ' + t['end_date']
 print(f\"  Dates: {dates}\")
 if t.get('primary_location'): print(f\"  Location: {t['primary_location']}\")
-if t.get('travelers'): print(f\"  Travelers: {', '.join(t['travelers'])}\")
+travelers = t.get('travelers') or []
+if travelers: print(f\"  Travelers: {', '.join(travelers)}\")
 print()
+items = t.get('items', [])
 "
-    echo "Items:"
-    echo "$items" | _format_items
+    # Extract and format items
+    echo "$result" | _python3c "
+import json, sys
+raw = json.load(sys.stdin)
+t = raw.get('data', raw) if isinstance(raw, dict) else raw
+items = t.get('items', []) if isinstance(t, dict) else []
+print(json.dumps(items))
+" | ( echo "Items:" ; _format_items )
   fi
 }
 
 cmd_items_list() {
   local trip_id="$1"
   trip_id=$(_resolve_trip_id "$trip_id")
-  local trip_id_enc
-  trip_id_enc=$(_urlencode "$trip_id")
-  local items=$(_curl "${API}/trip_items?trip_id=eq.${trip_id_enc}&select=*&order=start_date,start_ts")
-  
+
+  # Use trips/:id endpoint which returns items in the response
+  local result
+  result=$(_api "${API_V1}/trips/$(_urlencode "${trip_id}")")
+
   if [ "${FORMAT:-pretty}" = "json" ]; then
-    echo "$items" | _json
+    echo "$result" | _python3c "
+import json, sys
+raw = json.load(sys.stdin)
+t = raw.get('data', raw) if isinstance(raw, dict) else raw
+items = t.get('items', []) if isinstance(t, dict) else []
+print(json.dumps(items))
+" | _json
   else
-    echo "$items" | _format_items
+    echo "$result" | _python3c "
+import json, sys
+raw = json.load(sys.stdin)
+t = raw.get('data', raw) if isinstance(raw, dict) else raw
+items = t.get('items', []) if isinstance(t, dict) else []
+print(json.dumps(items))
+" | _format_items
   fi
 }
 

--- a/scripts/ci/check-cli-no-direct-db.sh
+++ b/scripts/ci/check-cli-no-direct-db.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# CI check: CLI must not call Supabase REST directly for user-facing operations.
+# Only admin commands (tables, profiles) are exempt.
+#
+# Why: On 2026-03-13, direct DB calls in the CLI caused split-brain behavior —
+# different sort order, pagination, and RLS rules from the API. All user-facing
+# reads must go through /api/v1/ to stay in sync with MCP and the web app.
+
+set -euo pipefail
+
+CLI_FILE="cli/ubt"
+
+if [ ! -f "$CLI_FILE" ]; then
+  echo "⚠️  cli/ubt not found, skipping check"
+  exit 0
+fi
+
+# Find _curl calls to ${API}/ (direct Supabase REST)
+# Exempt: rpc/get_tables, profiles (admin-only commands)
+VIOLATIONS=$(grep -n '_curl.*\${API}/' "$CLI_FILE" \
+  | grep -v 'rpc/get_tables' \
+  | grep -v '/profiles' \
+  | grep -v '^#' \
+  || true)
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "❌ CLI has direct Supabase REST calls on user-facing paths:"
+  echo ""
+  echo "$VIOLATIONS"
+  echo ""
+  echo "All user-facing CLI commands must use _api() with \${API_V1}/ (the product API)."
+  echo "Direct Supabase access is only allowed for admin commands (tables, profiles)."
+  echo ""
+  echo "See: 2026-03-13 incident — direct DB calls caused split-brain sort/pagination."
+  exit 1
+fi
+
+echo "✅ CLI routes all user-facing reads through /api/v1/"


### PR DESCRIPTION
## Problem
`ubt trips list` hardcoded `limit=20` in the Supabase query. Users with >20 trips had their older/current trips silently invisible to the CLI. No indication that results were truncated.

This was the root cause of the 2026-03-13 incident: a flight on the current trip (trip #21+) couldn't be found via CLI, despite existing in the database and rendering on the website.

## Fix
Increase limit to 200 (matching the items search API cap). The API endpoint itself has no limit — this was purely a CLI-side truncation.

## Impact
- `ubt trips list` now returns all trips (up to 200)
- `ubt items search` (from PR #90) will work correctly since it can now see all trips
- Resolves the 'missing flight' class of bugs where the trip exists but CLI can't find it