### PR TITLE
feat: PRD-052 Trip Update Notifications — Phase 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "check": "tsc --noEmit && eslint src/",
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src/",

--- a/src/app/api/v1/items/[id]/route.ts
+++ b/src/app/api/v1/items/[id]/route.ts
@@ -11,6 +11,7 @@ import { sanitizeItem, sanitizeItemInput } from '@/lib/api/sanitize'
 import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
+import { logTripEvent, scheduleTripNotificationProcessing, type TripUpdateChange } from '@/lib/notifications/trip-events'
 
 export async function GET(
   request: NextRequest,
@@ -103,6 +104,20 @@ async function fetchTripSummary(tripId: string, userId: string) {
   return data
 }
 
+interface MeaningfulItemFields {
+  trip_id: string | null
+  kind: string | null
+  provider: string | null
+  summary: string | null
+  start_date: string | null
+  end_date: string | null
+  start_ts: string | null
+  end_ts: string | null
+  status: string | null
+  start_location: string | null
+  end_location: string | null
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -157,7 +172,20 @@ export async function PATCH(
   // 6. Verify ownership
   const { data: existing } = await supabase
     .from('trip_items')
-    .select('id')
+    .select(`
+      id,
+      trip_id,
+      kind,
+      provider,
+      summary,
+      start_date,
+      end_date,
+      start_ts,
+      end_ts,
+      status,
+      start_location,
+      end_location
+    `)
     .eq('id', itemId)
     .eq('user_id', auth.userId)
     .single()
@@ -247,6 +275,37 @@ export async function PATCH(
     }).catch((err) => console.error('[webhooks] item.updated dispatch failed:', err))
   }
 
+  const meaningfulChanges = buildMeaningfulItemChanges(
+    existing as MeaningfulItemFields,
+    updatedItem as MeaningfulItemFields
+  )
+
+  if (meaningfulChanges.length > 0 && updatedItem.trip_id) {
+    const { data: actorProfile } = await supabase
+      .from('profiles')
+      .select('full_name, email')
+      .eq('id', auth.userId)
+      .maybeSingle()
+
+    const actorName = actorProfile?.full_name || actorProfile?.email || 'Someone'
+
+    try {
+      await logTripEvent(
+        supabase,
+        updatedItem.trip_id,
+        auth.userId,
+        'item_updated',
+        {
+          actor_name: actorName,
+          changes: meaningfulChanges,
+        }
+      )
+      scheduleTripNotificationProcessing(auth.userId, updatedItem.trip_id)
+    } catch (err) {
+      console.error('[items/[id]/trip-update-log]', err)
+    }
+  }
+
   return NextResponse.json({ data: sanitizeItem(updatedItem as Record<string, unknown>) })
 }
 
@@ -322,4 +381,60 @@ export async function DELETE(
   }
 
   return new NextResponse(null, { status: 204 })
+}
+
+function buildMeaningfulItemChanges(
+  before: MeaningfulItemFields,
+  after: MeaningfulItemFields
+): TripUpdateChange[] {
+  const changes: TripUpdateChange[] = []
+  const itemLabel = formatTripUpdateItemSummary(after.kind, after.summary, after.provider)
+
+  if (
+    before.start_date !== after.start_date ||
+    before.end_date !== after.end_date ||
+    before.start_ts !== after.start_ts ||
+    before.end_ts !== after.end_ts
+  ) {
+    changes.push({
+      kind: 'dates_updated',
+      summary: `Updated dates for ${itemLabel}`,
+    })
+  }
+
+  if (before.status !== after.status) {
+    changes.push({
+      kind: 'status_updated',
+      summary: `Changed status to ${(after.status || 'unknown').replace(/_/g, ' ')} for ${itemLabel}`,
+    })
+  }
+
+  if (
+    before.start_location !== after.start_location ||
+    before.end_location !== after.end_location
+  ) {
+    changes.push({
+      kind: 'location_updated',
+      summary: `Updated route for ${itemLabel}`,
+    })
+  }
+
+  return changes
+}
+
+function formatTripUpdateItemSummary(
+  kind: string | null | undefined,
+  summary: string | null | undefined,
+  provider: string | null | undefined
+) {
+  if (summary?.trim()) {
+    return summary.trim()
+  }
+
+  const kindLabel = kind ? kind.replace(/_/g, ' ') : 'trip item'
+  if (provider?.trim()) {
+    return `${provider.trim()} ${kindLabel}`
+  }
+
+  return kindLabel
 }

