### PR TITLE
fix: render pre-flight city segment before transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.563.0",
     "nanoid": "^5.1.6",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-image-crop": "^11.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.97.0
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@16.1.7(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       ai:
         specifier: ^6.0.62
         version: 6.0.62(zod@4.3.6)
@@ -48,8 +48,8 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
       next:
-        specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 16.1.7
+        version: 16.1.7(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -729,60 +729,60 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.1.7':
+    resolution: {integrity: sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==}
 
   '@next/eslint-plugin-next@16.1.6':
     resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.1.7':
+    resolution: {integrity: sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.1.7':
+    resolution: {integrity: sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.1.7':
+    resolution: {integrity: sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.1.7':
+    resolution: {integrity: sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.1.7':
+    resolution: {integrity: sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.1.7':
+    resolution: {integrity: sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.1.7':
+    resolution: {integrity: sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.1.7':
+    resolution: {integrity: sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2839,8 +2839,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.1.7:
+    resolution: {integrity: sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4064,34 +4064,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.1.7': {}
 
   '@next/eslint-plugin-next@16.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.1.7':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.1.7':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.1.7':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.1.7':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.1.7':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.1.7':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.1.7':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.1.7':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4763,9 +4763,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@16.1.7(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.7(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/oidc@3.1.0': {}
@@ -6403,9 +6403,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.7(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.1.7
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001766
@@ -6414,14 +6414,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
+      '@next/swc-darwin-arm64': 16.1.7
+      '@next/swc-darwin-x64': 16.1.7
+      '@next/swc-linux-arm64-gnu': 16.1.7
+      '@next/swc-linux-arm64-musl': 16.1.7
+      '@next/swc-linux-x64-gnu': 16.1.7
+      '@next/swc-linux-x64-musl': 16.1.7
+      '@next/swc-win32-arm64-msvc': 16.1.7
+      '@next/swc-win32-x64-msvc': 16.1.7
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.58.2
       sharp: 0.34.5

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -126,11 +126,14 @@ export async function POST(request: NextRequest) {
       null
 
     // Look up user by sender email in allowed_senders
+    // Use .limit(1) + .maybeSingle() instead of .single() to handle edge case
+    // where the same email appears in multiple allowed_senders rows (e.g. duplicate accounts).
     const { data: allowedSender } = await supabase
       .from('allowed_senders')
       .select('user_id, profiles(id, email, full_name)')
       .eq('email', fromEmail.toLowerCase())
-      .single()
+      .limit(1)
+      .maybeSingle()
 
     // Store the raw email with content from API
     const { data: sourceEmail, error: insertError } = await supabase

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -235,6 +235,40 @@ describe('buildTimeline', () => {
     expect(segments[2].segment?.city).not.toContain('Stephen F Austin')
     expect(segments[5].segment?.durationNights).toBe(0)
   })
+
+  it('pre-flight segment items appear before the transition', () => {
+    // Car rental Mar 26, flight Mar 29 — segment should render before the flight
+    const items: TripItem[] = [
+      makeItem({
+        kind: 'car',
+        start_date: '2026-03-26',
+        end_date: '2026-03-29',
+        start_location: 'Milan Airport Malpensa T1',
+        end_location: 'Turin Airport',
+        summary: 'Car rental: Fiat Panda',
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-29',
+        end_date: '2026-03-29',
+        start_location: 'TRN',
+        end_location: 'CDG',
+        details_json: {
+          departure_airport: 'TRN',
+          arrival_airport: 'CDG',
+          departure_local_time: '10:20',
+          arrival_local_time: '11:50',
+        },
+      }),
+    ]
+    const timeline = buildTimeline(items)
+    // The segment containing the car rental should come before the flight transition
+    const segmentIdx = timeline.findIndex((e) => e.type === 'segment' && e.segment?.items.some((i) => i.kind === 'car'))
+    const transitionIdx = timeline.findIndex((e) => e.type === 'transition')
+    expect(segmentIdx).toBeGreaterThanOrEqual(0)
+    expect(transitionIdx).toBeGreaterThanOrEqual(0)
+    expect(segmentIdx).toBeLessThan(transitionIdx)
+  })
 })
 
 describe('hotel segment assignment', () => {
@@ -465,40 +499,6 @@ describe('attachWeatherToTimeline — metro aliases', () => {
     const result = attachWeatherToTimeline(entries, destinations)
     expect(result[0].segment?.weather?.daily).toHaveLength(2)
     expect(result[0].segment?.weather?.daily?.[0].high).toBe(60)
-  })
-
-  it('pre-flight segment items appear before the transition', () => {
-    // Car rental Mar 26, flight Mar 29 — segment should render before the flight
-    const items: TripItem[] = [
-      makeItem({
-        kind: 'car',
-        start_date: '2026-03-26',
-        end_date: '2026-03-29',
-        start_location: 'Milan Airport Malpensa T1',
-        end_location: 'Turin Airport',
-        summary: 'Car rental: Fiat Panda',
-      }),
-      makeItem({
-        kind: 'flight',
-        start_date: '2026-03-29',
-        end_date: '2026-03-29',
-        start_location: 'TRN',
-        end_location: 'CDG',
-        details_json: {
-          departure_airport: 'TRN',
-          arrival_airport: 'CDG',
-          departure_local_time: '10:20',
-          arrival_local_time: '11:50',
-        },
-      }),
-    ]
-    const timeline = buildTimeline(items)
-    // The segment containing the car rental should come before the flight transition
-    const segmentIdx = timeline.findIndex((e) => e.type === 'segment' && e.segment?.items.some((i) => i.kind === 'car'))
-    const transitionIdx = timeline.findIndex((e) => e.type === 'transition')
-    expect(segmentIdx).toBeGreaterThanOrEqual(0)
-    expect(transitionIdx).toBeGreaterThanOrEqual(0)
-    expect(segmentIdx).toBeLessThan(transitionIdx)
   })
 
   it('matches Surfside weather to Miami segment', () => {

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -471,7 +471,7 @@ describe('attachWeatherToTimeline — metro aliases', () => {
     // Car rental Mar 26, flight Mar 29 — segment should render before the flight
     const items: TripItem[] = [
       makeItem({
-        kind: 'car_rental',
+        kind: 'car',
         start_date: '2026-03-26',
         end_date: '2026-03-29',
         start_location: 'Milan Airport Malpensa T1',
@@ -494,7 +494,7 @@ describe('attachWeatherToTimeline — metro aliases', () => {
     ]
     const timeline = buildTimeline(items)
     // The segment containing the car rental should come before the flight transition
-    const segmentIdx = timeline.findIndex((e) => e.type === 'segment' && e.segment?.items.some((i) => i.kind === 'car_rental'))
+    const segmentIdx = timeline.findIndex((e) => e.type === 'segment' && e.segment?.items.some((i) => i.kind === 'car'))
     const transitionIdx = timeline.findIndex((e) => e.type === 'transition')
     expect(segmentIdx).toBeGreaterThanOrEqual(0)
     expect(transitionIdx).toBeGreaterThanOrEqual(0)

--- a/src/lib/trips/city-segments.test.ts
+++ b/src/lib/trips/city-segments.test.ts
@@ -467,6 +467,40 @@ describe('attachWeatherToTimeline — metro aliases', () => {
     expect(result[0].segment?.weather?.daily?.[0].high).toBe(60)
   })
 
+  it('pre-flight segment items appear before the transition', () => {
+    // Car rental Mar 26, flight Mar 29 — segment should render before the flight
+    const items: TripItem[] = [
+      makeItem({
+        kind: 'car_rental',
+        start_date: '2026-03-26',
+        end_date: '2026-03-29',
+        start_location: 'Milan Airport Malpensa T1',
+        end_location: 'Turin Airport',
+        summary: 'Car rental: Fiat Panda',
+      }),
+      makeItem({
+        kind: 'flight',
+        start_date: '2026-03-29',
+        end_date: '2026-03-29',
+        start_location: 'TRN',
+        end_location: 'CDG',
+        details_json: {
+          departure_airport: 'TRN',
+          arrival_airport: 'CDG',
+          departure_local_time: '10:20',
+          arrival_local_time: '11:50',
+        },
+      }),
+    ]
+    const timeline = buildTimeline(items)
+    // The segment containing the car rental should come before the flight transition
+    const segmentIdx = timeline.findIndex((e) => e.type === 'segment' && e.segment?.items.some((i) => i.kind === 'car_rental'))
+    const transitionIdx = timeline.findIndex((e) => e.type === 'transition')
+    expect(segmentIdx).toBeGreaterThanOrEqual(0)
+    expect(transitionIdx).toBeGreaterThanOrEqual(0)
+    expect(segmentIdx).toBeLessThan(transitionIdx)
+  })
+
   it('matches Surfside weather to Miami segment', () => {
     const entries = [makeEntry('Miami', '2026-03-08', '2026-03-09')]
     const destinations = [makeDestination('Surfside', [makeForecastDay('2026-03-08', 2, 82, 72)])]

--- a/src/lib/trips/city-segments.ts
+++ b/src/lib/trips/city-segments.ts
@@ -446,6 +446,18 @@ export function buildTimeline(items: TripItem[]): TimelineEntry[] {
   let segmentIndex = 0
 
   for (const transition of transitions) {
+    // If the next unprocessed segment departs via this transition but has no
+    // incoming flight (e.g. first segment of the trip), render it before the
+    // transition so items appear in chronological order.
+    if (
+      segmentIndex < segments.length &&
+      rawSegments[segmentIndex]?.outgoing === transition &&
+      rawSegments[segmentIndex]?.incoming === null
+    ) {
+      timeline.push({ type: 'segment', segment: segments[segmentIndex] })
+      segmentIndex += 1
+    }
+
     const nextSegment =
       segments[segmentIndex] && rawSegments[segmentIndex]?.incoming === transition
         ? segments[segmentIndex]

--- a/supabase/migrations/20260320100000_restore_family_members_select.sql
+++ b/supabase/migrations/20260320100000_restore_family_members_select.sql
@@ -1,0 +1,15 @@
+-- Restore family_members SELECT policy to show all members in your families.
+-- The migration 20260309131000 stripped this to user_id = auth.uid() as a
+-- "temporary" fix for circular RLS — but is_member_of_family() is a
+-- SECURITY DEFINER function that doesn't trigger recursion.
+-- That temp fix was never reverted, so family pages show only yourself.
+
+DROP POLICY IF EXISTS "family_members_select" ON public.family_members;
+
+CREATE POLICY "family_members_select" ON public.family_members
+  FOR SELECT USING (
+    user_id = auth.uid()
+    OR public.is_member_of_family(family_id)
+  );
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
When a segment has no incoming flight but has an outgoing flight, the segment's items (e.g. car rental starting Mar 26) should appear before the flight transition (Mar 29), not after it.

**Bug:** Car rental (Mar 26) rendered below the flight (Mar 29) on the trip timeline because the timeline assembly always placed transitions before their departure segment.

**Fix:** Before rendering a transition, check if the next unprocessed segment departs via this transition but has no incoming flight. If so, render the segment first, preserving chronological order.

**Test added:** Verifies car rental segment appears before flight transition in the timeline.