### PR TITLE
fix: auto-refresh flight status badge when data is stale

### DIFF
--- a/src/components/trips/item-status-badge.tsx
+++ b/src/components/trips/item-status-badge.tsx
@@ -175,7 +175,13 @@ export function ItemStatusBadge({ itemId, scheduledDeparture, startTs, onStatusU
   // The GET /status endpoint returns { status: 'unknown' } when there's no
   // cached row — that's truthy, so we must check the inner status field.
   const hasTriggeredAutoRefresh = useRef(false)
-  const needsRefresh = !status || status.status === 'unknown'
+  const isStale = (() => {
+    if (!status?.last_checked_at) return true
+    const checkedAt = new Date(status.last_checked_at).getTime()
+    if (Number.isNaN(checkedAt)) return true
+    return Date.now() - checkedAt > 5 * 60 * 1000 // stale if >5 minutes old
+  })()
+  const needsRefresh = !status || status.status === 'unknown' || isStale
   useEffect(() => {
     if (!loading && needsRefresh && !hasTriggeredAutoRefresh.current) {
       hasTriggeredAutoRefresh.current = true


### PR DESCRIPTION
The badge only auto-refreshed when status was `unknown`. Now that the delayed mapping works (PR #95), status shows `delayed` correctly but data can be hours stale — showing old departure times while the live page has current data.

Fix: auto-refresh on page load when `last_checked_at` is >5 minutes old, matching the server-side staleness window. The server returns cached data if <5min old, so this adds zero extra FA API calls for recent data.