--- a/src/app/api/v1/notifications/preferences/route.ts
+++ b/src/app/api/v1/notifications/preferences/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isSessionAuthError, requireSessionAuth } from '@/lib/api/session-auth'
+
+const DEFAULT_PREFERENCES = { trip_updates: true }
+
+export async function GET() {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  const { data: profile, error } = await auth.supabase
+    .from('profiles')
+    .select('notification_preferences')
+    .eq('id', auth.userId)
+    .single()
+
+  if (error) {
+    console.error('[v1/notifications/preferences GET]', error)
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'Failed to fetch notification preferences.' } },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({
+    data: normalizePreferences(profile?.notification_preferences),
+  })
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  const body = (await request.json().catch(() => null)) as
+    | { trip_updates?: unknown; notification_preferences?: { trip_updates?: unknown } }
+    | null
+
+  const rawTripUpdates = body?.notification_preferences?.trip_updates ?? body?.trip_updates
+  if (typeof rawTripUpdates !== 'boolean') {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: '"trip_updates" must be a boolean.' } },
+      { status: 400 }
+    )
+  }
+
+  const notificationPreferences = {
+    trip_updates: rawTripUpdates,
+  }
+
+  const { data: profile, error } = await auth.supabase
+    .from('profiles')
+    .update({ notification_preferences: notificationPreferences })
+    .eq('id', auth.userId)
+    .select('notification_preferences')
+    .single()
+
+  if (error) {
+    console.error('[v1/notifications/preferences PATCH]', error)
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'Failed to update notification preferences.' } },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({
+    data: normalizePreferences(profile?.notification_preferences),
+  })
+}
+
+function normalizePreferences(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return DEFAULT_PREFERENCES
+  }
+
+  const tripUpdates = 'trip_updates' in value && typeof value.trip_updates === 'boolean'
+    ? value.trip_updates
+    : DEFAULT_PREFERENCES.trip_updates
+
+  return {
+    trip_updates: tripUpdates,
+  }
+}

--- a/src/app/api/v1/trips/[id]/items/route.ts
+++ b/src/app/api/v1/trips/[id]/items/route.ts
@@ -16,6 +16,7 @@ import { createUserScopedClient } from '@/lib/supabase/user-scoped'
 import { isValidUUID } from '@/lib/validation'
 import { applyNoVaultEntryFlag } from '@/lib/loyalty-flag'
 import { dispatchWebhookEvent } from '@/lib/webhooks'
