### PR TITLE
feat: PRD-051 trip page performance — Suspense streaming, skeleton, parallel queries

### DIFF
--- a/scripts/prompts/prd-051.md
+++ b/scripts/prompts/prd-051.md
@@ -1,0 +1,93 @@
+# PRD-051: Trip Page Performance
+
+## Context
+The trip detail page (`src/app/(dashboard)/trips/[id]/page.tsx`) takes 4+ seconds to render because everything is sequential with no streaming. This PR fixes it.
+
+## What to build
+
+### 1. Add `loading.tsx` skeleton
+Create `src/app/(dashboard)/trips/[id]/loading.tsx` with a skeleton UI that shows immediately while the page loads. Include:
+- Back arrow placeholder
+- Trip header skeleton (title, dates, location blocks)
+- Timeline skeleton (3-4 card placeholders)
+- Weather section skeleton
+
+Use the same styling patterns as the rest of the app (Tailwind, gray-200 animate-pulse blocks).
+
+### 2. Add `trip_items(trip_id)` index
+Create a new migration file `supabase/migrations/20260314000001_index_trip_items_trip_id.sql`:
+```sql
+CREATE INDEX IF NOT EXISTS idx_trip_items_trip_id ON trip_items(trip_id);
+```
+
+### 3. Parallelize auth + trip fetch
+In `src/app/(dashboard)/trips/[id]/page.tsx`, change the sequential:
+```typescript
+const { data: { user } } = await supabase.auth.getUser()
+const { data: trip } = await supabase.from('trips')...
+```
+To parallel:
+```typescript
+const [{ data: { user } }, { data: trip, error }] = await Promise.all([
+  supabase.auth.getUser(),
+  supabase.from('trips').select('*').eq('id', id).single()
+])
+```
+
+### 4. Refactor getTripWeather to accept pre-fetched data
+In `src/lib/weather/service.ts`, the `getTripWeather` function currently re-fetches trip and items from the DB. Refactor it to accept optional `trip` and `items` parameters so the page can pass its already-fetched data:
+
+Change the function signature to accept optional pre-fetched data:
+```typescript
+export async function getTripWeather(params: {
+  tripId: string
+  supabase: SupabaseClient
+  userId: string
+  requestedUnit?: TemperatureUnit
+  includePacking?: boolean
+  prefetchedTrip?: { start_date: string | null; end_date: string | null; primary_location: string | null }
+  prefetchedItems?: Array<{ kind: string; start_date: string | null; end_date: string | null; start_location: string | null; end_location: string | null }>
+}): Promise<TripWeatherResponse | null>
+```
+
+If `prefetchedTrip` and `prefetchedItems` are provided, skip the `loadTripContext()` call and use them directly. Otherwise fall back to the existing DB fetch for backward compatibility.
+
+Update the call site in `page.tsx` to pass the already-fetched trip and items.
+
+### 5. Wrap weather + events in Suspense boundaries
+Split the trip page so weather and events load via streaming:
+
+a) Create an async server component `WeatherSectionAsync` that:
+   - Receives tripId, supabase client (or userId), trip, items, isPro, userUnit
+   - Calls getTripWeather internally
+   - Renders WeatherSection with the result
+
+b) Create an async server component `TimelineWithEventsAsync` that:
+   - Receives items, allTrips, currentUserId, weather data or null
+   - Calls getTripTimelineEventPreviews internally  
+   - Renders MovementTimeline with segmentEvents
+
+c) Wrap both in `<Suspense>` with skeleton fallbacks in the page
+
+IMPORTANT: The Supabase server client from `createClient()` uses cookies and cannot be passed to async components inside Suspense. Instead, create a new Supabase client inside each async component, or pass only the data needed (not the client).
+
+### 6. Move packing suggestions out of page load
+The LLM call in `generatePackingSuggestions()` (src/lib/weather/packing.ts) is the single biggest blocker (2-5s). 
+
+In `getTripWeather`, when `includePacking` is true, still include the packing data IF it's already cached. But do NOT make a new LLM call during page load. Instead:
+- Check if cached packing exists (in the weather cache)
+- If yes, include it
+- If no, return `packing: null` and let the client fetch it on demand
+
+The WeatherSection component already has a client-side endpoint (`/api/trips/${trip.id}/weather`). The packing can be fetched via that endpoint when the user scrolls to it or clicks a button.
+
+## Rules
+- Do NOT use `createSecretClient()` or service role to bypass RLS. Fix RLS policies instead.
+- Do NOT add any `process.env` references to client components.
+- All new components must be TypeScript with proper types.
+- Keep the existing visual design — this is a performance refactor, not a redesign.
+- Run `pnpm build` and `pnpm test` before finishing to make sure nothing breaks.
+- Commit with a clear message referencing PRD-051.
+
+When completely finished, run this command to notify me:
+openclaw system event --text "Done: PRD-051 trip page performance — loading skeleton, Suspense streaming, parallel queries, weather refactor" --mode now

--- a/src/app/(dashboard)/trips/[id]/page.tsx
+++ b/src/app/(dashboard)/trips/[id]/page.tsx
@@ -250,6 +250,7 @@ async function TimelineWithEventsAsync({
   const segmentEntries = timeline
     .filter((entry) => entry.type === 'segment' && entry.segment != null)
     .map((entry) => entry.segment!)
+
   const segmentEvents = currentUserId
     ? await getTripTimelineEventPreviews(await createClient(), segmentEntries)
     : {}


### PR DESCRIPTION
## PRD-051: Trip Page Performance

The trip detail page was taking 4+ seconds to render because everything was sequential with no streaming. This PR fixes it.

### Changes

**Instant perceived response:**
- New `loading.tsx` skeleton — shows immediately while server renders
- Matches the real page structure (header, timeline cards, weather section)

**Eliminated the biggest blocker (2-5s):**
- LLM packing suggestions call removed from page load critical path
- Cached packing still shown instantly; fresh packing fetched on demand via client endpoint

**Suspense streaming:**
- Timeline + events wrapped in `<Suspense>` with skeleton fallback
- Weather section wrapped in `<Suspense>` with skeleton fallback
- Page shell (header, actions, collaborators) renders immediately

**Parallel queries:**
- Auth + trip fetch now run in `Promise.all` (was sequential)
- Weather service accepts prefetched trip/items (eliminates redundant DB round trips)

**Database:**
- New `idx_trip_items_trip_id` index (was doing sequential scans)

### Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| TTFB (shell) | 4-5s | <300ms |
| Full page (warm cache) | ~500ms | ~500ms (streamed) |
| Full page (cold cache) | 4-5s | <1s (streamed) |
| Perceived wait | 4-5s blank | Instant skeleton |