### PR TITLE
fix: show arrival date on overnight flights

### DIFF
--- a/src/components/trips/transition-card.tsx
+++ b/src/components/trips/transition-card.tsx
@@ -45,7 +45,7 @@ export function TransitionCard({
             </div>
 
             <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-600">
-              <span>{journey.date ? `${formatShortDate(journey.date)}, ` : ''}{journey.departure.code} {journey.departure.time || '--:--'} to {journey.arrival.code} {journey.arrival.time || '--:--'}</span>
+              <span>{journey.date ? `${formatShortDate(journey.date)}, ` : ''}{journey.departure.code} {journey.departure.time || '--:--'} to {journey.arrivalDate ? `${formatShortDate(journey.arrivalDate)}, ` : ''}{journey.arrival.code} {journey.arrival.time || '--:--'}</span>
               <span>{stopLabel(journey)}</span>
               {journey.duration ? (
                 <span className="inline-flex items-center gap-1">

--- a/src/components/trips/trip-item-card.tsx
+++ b/src/components/trips/trip-item-card.tsx
@@ -361,12 +361,14 @@ export function TripItemCard({ item, allTrips, currentUserId, readOnly = false, 
                   if (!item.start_ts && !det?.departure_local_time && !det?.check_in_time) return null
                   const [start, end] = getLocalTimes({ start_ts: item.start_ts, end_ts: item.end_ts, details: det })
                   const datePrefix = item.start_date ? formatShortDate(item.start_date) : ''
+                  const showArrivalDate = item.kind === 'flight' && item.end_date && item.start_date && item.end_date !== item.start_date
+                  const arrivalDateLabel = showArrivalDate ? formatShortDate(item.end_date) : ''
                   return (
                     <span className="flex items-center gap-1">
                       <Clock className="h-3.5 w-3.5" />
                       {datePrefix && `${datePrefix}, `}
                       {start}
-                      {end && ` - ${end}`}
+                      {end && (<>{showArrivalDate ? ` - ${arrivalDateLabel}, ` : ' - '}{end}</>)}
                     </span>
                   )
                 })()}

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -21,6 +21,7 @@ export interface FlightJourney {
   stopCodes: string[]
   legs: TripItem[]
   date: string
+  arrivalDate?: string
   duration?: string
 }
 
@@ -173,6 +174,10 @@ function firstPass(items: TripItem[]): Array<TripItem | FlightJourney> {
     const endTime = parseItemDateTime(legs[legs.length - 1], 'end')?.getTime() ?? startTime
     const stopCodes = buildStopCodes(legs)
 
+    const departureDate = legs[0].start_date
+    const lastLeg = legs[legs.length - 1]
+    const arrDate = lastLeg.end_date ?? lastLeg.start_date
+
     processed.push({
       type: 'flight-journey',
       departure,
@@ -180,7 +185,8 @@ function firstPass(items: TripItem[]): Array<TripItem | FlightJourney> {
       stops: stopCodes.length,
       stopCodes,
       legs,
-      date: legs[0].start_date,
+      date: departureDate,
+      arrivalDate: arrDate !== departureDate ? arrDate : undefined,
       duration: formatDuration(endTime - startTime),
     })
   }


### PR DESCRIPTION
## What

When a flight crosses midnight (arrival date ≠ departure date), both the transition card and the flight item card now display the arrival date.

**Transition card:**
- Before: `Mar 24, JFK 19:00 to LHR 06:20`
- After: `Mar 24, JFK 19:00 to Mar 25, LHR 06:20`

**Flight item card:**
- Before: `Mar 24, 7:00 PM - 6:20 AM`
- After: `Mar 24, 7:00 PM - Mar 25, 6:20 AM`

## Why

Overnight international flights show only the departure date, making the arrival time ambiguous. Users need to see that 06:20 AM is the *next day*.

## Changes

- `city-segments.ts`: Added `arrivalDate` field to `FlightJourney` interface, populated from last leg's `end_date` when it differs from departure date
- `transition-card.tsx`: Display arrival date prefix before arrival airport code when present
- `trip-item-card.tsx`: For flight items, show arrival date before arrival time when `end_date ≠ start_date`

## Testing

- Flights departing and arriving same day: no change (arrival date not shown)
- Overnight flights (e.g., JFK→LHR): arrival date now shown
- Multi-leg journeys: uses last leg's end_date for the journey arrival date
- TypeScript compiles clean