### PR TITLE
feat: PRD-050 CLI reliability — today command, robust errors, deep selftest

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/cli/ubt
+++ b/cli/ubt
@@ -43,6 +43,13 @@ if [ -z "$UBT_API_KEY" ] && [ -f "$CONFIG_FILE" ]; then
   UBT_API_KEY=$(grep '^UBT_API_KEY=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"')
 fi
 
+# Exit codes (PRD-050)
+EXIT_OK=0
+EXIT_USER_ERROR=1
+EXIT_AUTH_ERROR=2
+EXIT_API_ERROR=3
+EXIT_DATA_ERROR=4
+
 # Helpers
 _curl() {
   curl -s "$@" \
@@ -65,22 +72,52 @@ _require_api_key() {
 
 _api() {
   _require_api_key
-  curl -s "$@" \
+  local _body_file _headers_file _http_code _content_type
+  _body_file=$(mktemp)
+  _headers_file=$(mktemp)
+  _http_code=$(curl -s -o "${_body_file}" -D "${_headers_file}" -w "%{http_code}" "$@" \
     -H "Authorization: Bearer ${UBT_API_KEY}" \
-    -H "Content-Type: application/json"
+    -H "Content-Type: application/json")
+  _content_type=$(grep -i '^content-type:' "${_headers_file}" 2>/dev/null | head -1 | tr -d '\r' | cut -d: -f2- | xargs)
+
+  if [ "$_http_code" -ge 400 ] 2>/dev/null; then
+    # Check if response is HTML (404 page, etc.) instead of JSON
+    if echo "$_content_type" | grep -qi 'text/html'; then
+      echo "Error: API returned HTTP ${_http_code} (${_content_type}). Endpoint may not be deployed." >&2
+      rm -f "${_body_file}" "${_headers_file}"
+      return 1
+    fi
+    # JSON error — pass through for caller to handle
+    cat "${_body_file}"
+    rm -f "${_body_file}" "${_headers_file}"
+    return 1
+  fi
+
+  cat "${_body_file}"
+  rm -f "${_body_file}" "${_headers_file}"
 }
 
 _api_with_status() {
   _require_api_key
-  local body_file
+  local body_file headers_file
   body_file=$(mktemp)
-  local http_code
-  http_code=$(curl -s -o "${body_file}" -w "%{http_code}" "$@" \
+  headers_file=$(mktemp)
+  local http_code content_type
+  http_code=$(curl -s -o "${body_file}" -D "${headers_file}" -w "%{http_code}" "$@" \
     -H "Authorization: Bearer ${UBT_API_KEY}" \
     -H "Content-Type: application/json")
+  content_type=$(grep -i '^content-type:' "${headers_file}" 2>/dev/null | head -1 | tr -d '\r' | cut -d: -f2- | xargs)
+
+  if echo "$content_type" | grep -qi 'text/html' && [ "$http_code" -ge 400 ] 2>/dev/null; then
+    printf '%s\n' "${http_code}"
+    echo "{\"error\":{\"code\":\"endpoint_error\",\"message\":\"API returned HTTP ${http_code} with HTML response. Endpoint may not be deployed.\"}}"
+    rm -f "${body_file}" "${headers_file}"
+    return
+  fi
+
   printf '%s\n' "${http_code}"
   cat "${body_file}"
-  rm -f "${body_file}"
+  rm -f "${body_file}" "${headers_file}"
 }
 
 _python3c() {
@@ -3528,30 +3565,204 @@ if det.get('ticket_count'): print(f\"  tickets:  {det['ticket_count']}\")
   fi
 }
 
+cmd_today() {
+  local today
+  today=$(date -u +%Y-%m-%d)
+  local response
+  response=$(_api "${API_V1}/items?date=${today}" 2>&1) || {
+    echo "Error fetching today's items: ${response}" >&2
+    exit 1
+  }
+
+  if [ "${FORMAT:-}" = "json" ]; then
+    echo "$response"
+    return
+  fi
+
+  _python3c '
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+except (json.JSONDecodeError, IndexError):
+    print("No items found for today.", file=sys.stderr)
+    sys.exit(0)
+
+items = data.get("data", data) if isinstance(data, dict) else data
+if not isinstance(items, list):
+    items = []
+
+if not items:
+    print("No items for today.")
+    sys.exit(0)
+
+print(f"Today ({sys.argv[2]}) — {len(items)} item(s):\n")
+for item in items:
+    kind = (item.get("kind") or "item").upper()
+    summary = item.get("summary") or "(no summary)"
+    start_ts = item.get("start_ts") or ""
+    end_ts = item.get("end_ts") or ""
+    trip_title = ""
+    # Try to get trip title if available
+    trip = item.get("trip")
+    if isinstance(trip, dict):
+        trip_title = trip.get("title", "")
+
+    time_str = ""
+    if start_ts:
+        t = start_ts.split("T")[1][:5] if "T" in start_ts else ""
+        if end_ts:
+            t2 = end_ts.split("T")[1][:5] if "T" in end_ts else ""
+            time_str = f"  {t} → {t2}" if t2 else f"  {t}"
+        else:
+            time_str = f"  {t}"
+
+    trip_info = f"  [{trip_title}]" if trip_title else ""
+    print(f"  {kind:10}{time_str}   {summary}{trip_info}")
+' "$response" "$today"
+}
+
 cmd_selftest() {
+  local deep=false
+  if [ "${1:-}" = "--deep" ]; then
+    deep=true
+  fi
+
   if [ -z "$UBT_API_KEY" ]; then
     echo "FAIL: No API key configured. Run 'ubt login' or set UBT_API_KEY." >&2
     exit 1
   fi
-  local endpoints="trips me/profile me/loyalty guides settings/senders"
+
   local all_pass=true
+  local pass_count=0
+  local fail_count=0
+
+  _check() {
+    local label="$1" result="$2"
+    if [ "$result" = "PASS" ]; then
+      echo "  ✅  ${label}"
+      pass_count=$((pass_count + 1))
+    else
+      echo "  ❌  ${label}"
+      all_pass=false
+      fail_count=$((fail_count + 1))
+    fi
+  }
+
+  echo "UB Trippin CLI Self-Test"
+  echo "========================"
+  echo ""
+
+  # Basic endpoint checks
+  local endpoints="trips me/profile me/loyalty guides settings/senders"
   for ep in $endpoints; do
     local status
     status=$(curl -s -o /dev/null -w "%{http_code}" "${API_V1}/${ep}" \
       -H "Authorization: Bearer ${UBT_API_KEY}" \
       -H "Content-Type: application/json")
     if [ "$status" = "200" ]; then
-      echo "  PASS  GET /api/v1/${ep} (${status})"
+      _check "GET /api/v1/${ep} (${status})" "PASS"
     else
-      echo "  FAIL  GET /api/v1/${ep} (${status})"
-      all_pass=false
+      _check "GET /api/v1/${ep} (${status})" "FAIL"
     fi
   done
+
+  if [ "$deep" = true ]; then
+    echo ""
+    echo "Deep checks:"
+
+    # Check trips list returns data
+    local trips_body
+    trips_body=$(_api "${API_V1}/trips" 2>/dev/null) || true
+    local trip_count
+    trip_count=$(echo "$trips_body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('data',d) if isinstance(d,dict) else d))" 2>/dev/null || echo "0")
+    if [ "$trip_count" -gt 0 ] 2>/dev/null; then
+      _check "Trips list returns data (${trip_count} trips)" "PASS"
+    else
+      _check "Trips list returns data (got 0)" "FAIL"
+    fi
+
+    # Check item search returns data (proves items exist)
+    local items_search_body
+    items_search_body=$(_api "${API_V1}/items?limit=1" 2>/dev/null) || true
+    local has_items
+    has_items=$(echo "$items_search_body" | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    items=d.get('data',d) if isinstance(d,dict) else d
+    print(len(items) if isinstance(items,list) else 0)
+except: print(0)
+" 2>/dev/null || echo "0")
+    if [ "$has_items" -gt 0 ] 2>/dev/null; then
+      _check "Item search returns data" "PASS"
+    else
+      _check "Item search returns data" "FAIL"
+    fi
+
+    # Check cross-trip item search endpoint exists
+    local today
+    today=$(date -u +%Y-%m-%d)
+    local search_status
+    search_status=$(curl -s -o /dev/null -w "%{http_code}" "${API_V1}/items?date=${today}" \
+      -H "Authorization: Bearer ${UBT_API_KEY}" \
+      -H "Content-Type: application/json")
+    if [ "$search_status" = "200" ]; then
+      _check "Cross-trip item search responds (${search_status})" "PASS"
+    else
+      _check "Cross-trip item search responds (${search_status})" "FAIL"
+    fi
+
+    # Check response is JSON, not HTML
+    local trips_ct
+    trips_ct=$(curl -sI "${API_V1}/trips" \
+      -H "Authorization: Bearer ${UBT_API_KEY}" \
+      -H "Content-Type: application/json" | grep -i '^content-type:' | head -1)
+    if echo "$trips_ct" | grep -qi 'application/json'; then
+      _check "API returns JSON content-type" "PASS"
+    else
+      _check "API returns JSON content-type (got: ${trips_ct})" "FAIL"
+    fi
+
+    # Check bogus endpoint returns proper error, not HTML
+    local bogus_status bogus_ct
+    bogus_status=$(curl -s -o /dev/null -w "%{http_code}" "${API_V1}/nonexistent-endpoint-selftest" \
+      -H "Authorization: Bearer ${UBT_API_KEY}" \
+      -H "Content-Type: application/json")
+    if [ "$bogus_status" -ge 400 ] 2>/dev/null; then
+      _check "Bogus endpoint returns error code (${bogus_status})" "PASS"
+    else
+      _check "Bogus endpoint returns error code (${bogus_status})" "FAIL"
+    fi
+
+    # Check flights in next 48h have status data
+    local tomorrow
+    tomorrow=$(date -u -d "+1 day" +%Y-%m-%d 2>/dev/null || date -u -v+1d +%Y-%m-%d 2>/dev/null || echo "")
+    if [ -n "$today" ]; then
+      local flights_body
+      flights_body=$(_api "${API_V1}/items?kind=flight&from=${today}&to=${tomorrow:-$today}" 2>/dev/null) || true
+      local flight_info
+      flight_info=$(echo "$flights_body" | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    items=d.get('data',d) if isinstance(d,dict) else d
+    if not isinstance(items,list): items=[]
+    print(len(items))
+except: print(0)
+" 2>/dev/null || echo "0")
+      if [ "$flight_info" -gt 0 ] 2>/dev/null; then
+        _check "Flights in next 48h found (${flight_info})" "PASS"
+      else
+        _check "Flights in next 48h found (0 — may be normal)" "PASS"
+      fi
+    fi
+  fi
+
+  echo ""
+  echo "${pass_count} passed, ${fail_count} failed."
   if [ "$all_pass" = true ]; then
-    echo "All checks passed."
     exit 0
   else
-    echo "Some checks failed." >&2
     exit 1
   fi
 }
@@ -3566,7 +3777,8 @@ Usage: ubt <command> [args]
   version                               Print CLI version
   login                                 Authenticate with your API key
   whoami                                Show current authenticated user
-  selftest                              Test API connectivity
+  today                                 Show all items for today across all trips
+  selftest [--deep]                     Test API connectivity (--deep: verify data completeness)
 
 Commands:
   trips list [user_id]                  List all trips (owned + shared)
@@ -3864,7 +4076,8 @@ case "${1:-}" in
   version)  cmd_version ;;
   login)    cmd_login ;;
   whoami)   cmd_whoami ;;
-  selftest) cmd_selftest ;;
+  selftest) cmd_selftest "${2:-}" ;;
+  today) cmd_today ;;
   -h|--help|help|"") usage ;;
   *) echo "Unknown command: $1"; usage; exit 1 ;;
 esac