+import { logTripEvent, scheduleTripNotificationProcessing } from '@/lib/notifications/trip-events'
 
 const ITEM_SELECT = `id,
        trip_id,
@@ -168,16 +169,40 @@ export async function POST(
     })
   }
 
-  // 8. Fire notification to trip owner when a collaborator adds an item
-  if (isEditor && item) {
-    // Get collaborator's display name
+  let actorName = 'Someone'
+  if (item) {
     const { data: actorProfile } = await supabase
       .from('profiles')
       .select('full_name, email')
       .eq('id', auth.userId)
       .maybeSingle()
 
-    const actorName = actorProfile?.full_name || actorProfile?.email || 'A collaborator'
+    actorName = actorProfile?.full_name || actorProfile?.email || actorName
+
+    try {
+      await logTripEvent(
+        supabase,
+        tripId,
+        auth.userId,
+        'item_added',
+        {
+          actor_name: actorName,
+          changes: [
+            {
+              kind: 'item_added',
+              summary: `Added ${formatTripUpdateItemSummary(item.kind, item.summary, item.provider)}`,
+            },
+          ],
+        }
+      )
+      scheduleTripNotificationProcessing(auth.userId, tripId)
+    } catch (err) {
+      console.error('[items/trip-update-log]', err)
+    }
+  }
+
+  // 8. Fire notification to trip owner when a collaborator adds an item
+  if (isEditor && item) {
     const summary = clean.summary || `${clean.kind} entry`
 
     void (async () => {
@@ -223,4 +248,21 @@ export async function POST(
     { data: sanitizeItem(item as Record<string, unknown>) },
     { status: 201 }
   )
+}
+
+function formatTripUpdateItemSummary(
+  kind: string | null | undefined,
+  summary: string | null | undefined,
+  provider: string | null | undefined
+) {
+  if (summary?.trim()) {
+    return summary.trim()
+  }
+
+  const kindLabel = kind ? kind.replace(/_/g, ' ') : 'trip item'
+  if (provider?.trim()) {
+    return `${provider.trim()} ${kindLabel}`
+  }
+
+  return kindLabel
 }

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -24,6 +24,8 @@ import { trackFirstForward, trackTripCreated } from '@/lib/activation'
 import { applyEmailLoyaltyFlag } from '@/lib/loyalty-flag'
 import { decryptLoyaltyNumber, encryptLoyaltyNumber, maskLoyaltyNumber } from '@/lib/loyalty-crypto'
 import { resolveProviderKey } from '@/lib/loyalty-matching'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
+import { logTripEvent, scheduleTripNotificationProcessing } from '@/lib/notifications/trip-events'
 
 // Force dynamic rendering - webhooks must never be cached/static
 export const dynamic = 'force-dynamic'
@@ -176,6 +178,8 @@ export async function POST(request: NextRequest) {
     const userProfile = Array.isArray(profilesData)
       ? profilesData[0] as { email: string; full_name: string | null } | undefined
       : profilesData as { email: string; full_name: string | null } | null
+    const actorName = userProfile?.full_name?.trim() || senderName || userProfile?.email || 'Someone'
+    const notificationSupabase = await createUserScopedClient(userId)
 
     // ── Soft usage gate: check monthly extraction limit ───────────────────────
     const extractionCheck = await checkExtractionLimit(userId, supabase)
@@ -438,6 +442,7 @@ export async function POST(request: NextRequest) {
 
       // Process extracted items - all items from same email go to same trip
       const createdItems: { tripId: string; itemId: string }[] = []
+      const notificationTripIds = new Set<string>()
       const tripsToUpdate = new Map<string, { items: typeof extractionResult.items }>()
 
       // Determine trip assignment using the first item, then use same trip for all
@@ -650,6 +655,27 @@ export async function POST(request: NextRequest) {
         }
 
         createdItems.push({ tripId: confirmedTripId, itemId: tripItem.id })
+        notificationTripIds.add(confirmedTripId)
+
+        try {
+          await logTripEvent(
+            notificationSupabase,
+            confirmedTripId,
+            userId,
+            'item_added',
+            {
+              actor_name: actorName,
+              changes: [
+                {
+                  kind: 'item_added',
+                  summary: `Added ${formatTripUpdateItemSummary(item.kind, item.summary, item.provider)}`,
+                },
+              ],
+            }
+          )
+        } catch (tripUpdateError) {
+          console.error('[webhooks/resend trip-update-log]', tripUpdateError)
+        }
       }
 
       // Update trip dates and info for affected trips
@@ -718,6 +744,10 @@ export async function POST(request: NextRequest) {
           extractionResult.items,
           supabase
         )
+      }
+
+      for (const notifiedTripId of notificationTripIds) {
+        scheduleTripNotificationProcessing(userId, notifiedTripId)
       }
 
       return NextResponse.json({
@@ -1083,6 +1113,23 @@ function looksLikeBookingEmail(subject: string, bodyText: string): boolean {
     'pnr',
   ]
   return bookingSignals.some((signal) => haystack.includes(signal))
+}
+
+function formatTripUpdateItemSummary(
+  kind: string | null | undefined,
+  summary: string | null | undefined,
+  provider: string | null | undefined
+) {
+  if (summary?.trim()) {
+    return summary.trim()
+  }
+
+  const kindLabel = kind ? kind.replace(/_/g, ' ') : 'trip item'
+  if (provider?.trim()) {
+    return `${provider.trim()} ${kindLabel}`
+  }
+
+  return kindLabel
 }
 
 function looksLikeRecommendationEmail(subject: string, bodyText: string): boolean {

--- a/src/components/email/trip-update.tsx
+++ b/src/components/email/trip-update.tsx
@@ -1,0 +1,137 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+
+export interface TripUpdateEmailChange {
+  kind: string
+  summary: string
+}
+
+interface TripUpdateEmailProps {
+  tripTitle: string
+  actorName: string
+  changes: TripUpdateEmailChange[]
+  tripUrl: string
+  unsubscribeUrl: string
+}
+
+export function TripUpdateEmail({
+  tripTitle,
+  actorName,
+  changes,
+  tripUrl,
+  unsubscribeUrl,
+}: TripUpdateEmailProps) {
+  const previewText = `${actorName} updated ${tripTitle} on UBTRIPPIN`
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading style={h1}>Trip updated</Heading>
+
+          <Text style={text}>
+            <strong>{actorName}</strong> made changes to <strong>{tripTitle}</strong>.
+          </Text>
+
+          <Section style={listSection}>
+            {changes.map((change, index) => (
+              <Text key={`${change.kind}-${index}`} style={listItem}>
+                • {change.summary}
+              </Text>
+            ))}
+          </Section>
+
+          <Button href={tripUrl} style={button}>
+            View trip {'->'}
+          </Button>
+
+          <Text style={smallText}>
+            Manage trip update emails in{' '}
+            <Link href={unsubscribeUrl} style={link}>
+              Settings
+            </Link>
+            .
+          </Text>
+
+          <Text style={smallText}>
+            - <Link href="https://ubtrippin.xyz" style={link}>UBTRIPPIN</Link>
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+const main = {
+  backgroundColor: '#f8fafc',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+}
+
+const container = {
+  backgroundColor: '#ffffff',
+  margin: '32px auto',
+  padding: '32px 40px',
+  maxWidth: '560px',
+  borderRadius: '8px',
+}
+
+const h1 = {
+  color: '#1e293b',
+  fontSize: '24px',
+  fontWeight: '700',
+  marginBottom: '20px',
+}
+
+const text = {
+  color: '#334155',
+  fontSize: '15px',
+  lineHeight: '24px',
+  marginBottom: '16px',
+}
+
+const listSection = {
+  marginBottom: '20px',
+}
+
+const listItem = {
+  color: '#334155',
+  fontSize: '15px',
+  lineHeight: '24px',
+  margin: '0 0 8px',
+}
+
+const button = {
+  backgroundColor: '#4338ca',
+  borderRadius: '6px',
+  color: '#ffffff',
+  fontSize: '15px',
+  fontWeight: '600',
+  padding: '12px 24px',
+  textDecoration: 'none',
+  marginTop: '8px',
+  marginBottom: '20px',
+}
+
+const smallText = {
+  color: '#64748b',
+  fontSize: '13px',
+  lineHeight: '20px',
+  marginBottom: '8px',
+}
+
+const link = {
+  color: '#4338ca',
+  textDecoration: 'underline',
+}

--- a/src/lib/email/trip-update.ts
+++ b/src/lib/email/trip-update.ts
@@ -1,0 +1,45 @@
+import { render } from '@react-email/components'
+import { TripUpdateEmail, type TripUpdateEmailChange } from '@/components/email/trip-update'
+import { getResendClient } from '@/lib/resend/client'
+
+const FROM = 'UBTRIPPIN <hello@ubtrippin.xyz>'
+
+interface SendTripUpdateEmailParams {
+  to: string
+  tripTitle: string
+  actorName: string
+  changes: TripUpdateEmailChange[]
+  tripUrl: string
+  unsubscribeUrl: string
+}
+
+export async function sendTripUpdateEmail({
+  to,
+  tripTitle,
+  actorName,
+  changes,
+  tripUrl,
+  unsubscribeUrl,
+}: SendTripUpdateEmailParams): Promise<void> {
+  const html = await render(
+    TripUpdateEmail({
+      tripTitle,
+      actorName,
+      changes,
+      tripUrl,
+      unsubscribeUrl,
+    })
+  )
+
+  const resend = getResendClient()
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `Trip Updated: ${tripTitle}`,
+    html,
+    headers: {
+      'List-Unsubscribe': `<${unsubscribeUrl}>`,
+      'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+    },
+  })
+}

--- a/src/lib/notifications/trip-events.ts
+++ b/src/lib/notifications/trip-events.ts
@@ -1,0 +1,196 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { sendTripUpdateEmail } from '@/lib/email/trip-update'
+import { createUserScopedClient } from '@/lib/supabase/user-scoped'
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://ubtrippin.xyz'
+const TRIP_UPDATE_DEBOUNCE_MS = 5 * 60 * 1000
+
+export interface TripUpdateChange {
+  kind: string
+  summary: string
+}
+
+interface TripUpdateLogRow {
+  id: string
+  actor_id: string
+  event_data: unknown
+}
+
+interface NotificationRecipientRow {
+  user_id: string
+  email: string
+}
+
+type DbClient = SupabaseClient
+
+export async function logTripEvent(
+  supabase: DbClient,
+  tripId: string,
+  actorId: string,
+  eventType: string,
+  eventData: Record<string, unknown>
+) {
+  const { error } = await supabase
+    .from('trip_update_log')
+    .insert({
+      trip_id: tripId,
+      actor_id: actorId,
+      event_type: eventType,
+      event_data: eventData,
+    })
+
+  if (error) {
+    throw new Error(`Failed to log trip event: ${error.message}`)
+  }
+}
+
+export async function getNotificationRecipients(
+  supabase: DbClient,
+  tripId: string,
+  actorId: string
+) {
+  const { data, error } = await supabase.rpc(
+    'get_trip_update_notification_recipients',
+    {
+      p_trip_id: tripId,
+      p_actor_id: actorId,
+    }
+  )
+
+  if (error) {
+    throw new Error(`Failed to fetch trip update recipients: ${error.message}`)
+  }
+
+  return (data ?? []) as NotificationRecipientRow[]
+}
+
+export async function processPendingNotifications(
+  supabase: DbClient,
+  tripId: string
+) {
+  const { data: pendingRows, error: pendingError } = await supabase.rpc(
+    'get_pending_trip_update_events',
+    { p_trip_id: tripId }
+  )
+
+  if (pendingError) {
+    throw new Error(`Failed to fetch pending trip updates: ${pendingError.message}`)
+  }
+
+  const pendingEvents = (pendingRows ?? []) as TripUpdateLogRow[]
+  if (pendingEvents.length === 0) {
+    return
+  }
+
+  const { data: trip, error: tripError } = await supabase
+    .from('trips')
+    .select('id, title')
+    .eq('id', tripId)
+    .maybeSingle()
+
+  if (tripError) {
+    throw new Error(`Failed to fetch trip details: ${tripError.message}`)
+  }
+
+  if (!trip) {
+    return
+  }
+
+  const { data: audienceRows, error: audienceError } = await supabase.rpc(
+    'get_trip_update_notification_recipients',
+    {
+      p_trip_id: tripId,
+      p_actor_id: null,
+    }
+  )
+
+  if (audienceError) {
+    throw new Error(`Failed to fetch trip update audience: ${audienceError.message}`)
+  }
+
+  const audience = (audienceRows ?? []) as NotificationRecipientRow[]
+  const tripUrl = `${APP_URL}/trips/${tripId}`
+  const unsubscribeUrl = `${APP_URL}/settings`
+
+  await Promise.all(
+    audience.map(async (recipient) => {
+      const visibleEvents = pendingEvents.filter((event) => event.actor_id !== recipient.user_id)
+      if (visibleEvents.length === 0) {
+        return
+      }
+
+      const changes = visibleEvents.flatMap((event) => getEventChanges(event.event_data))
+      if (changes.length === 0) {
+        return
+      }
+
+      const actorNames = [...new Set(
+        visibleEvents
+          .map((event) => getActorName(event.event_data))
+          .filter((name): name is string => !!name)
+      )]
+
+      await sendTripUpdateEmail({
+        to: recipient.email,
+        tripTitle: trip.title,
+        actorName: actorNames.length === 1 ? actorNames[0] : 'Your trip group',
+        changes,
+        tripUrl,
+        unsubscribeUrl,
+      })
+    })
+  )
+
+  const eventIds = pendingEvents.map((event) => event.id)
+  const { error: markError } = await supabase.rpc('mark_trip_update_events_notified', {
+    p_trip_id: tripId,
+    p_event_ids: eventIds,
+  })
+
+  if (markError) {
+    throw new Error(`Failed to mark trip updates as notified: ${markError.message}`)
+  }
+}
+
+export function scheduleTripNotificationProcessing(userId: string, tripId: string) {
+  const timeout = setTimeout(() => {
+    void (async () => {
+      const supabase = await createUserScopedClient(userId)
+      await processPendingNotifications(supabase as DbClient, tripId)
+    })().catch((error) => {
+      console.error('[trip-notifications/process]', error)
+    })
+  }, TRIP_UPDATE_DEBOUNCE_MS)
+
+  if (typeof timeout.unref === 'function') {
+    timeout.unref()
+  }
+}
+
+function getEventChanges(eventData: unknown): TripUpdateChange[] {
+  if (!isRecord(eventData) || !Array.isArray(eventData.changes)) {
+    return []
+  }
+
+  return eventData.changes
+    .map((change) => {
+      if (!isRecord(change)) return null
+      const kind = typeof change.kind === 'string' ? change.kind : null
+      const summary = typeof change.summary === 'string' ? change.summary : null
+      if (!kind || !summary) return null
+      return { kind, summary }
+    })
+    .filter((change): change is TripUpdateChange => change !== null)
+}
+
+function getActorName(eventData: unknown) {
+  if (!isRecord(eventData) || typeof eventData.actor_name !== 'string') {
+    return null
+  }
+
+  return eventData.actor_name.trim() || null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -20,6 +20,7 @@ export interface Database {
           full_name: string | null
           avatar_url: string | null
           calendar_token: string | null
+          notification_preferences: Json
           created_at: string
           updated_at: string
           // Billing columns (added in 20260228000001_stripe_billing)
@@ -37,6 +38,7 @@ export interface Database {
           full_name?: string | null
           avatar_url?: string | null
           calendar_token?: string | null
+          notification_preferences?: Json
           created_at?: string
           updated_at?: string
           subscription_tier?: string | null
@@ -53,6 +55,7 @@ export interface Database {
           full_name?: string | null
           avatar_url?: string | null
           calendar_token?: string | null
+          notification_preferences?: Json
           created_at?: string
           updated_at?: string
           subscription_tier?: string | null
@@ -446,6 +449,35 @@ export interface Database {
           user_id?: string
           storage_path?: string
           generated_at?: string
+        }
+      }
+      trip_update_log: {
+        Row: {
+          id: string
+          trip_id: string
+          actor_id: string
+          event_type: string
+          event_data: Json
+          created_at: string
+          notified_at: string | null
+        }
+        Insert: {
+          id?: string
+          trip_id: string
+          actor_id: string
+          event_type: string
+          event_data?: Json
+          created_at?: string
+          notified_at?: string | null
+        }
+        Update: {
+          id?: string
+          trip_id?: string
+          actor_id?: string
+          event_type?: string
+          event_data?: Json
+          created_at?: string
+          notified_at?: string | null
         }
       }
       extraction_examples: {

--- a/supabase/migrations/20260316000000_trip_update_notifications.sql
+++ b/supabase/migrations/20260316000000_trip_update_notifications.sql
@@ -1,0 +1,275 @@
+-- PRD-052 Phase 1 — Trip update notification emails
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS notification_preferences jsonb NOT NULL DEFAULT '{"trip_updates": true}'::jsonb;
+
+CREATE TABLE IF NOT EXISTS public.trip_update_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id uuid NOT NULL REFERENCES public.trips(id) ON DELETE CASCADE,
+  actor_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  event_data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  notified_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_update_log_trip_created
+  ON public.trip_update_log(trip_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_trip_update_log_trip_pending
+  ON public.trip_update_log(trip_id, created_at ASC)
+  WHERE notified_at IS NULL;
+
+ALTER TABLE public.trip_update_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "trip_update_log_select" ON public.trip_update_log;
+CREATE POLICY "trip_update_log_select" ON public.trip_update_log
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_update_log.trip_id
+        AND (
+          t.user_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.trip_collaborators tc
+            WHERE tc.trip_id = t.id
+              AND tc.user_id = auth.uid()
+              AND tc.accepted_at IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.family_members fm1
+            JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+            WHERE fm1.user_id = auth.uid()
+              AND fm2.user_id = t.user_id
+              AND fm1.accepted_at IS NOT NULL
+              AND fm2.accepted_at IS NOT NULL
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "trip_update_log_insert" ON public.trip_update_log;
+CREATE POLICY "trip_update_log_insert" ON public.trip_update_log
+  FOR INSERT WITH CHECK (
+    actor_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = trip_update_log.trip_id
+        AND (
+          t.user_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.trip_collaborators tc
+            WHERE tc.trip_id = t.id
+              AND tc.user_id = auth.uid()
+              AND tc.role IN ('owner', 'editor')
+              AND tc.accepted_at IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.family_members fm1
+            JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+            WHERE fm1.user_id = auth.uid()
+              AND fm2.user_id = t.user_id
+              AND fm1.accepted_at IS NOT NULL
+              AND fm2.accepted_at IS NOT NULL
+          )
+        )
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.get_trip_update_notification_recipients(
+  p_trip_id uuid,
+  p_actor_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  user_id uuid,
+  email text,
+  full_name text,
+  notification_preferences jsonb
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  WITH requester_has_access AS (
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = p_trip_id
+        AND (
+          t.user_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.trip_collaborators tc
+            WHERE tc.trip_id = t.id
+              AND tc.user_id = auth.uid()
+              AND tc.accepted_at IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.family_members fm1
+            JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+            WHERE fm1.user_id = auth.uid()
+              AND fm2.user_id = t.user_id
+              AND fm1.accepted_at IS NOT NULL
+              AND fm2.accepted_at IS NOT NULL
+          )
+        )
+    ) AS allowed
+  ),
+  owner_recipient AS (
+    SELECT p.id AS user_id, p.email, p.full_name, p.notification_preferences
+    FROM public.trips t
+    JOIN public.profiles p ON p.id = t.user_id
+    WHERE t.id = p_trip_id
+  ),
+  family_recipients AS (
+    SELECT DISTINCT p.id AS user_id, p.email, p.full_name, p.notification_preferences
+    FROM public.trips t
+    JOIN public.family_members owner_member
+      ON owner_member.user_id = t.user_id
+     AND owner_member.accepted_at IS NOT NULL
+    JOIN public.family_members family_member
+      ON family_member.family_id = owner_member.family_id
+     AND family_member.user_id IS NOT NULL
+     AND family_member.accepted_at IS NOT NULL
+    JOIN public.profiles p ON p.id = family_member.user_id
+    WHERE t.id = p_trip_id
+  ),
+  collaborator_recipients AS (
+    SELECT DISTINCT p.id AS user_id, p.email, p.full_name, p.notification_preferences
+    FROM public.trip_collaborators tc
+    JOIN public.profiles p ON p.id = tc.user_id
+    WHERE tc.trip_id = p_trip_id
+      AND tc.user_id IS NOT NULL
+      AND tc.accepted_at IS NOT NULL
+  ),
+  combined AS (
+    SELECT * FROM owner_recipient
+    UNION
+    SELECT * FROM family_recipients
+    UNION
+    SELECT * FROM collaborator_recipients
+  )
+  SELECT c.user_id, c.email, c.full_name, c.notification_preferences
+  FROM combined c
+  WHERE EXISTS (
+    SELECT 1
+    FROM requester_has_access
+    WHERE allowed
+  )
+    AND (p_actor_id IS NULL OR c.user_id <> p_actor_id)
+    AND COALESCE((c.notification_preferences ->> 'trip_updates')::boolean, true);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_pending_trip_update_events(p_trip_id uuid)
+RETURNS TABLE (
+  id uuid,
+  trip_id uuid,
+  actor_id uuid,
+  event_type text,
+  event_data jsonb,
+  created_at timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  WITH requester_has_access AS (
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.trips t
+      WHERE t.id = p_trip_id
+        AND (
+          t.user_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.trip_collaborators tc
+            WHERE tc.trip_id = t.id
+              AND tc.user_id = auth.uid()
+              AND tc.accepted_at IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM public.family_members fm1
+            JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+            WHERE fm1.user_id = auth.uid()
+              AND fm2.user_id = t.user_id
+              AND fm1.accepted_at IS NOT NULL
+              AND fm2.accepted_at IS NOT NULL
+          )
+        )
+    ) AS allowed
+  )
+  SELECT tul.id, tul.trip_id, tul.actor_id, tul.event_type, tul.event_data, tul.created_at
+  FROM public.trip_update_log tul
+  WHERE tul.trip_id = p_trip_id
+    AND tul.notified_at IS NULL
+    AND EXISTS (
+      SELECT 1
+      FROM requester_has_access
+      WHERE allowed
+    )
+  ORDER BY tul.created_at ASC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_trip_update_events_notified(
+  p_trip_id uuid,
+  p_event_ids uuid[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.trips t
+    WHERE t.id = p_trip_id
+      AND (
+        t.user_id = auth.uid()
+        OR EXISTS (
+          SELECT 1
+          FROM public.trip_collaborators tc
+          WHERE tc.trip_id = t.id
+            AND tc.user_id = auth.uid()
+            AND tc.accepted_at IS NOT NULL
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM public.family_members fm1
+          JOIN public.family_members fm2 ON fm1.family_id = fm2.family_id
+          WHERE fm1.user_id = auth.uid()
+            AND fm2.user_id = t.user_id
+            AND fm1.accepted_at IS NOT NULL
+            AND fm2.accepted_at IS NOT NULL
+        )
+      )
+  ) THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.trip_update_log
+  SET notified_at = now()
+  WHERE trip_id = p_trip_id
+    AND id = ANY(p_event_ids)
+    AND notified_at IS NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_trip_update_notification_recipients(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_trip_update_notification_recipients(uuid, uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_pending_trip_update_events(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_pending_trip_update_events(uuid) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.mark_trip_update_events_notified(uuid, uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_trip_update_events_notified(uuid, uuid[]) TO authenticated, service_role;


### PR DESCRIPTION
## What

Email family members and collaborators when a shared trip is updated (new item added, meaningful item changes). Per PRD-052.

## Changes

- **Migration:** `notification_preferences` JSONB column on profiles + `trip_update_log` table with RLS and SECURITY DEFINER helpers for cross-user recipient lookup
- **Email template:** React Email component matching existing brand style
- **Notification engine:** event logging, recipient resolution (owner + family + collaborators - actor), 5-minute debounce batching
- **API hooks:** item create (REST + email webhook), item update (dates/status/location only)
- **Preferences API:** GET/PATCH notification preferences
- **Unsubscribe:** List-Unsubscribe header + one-click settings link

## What does NOT trigger notifications

- Item deletion
- Trip deletion
- Trip title/cover changes
- Collaborator additions (they get their own invite)

## Testing

- `pnpm check` passes
- `pnpm test` passes (27 suites, 180 tests)