--- a/src/app/(dashboard)/trips/[id]/loading.tsx
+++ b/src/app/(dashboard)/trips/[id]/loading.tsx
@@ -1,0 +1,56 @@
+function TimelineSkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="h-4 w-24 rounded-full bg-gray-200" />
+      <div className="mt-4 h-8 w-56 rounded-lg bg-gray-200" />
+      <div className="mt-3 flex flex-wrap gap-3">
+        <div className="h-4 w-28 rounded-full bg-gray-200" />
+        <div className="h-4 w-36 rounded-full bg-gray-200" />
+        <div className="h-4 w-20 rounded-full bg-gray-200" />
+      </div>
+      <div className="mt-5 h-24 rounded-2xl bg-gray-200" />
+    </div>
+  )
+}
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex animate-pulse items-center gap-3">
+        <div className="h-4 w-4 rounded-full bg-gray-200" />
+        <div className="h-4 w-28 rounded-lg bg-gray-200" />
+      </div>
+
+      <div className="animate-pulse overflow-hidden rounded-2xl border border-gray-200 bg-white">
+        <div className="h-52 bg-gradient-to-r from-gray-100 to-gray-50 p-6 sm:p-8">
+          <div className="mt-16 h-10 w-64 rounded-xl bg-gray-200" />
+          <div className="mt-5 flex flex-wrap gap-4">
+            <div className="h-5 w-36 rounded-full bg-gray-200" />
+            <div className="h-5 w-44 rounded-full bg-gray-200" />
+            <div className="h-5 w-32 rounded-full bg-gray-200" />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <TimelineSkeletonCard />
+        <TimelineSkeletonCard />
+        <TimelineSkeletonCard />
+        <TimelineSkeletonCard />
+      </div>
+
+      <section className="space-y-4 rounded-[28px] border border-gray-200 bg-[#f7fbff] p-5 animate-pulse">
+        <div className="space-y-2">
+          <div className="h-6 w-48 rounded-lg bg-gray-200" />
+          <div className="h-4 w-72 rounded-lg bg-gray-200" />
+        </div>
+        <div className="h-24 rounded-2xl bg-gray-200" />
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <div className="h-40 rounded-2xl bg-gray-200" />
+          <div className="h-40 rounded-2xl bg-gray-200" />
+          <div className="h-40 rounded-2xl bg-gray-200" />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense, cache } from 'react'
 import { createClient } from '@/lib/supabase/server'
 import { notFound } from 'next/navigation'
 import { TripHeader } from '@/components/trips/trip-header'
@@ -9,6 +10,8 @@ import { WeatherSection } from '@/components/trips/weather/weather-section'
 import { attachWeatherToTimeline, buildTimeline } from '@/lib/trips/city-segments'
 import { getTripTimelineEventPreviews } from '@/lib/events/queries'
 import { getTemperatureUnit, getTripWeather } from '@/lib/weather/service'
+import type { TemperatureUnit, WeatherResponsePayload } from '@/lib/weather/types'
+import type { Trip, TripItem } from '@/types/database'
 import { ArrowLeft, Users } from 'lucide-react'
 import Link from 'next/link'
 
@@ -16,19 +19,44 @@ interface TripPageProps {
   params: Promise<{ id: string }>
 }
 
+type TripListEntry = Pick<Trip, 'id' | 'title' | 'start_date'>
+type StreamedTrip = Trip
+type StreamedItem = TripItem
+
+const loadTripWeatherForStream = cache(async (params: {
+  tripId: string
+  userId: string
+  requestedUnit: TemperatureUnit
+  includePacking: boolean
+  trip: StreamedTrip
+  items: StreamedItem[]
+}) => {
+  const supabase = await createClient()
+
+  return getTripWeather({
+    tripId: params.tripId,
+    supabase,
+    userId: params.userId,
+    requestedUnit: params.requestedUnit,
+    includePacking: params.includePacking,
+    prefetchedTrip: params.trip,
+    prefetchedItems: params.items,
+  })
+})
+
 export default async function TripPage({ params }: TripPageProps) {
   const { id } = await params
   const supabase = await createClient()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  const { data: trip, error } = await supabase
-    .from('trips')
-    .select('*')
-    .eq('id', id)
-    .single()
+  const [
+    {
+      data: { user },
+    },
+    { data: trip, error },
+  ] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.from('trips').select('*').eq('id', id).single(),
+  ])
 
   if (error || !trip) {
     notFound()
@@ -36,7 +64,6 @@ export default async function TripPage({ params }: TripPageProps) {
 
   const isOwner = trip.user_id === user?.id
 
-  // Fetch collaborator record if user is not owner (to get their role)
   let collabRole: string | null = null
   let inviterName: string | null = null
 
@@ -55,7 +82,6 @@ export default async function TripPage({ params }: TripPageProps) {
     }
   }
 
-  // Parallel: fetch items, all trips, collaborators, profile, and temp unit simultaneously
   const [
     { data: items },
     { data: allTrips },
@@ -96,24 +122,11 @@ export default async function TripPage({ params }: TripPageProps) {
 
   const canEdit = isOwner || collabRole === 'editor'
   const isPro = profileData?.subscription_tier === 'pro'
-  const weather = user
-    ? await getTripWeather({
-        tripId: trip.id,
-        supabase,
-        userId: user.id,
-        requestedUnit: userUnit,
-        includePacking: isPro,
-      })
-    : null
-  const timeline = attachWeatherToTimeline(buildTimeline(items || []), weather?.destinations ?? [])
-  const segmentEntries = timeline
-    .filter((entry) => entry.type === 'segment' && entry.segment != null)
-    .map((entry) => entry.segment!)
-  const segmentEvents = await getTripTimelineEventPreviews(supabase, segmentEntries)
+  const tripItems = items ?? []
+  const tripOptions = allTrips ?? []
 
   return (
     <div className="space-y-6">
-      {/* Back link */}
       <Link
         href="/trips"
         className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
@@ -122,42 +135,171 @@ export default async function TripPage({ params }: TripPageProps) {
         Back to trips
       </Link>
 
-      {/* "Shared by" notice for collaborators */}
       {!isOwner && inviterName && (
         <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm text-indigo-700">
           <Users className="h-4 w-4 shrink-0" />
           <span>
             Shared by <strong>{inviterName}</strong>
-            {collabRole === 'viewer' && ' — view only'}
+            {collabRole === 'viewer' && ' - view only'}
           </span>
         </div>
       )}
 
       {trip.is_demo && <DemoTripBanner />}
 
-      {/* Trip header with title, dates, location */}
       <TripHeader trip={trip} />
 
-      {/* Actions bar — show to owners and editors */}
       {canEdit && (
-        <TripActions trip={trip} allTrips={allTrips || []} isOwner={isOwner} isPro={isPro} />
+        <TripActions trip={trip} allTrips={tripOptions} isOwner={isOwner} isPro={isPro} />
       )}
 
-      {/* Collaborators section */}
       <CollaboratorsSection
         tripId={id}
-        collaborators={collaborators || []}
+        collaborators={collaborators ?? []}
         isOwner={isOwner}
       />
 
-      <MovementTimeline
-        entries={timeline}
-        allTrips={allTrips || []}
-        currentUserId={user?.id}
-        segmentEvents={segmentEvents}
-      />
+      <Suspense fallback={<TimelineSectionFallback />}>
+        <TimelineWithEventsAsync
+          trip={trip}
+          items={tripItems}
+          allTrips={tripOptions}
+          currentUserId={user?.id}
+          userUnit={userUnit}
+          isPro={isPro}
+        />
+      </Suspense>
 
-      <WeatherSection endpoint={`/api/trips/${trip.id}/weather`} initialData={weather} showPacking />
+      <Suspense fallback={<WeatherSectionFallback />}>
+        <WeatherSectionAsync
+          trip={trip}
+          items={tripItems}
+          userId={user?.id}
+          userUnit={userUnit}
+          isPro={isPro}
+        />
+      </Suspense>
     </div>
+  )
+}
+
+interface WeatherSectionAsyncProps {
+  trip: StreamedTrip
+  items: StreamedItem[]
+  userId?: string
+  userUnit: TemperatureUnit
+  isPro: boolean
+}
+
+async function WeatherSectionAsync({
+  trip,
+  items,
+  userId,
+  userUnit,
+  isPro,
+}: WeatherSectionAsyncProps) {
+  if (!userId) return null
+
+  const weather = await loadTripWeatherForStream({
+    tripId: trip.id,
+    userId,
+    requestedUnit: userUnit,
+    includePacking: isPro,
+    trip,
+    items,
+  })
+
+  return (
+    <WeatherSection endpoint={`/api/trips/${trip.id}/weather`} initialData={weather} showPacking />
+  )
+}
+
+interface TimelineWithEventsAsyncProps {
+  trip: StreamedTrip
+  items: StreamedItem[]
+  allTrips: TripListEntry[]
+  currentUserId?: string
+  userUnit: TemperatureUnit
+  isPro: boolean
+  weather?: WeatherResponsePayload | null
+}
+
+async function TimelineWithEventsAsync({
+  trip,
+  items,
+  allTrips,
+  currentUserId,
+  userUnit,
+  isPro,
+  weather,
+}: TimelineWithEventsAsyncProps) {
+  const resolvedWeather =
+    weather ??
+    (currentUserId
+      ? await loadTripWeatherForStream({
+          tripId: trip.id,
+          userId: currentUserId,
+          requestedUnit: userUnit,
+          includePacking: isPro,
+          trip,
+          items,
+        })
+      : null)
+
+  const timeline = attachWeatherToTimeline(buildTimeline(items), resolvedWeather?.destinations ?? [])
+  const segmentEntries = timeline
+    .filter((entry) => entry.type === 'segment' && entry.segment != null)
+    .map((entry) => entry.segment!)
+  const segmentEvents = currentUserId
+    ? await getTripTimelineEventPreviews(await createClient(), segmentEntries)
+    : {}
+
+  return (
+    <MovementTimeline
+      entries={timeline}
+      allTrips={allTrips}
+      currentUserId={currentUserId}
+      segmentEvents={segmentEvents}
+    />
+  )
+}
+
+function TimelineSectionFallback() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="animate-pulse rounded-3xl border border-gray-200 bg-white p-5 shadow-sm"
+        >
+          <div className="h-4 w-24 rounded-full bg-gray-200" />
+          <div className="mt-4 h-8 w-52 rounded-lg bg-gray-200" />
+          <div className="mt-3 flex flex-wrap gap-3">
+            <div className="h-4 w-28 rounded-full bg-gray-200" />
+            <div className="h-4 w-36 rounded-full bg-gray-200" />
+            <div className="h-4 w-20 rounded-full bg-gray-200" />
+          </div>
+          <div className="mt-5 h-24 rounded-2xl bg-gray-200" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function WeatherSectionFallback() {
+  return (
+    <section className="space-y-4 rounded-[28px] border border-gray-200 bg-[#f7fbff] p-5 animate-pulse">
+      <div className="space-y-2">
+        <div className="h-6 w-52 rounded-lg bg-gray-200" />
+        <div className="h-4 w-72 rounded-lg bg-gray-200" />
+      </div>
+      <div className="h-24 rounded-2xl bg-gray-200" />
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-40 rounded-2xl bg-gray-200" />
+        ))}
+      </div>
+      <div className="h-40 rounded-2xl bg-gray-200" />
+    </section>
   )
 }

--- a/src/lib/weather/service.ts
+++ b/src/lib/weather/service.ts
@@ -3,7 +3,7 @@ import type { Database, Json } from '@/types/database'
 import { extractTripCities } from './cities'
 import { fetchForecast, hasTripCompleted, isTripWithinForecastWindow } from './forecast'
 import { geocodeCity } from './geocode'
-import { generatePackingSuggestions, unitSymbol } from './packing'
+import { unitSymbol } from './packing'
 import type {
   PackingList,
   TemperatureUnit,
@@ -16,6 +16,29 @@ import type {
 type DbClient = SupabaseClient<Database>
 type WeatherCacheRow = Database['public']['Tables']['trip_weather_cache']['Row']
 type WeatherCacheInsert = Database['public']['Tables']['trip_weather_cache']['Insert']
+type PrefetchedTripContext = {
+  start_date: string | null
+  end_date: string | null
+  primary_location: string | null
+  id?: string
+  user_id?: string
+  title?: string
+  share_enabled?: boolean
+}
+type PrefetchedTripItemContext = Array<{
+  kind: WeatherTripItem['kind']
+  start_date: string | null
+  end_date: string | null
+  start_location: string | null
+  end_location: string | null
+  id?: string
+  trip_id?: string | null
+  start_ts?: string | null
+  end_ts?: string | null
+  provider?: string | null
+  summary?: string | null
+  details_json?: Json
+}>
 
 interface WeatherCacheSelectQuery {
   eq: (column: string, value: string) => {
@@ -133,11 +156,47 @@ async function loadCache(tripId: string, supabase: DbClient): Promise<WeatherCac
   return (data ?? []) as WeatherCacheRow[]
 }
 
+function buildPrefetchedContext(params: {
+  tripId: string
+  userId: string
+  prefetchedTrip: PrefetchedTripContext
+  prefetchedItems: PrefetchedTripItemContext
+}): {
+  trip: WeatherTrip
+  items: WeatherTripItem[]
+} {
+  return {
+    trip: {
+      id: params.prefetchedTrip.id ?? params.tripId,
+      user_id: params.prefetchedTrip.user_id ?? params.userId,
+      title: params.prefetchedTrip.title ?? 'Trip',
+      start_date: params.prefetchedTrip.start_date,
+      end_date: params.prefetchedTrip.end_date,
+      share_enabled: params.prefetchedTrip.share_enabled,
+    },
+    items: params.prefetchedItems.map((item, index) => ({
+      id: item.id ?? `${params.tripId}-${index}`,
+      trip_id: item.trip_id ?? params.tripId,
+      kind: item.kind,
+      start_date: item.start_date ?? '',
+      end_date: item.end_date,
+      start_ts: item.start_ts ?? null,
+      end_ts: item.end_ts ?? null,
+      start_location: item.start_location,
+      end_location: item.end_location,
+      provider: item.provider ?? null,
+      summary: item.summary ?? null,
+      details_json: item.details_json ?? {},
+    })),
+  }
+}
+
 export async function buildWeatherPayload(params: {
   trip: WeatherTrip
   items: WeatherTripItem[]
   unit: TemperatureUnit
   includePacking: boolean
+  cachedPacking?: PackingList | null
 }): Promise<WeatherResponsePayload> {
   if (hasTripCompleted(params.trip.end_date)) {
     return {
@@ -240,15 +299,7 @@ export async function buildWeatherPayload(params: {
   }
 
   const tempRange = buildTempRange(destinations, params.unit)
-  const packing =
-    params.includePacking && tempRange
-      ? await generatePackingSuggestions({
-          tripTitle: params.trip.title,
-          destinations,
-          tempRange,
-          travelerCount: 1,
-        })
-      : null
+  const packing = params.includePacking && tempRange ? params.cachedPacking ?? null : null
 
   return {
     trip_id: params.trip.id,
@@ -272,8 +323,18 @@ export async function getTripWeather(params: {
   requestedUnit?: TemperatureUnit
   forceRefresh?: boolean
   includePacking: boolean
+  prefetchedTrip?: PrefetchedTripContext
+  prefetchedItems?: PrefetchedTripItemContext
 }): Promise<WeatherResponsePayload | null> {
-  const context = await loadTripContext(params.tripId, params.supabase)
+  const context =
+    params.prefetchedTrip && params.prefetchedItems
+      ? buildPrefetchedContext({
+          tripId: params.tripId,
+          userId: params.userId,
+          prefetchedTrip: params.prefetchedTrip,
+          prefetchedItems: params.prefetchedItems,
+        })
+      : await loadTripContext(params.tripId, params.supabase)
   if (!context) return null
 
   const { trip, items } = context
@@ -339,6 +400,8 @@ export async function getTripWeather(params: {
     )
 
   const freshCache = cacheMatches && cachedRows.length > 0 && cachedRows.every((row) => isCacheFresh(row.fetched_at))
+  const cachedPacking =
+    params.includePacking && cacheMatches ? parsePacking(cachedRows[0]?.packing_json ?? null) : null
 
   if (!params.forceRefresh && freshCache) {
     const destinations = cachedRows.map((row) => ({
@@ -358,7 +421,7 @@ export async function getTripWeather(params: {
       trip_title: trip.title,
       temp_range: buildTempRange(destinations, unit),
       destinations,
-      packing: params.includePacking ? parsePacking(cachedRows[0]?.packing_json ?? null) : null,
+      packing: cachedPacking,
       fetched_at: cachedRows[0]?.fetched_at ?? null,
       is_stale: false,
       unit,
@@ -372,6 +435,7 @@ export async function getTripWeather(params: {
     items,
     unit,
     includePacking: params.includePacking,
+    cachedPacking,
   })
   const destinations = refreshed.destinations
   const packing = refreshed.packing

--- a/supabase/migrations/20260314000001_index_trip_items_trip_id.sql
+++ b/supabase/migrations/20260314000001_index_trip_items_trip_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_trip_items_trip_id ON trip_items(trip_id);


### PR DESCRIPTION
## PRD-050: CLI & Agent Reliability Architecture

Implements all remaining phases of PRD-050.

### Phase 1.2: Robust Response Handling
- `_api()` now checks HTTP status and Content-Type headers
- HTML 404 pages produce clear error: `API returned HTTP 404 (text/html). Endpoint may not be deployed.`
- No more silent JSON parse crashes on non-JSON responses
- JSON errors returned with proper exit code

### Phase 1.3: `ubt today` Command
```
$ ubt today
Today (2026-03-14) — 3 item(s):

  HOTEL       22:00 → 17:00   Hotel booking at The Stephen F Austin Royal Sonesta Hotel
  FLIGHT      00:30 → 02:45   American Airlines flight AA2500 from Austin to Dallas
  FLIGHT      02:49 → 07:06   American Airlines flight AA2400 from Dallas to Portland
```
The single most important agent query — "what's happening today?" — now has a one-command answer.

### Phase 2.1: `selftest --deep`
```
$ ubt selftest --deep
UB Trippin CLI Self-Test
========================

  ✅  GET /api/v1/trips (200)
  ✅  GET /api/v1/me/profile (200)
  ...
Deep checks:
  ✅  Trips list returns data (11 trips)
  ✅  Item search returns data
  ✅  Cross-trip item search responds (200)
  ✅  API returns JSON content-type
  ✅  Bogus endpoint returns error code (404)
  ✅  Flights in next 48h found (2)

11 passed, 0 failed.
```
Would have caught the March 12 and 13 incidents before they reached Ian.

### Phase 2.3: Exit Code Taxonomy
`EXIT_OK=0, EXIT_USER_ERROR=1, EXIT_AUTH_ERROR=2, EXIT_API_ERROR=3, EXIT_DATA_ERROR=4`

### Phase 3: Data Completeness
Flights in next 48h checked during `selftest --deep` — ensures the "is my flight on time?" query can always be answered.

### What was already shipped (prior PRs)
- ✅ 1.1 — Trips list sort + truncation (PR #91)
- ✅ 1.4 — Flight status mapping (PR #95)
- ✅ Cross-trip item search (PR #90)