### PR TITLE
feat: PRD-055 Demand-Driven Event Pipeline — home city + orchestration

### DIFF
--- a/scripts/collect-demand-cities.ts
+++ b/scripts/collect-demand-cities.ts
@@ -1,0 +1,274 @@
+/**
+ * Collect demand cities from active/upcoming trips and user home cities,
+ * ensure they are tracked, and trigger event discovery for stale ones.
+ *
+ * Usage: npx tsx scripts/collect-demand-cities.ts [--dry-run]
+ */
+
+import { createSecretClient } from '@/lib/supabase/service'
+import { normaliseToCity } from '@/lib/trips/assignment'
+import { runCityDiscovery } from './lib/discover-events-core'
+import type { PipelineCity } from './lib/types'
+
+const isDryRun = process.argv.includes('--dry-run')
+
+// Keywords that indicate a non-city string (venues, transit infrastructure, etc.)
+const NON_CITY_PATTERN = /\b(shop|station|mall|terminal|kiosk|shinkansen|ext\.)\b/i
+
+function generateSlug(city: string): string {
+  return city.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Normalise a raw location string to a city name suitable for demand tracking.
+ * Returns null if the value doesn't look like a real city.
+ *
+ * Rules applied on top of normaliseToCity:
+ *   'Turin Airport'                → 'Turin'   (strip Airport suffix)
+ *   'KTOL'                        → null       (all-caps code)
+ *   'Shizuoka Shinkansen Ext. Shop' → null     (non-city keywords)
+ */
+function toDemandCity(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  // Skip all-caps codes (IATA, transport codes, etc.)
+  if (/^[A-Z0-9]{2,6}$/.test(trimmed)) return null
+
+  // Strip 'Airport' suffix before further normalisation
+  let city = trimmed.replace(/\s+Airport\b/i, '').trim()
+
+  // Delegate comma/venue normalisation to the shared function
+  city = normaliseToCity(city)
+
+  // Skip if non-city keywords remain after normalisation
+  if (NON_CITY_PATTERN.test(city)) return null
+
+  return city || null
+}
+
+async function main() {
+  const supabase = createSecretClient()
+  const today = new Date().toISOString().slice(0, 10)
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+  console.log(`[collect-demand-cities] Starting${isDryRun ? ' (dry-run)' : ''}...`)
+
+  // 1. Query active + upcoming trips
+  const { data: trips, error: tripsError } = await supabase
+    .from('trips')
+    .select('id, primary_location, start_date')
+    .gte('end_date', today)
+
+  if (tripsError) throw new Error(`Failed to load trips: ${tripsError.message}`)
+
+  // Build trip start_date lookup for sorting cities by urgency
+  const tripStartDates = new Map<string, string>()
+  for (const trip of trips ?? []) {
+    tripStartDates.set(trip.id, trip.start_date ?? today)
+  }
+
+  // Track city → earliest trip start_date (lowercase key for consistency)
+  const cityToEarliestTrip = new Map<string, string>()
+
+  function trackCityDate(city: string, tripId: string) {
+    const tripDate = tripStartDates.get(tripId) ?? today
+    const key = city.toLowerCase()
+    const existing = cityToEarliestTrip.get(key)
+    if (!existing || tripDate < existing) {
+      cityToEarliestTrip.set(key, tripDate)
+    }
+  }
+
+  // 2. Extract cities from primary_location of active trips
+  const demandCityNames = new Set<string>()
+
+  for (const trip of trips ?? []) {
+    const city = toDemandCity(trip.primary_location)
+    if (city) {
+      demandCityNames.add(city)
+      trackCityDate(city, trip.id)
+    }
+  }
+
+  // 3. Scan trip_items of active trips for multi-city coverage
+  const activeTripIds = [...tripStartDates.keys()]
+  if (activeTripIds.length > 0) {
+    const { data: tripItems, error: tripItemsError } = await supabase
+      .from('trip_items')
+      .select('trip_id, start_location, end_location')
+      .in('trip_id', activeTripIds)
+
+    if (tripItemsError) throw new Error(`Failed to load trip_items: ${tripItemsError.message}`)
+
+    for (const item of tripItems ?? []) {
+      for (const loc of [item.start_location, item.end_location]) {
+        const city = toDemandCity(loc)
+        if (city) {
+          demandCityNames.add(city)
+          trackCityDate(city, item.trip_id)
+        }
+      }
+    }
+  }
+
+  // 4. Query non-null home_city values from user_profiles
+  const { data: profiles, error: profilesError } = await supabase
+    .from('user_profiles')
+    .select('home_city')
+    .not('home_city', 'is', null)
+
+  if (profilesError) throw new Error(`Failed to load user profiles: ${profilesError.message}`)
+
+  for (const profile of profiles ?? []) {
+    const city = toDemandCity(profile.home_city as string | null)
+    if (city) {
+      demandCityNames.add(city)
+      if (!cityToEarliestTrip.has(city.toLowerCase())) {
+        cityToEarliestTrip.set(city.toLowerCase(), today)
+      }
+    }
+  }
+
+  console.log(`[collect-demand-cities] ${demandCityNames.size} demand cities identified`)
+
+  // 5. Load all tracked cities into a case-insensitive map
+  const { data: existingCities, error: existingError } = await supabase
+    .from('tracked_cities')
+    .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
+
+  if (existingError) throw new Error(`Failed to load tracked cities: ${existingError.message}`)
+
+  const trackedMap = new Map<string, PipelineCity>()
+  for (const tc of existingCities ?? []) {
+    trackedMap.set(tc.city.toLowerCase(), tc as PipelineCity)
+  }
+
+  // 6. Ensure each demand city is tracked; collect cities needing refresh
+  const citiesToRefresh: Array<{ city: PipelineCity; earliestTrip: string }> = []
+  let newCitiesCount = 0
+
+  for (const cityName of demandCityNames) {
+    let tracked = trackedMap.get(cityName.toLowerCase())
+
+    if (!tracked) {
+      const slug = generateSlug(cityName)
+      newCitiesCount++
+      console.log(`[collect-demand-cities] New city: ${cityName} (slug: ${slug})`)
+
+      if (!isDryRun) {
+        const { data: inserted, error: insertError } = await supabase
+          .from('tracked_cities')
+          .insert({
+            city: cityName,
+            country: '',
+            slug,
+            latitude: null,
+            longitude: null,
+            timezone: null,
+            hero_image_url: null,
+          })
+          .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
+          .single()
+
+        if (insertError) {
+          // Unique constraint violation or race condition — look up the existing record
+          const { data: existing } = await supabase
+            .from('tracked_cities')
+            .select('id, city, country, country_code, slug, timezone, last_refreshed_at')
+            .ilike('city', cityName)
+            .maybeSingle()
+
+          if (existing) {
+            tracked = existing as PipelineCity
+          } else {
+            console.warn(
+              `[collect-demand-cities] Could not insert or find "${cityName}": ${insertError.message}`
+            )
+            continue
+          }
+        } else {
+          tracked = inserted as PipelineCity
+        }
+      } else {
+        // Dry-run: create a placeholder so refresh planning still works
+        tracked = {
+          id: 'dry-run',
+          city: cityName,
+          country: '',
+          country_code: null,
+          slug,
+          timezone: null,
+          last_refreshed_at: null,
+        }
+      }
+    }
+
+    const needsRefresh =
+      !tracked.last_refreshed_at || tracked.last_refreshed_at < twentyFourHoursAgo
+
+    if (needsRefresh) {
+      const earliestTrip = cityToEarliestTrip.get(cityName.toLowerCase()) ?? today
+      citiesToRefresh.push({ city: tracked, earliestTrip })
+    }
+  }
+
+  // 7. Sort by soonest trip date, cap at 10
+  citiesToRefresh.sort((a, b) => a.earliestTrip.localeCompare(b.earliestTrip))
+  const toProcess = citiesToRefresh.slice(0, 10)
+
+  console.log(
+    `[collect-demand-cities] ${citiesToRefresh.length} cities need refresh, processing up to ${toProcess.length}`
+  )
+
+  // 8. Run discovery for each city with 30s gaps
+  let refreshed = 0
+
+  for (let i = 0; i < toProcess.length; i++) {
+    const { city } = toProcess[i]
+    console.log(`[collect-demand-cities] Running discovery for: ${city.city}`)
+
+    if (!isDryRun) {
+      try {
+        const summary = await runCityDiscovery({ supabase, city })
+        console.log(
+          `[collect-demand-cities] ${city.city}: inserted ${summary.inserted}, updated ${summary.updated}, sources ${summary.sourcesChecked}`
+        )
+        refreshed++
+      } catch (error) {
+        console.error(
+          `[collect-demand-cities] Error for ${city.city}:`,
+          error instanceof Error ? error.message : error
+        )
+      }
+
+      if (i < toProcess.length - 1) {
+        await sleep(30_000)
+      }
+    } else {
+      console.log(`[collect-demand-cities] [DRY RUN] Would run discovery for: ${city.city}`)
+      refreshed++
+    }
+  }
+
+  // 9. Summary
+  console.log(
+    `[collect-demand-cities] Done: ${demandCityNames.size} demand cities, ` +
+      `${newCitiesCount} new tracked, ${citiesToRefresh.length} needed refresh, ${refreshed} refreshed`
+  )
+
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(
+    '[collect-demand-cities] Fatal:',
+    error instanceof Error ? error.message : error
+  )
+  process.exit(1)
+})

--- a/src/app/(dashboard)/settings/profile/ProfileForm.tsx
+++ b/src/app/(dashboard)/settings/profile/ProfileForm.tsx
@@ -17,6 +17,7 @@ interface ProfileData {
   airline_alliance: AlliancePreference
   hotel_brand_preference: string | null
   home_airport: string | null
+  home_city: string | null
   currency_preference: string
   temperature_unit: 'fahrenheit' | 'celsius'
   notes: string | null
@@ -30,6 +31,7 @@ interface ProfileFormProps {
 
 export function ProfileForm({ initialProfile, canEditNotes }: ProfileFormProps) {
   const [homeAirport, setHomeAirport] = useState(initialProfile.home_airport ?? '')
+  const [homeCity, setHomeCity] = useState(initialProfile.home_city ?? '')
   const [seatPreference, setSeatPreference] = useState<SeatPreference>(initialProfile.seat_preference)
   const [mealPreference, setMealPreference] = useState<MealPreference>(initialProfile.meal_preference)
   const [airlineAlliance, setAirlineAlliance] = useState<AlliancePreference>(initialProfile.airline_alliance)
@@ -55,6 +57,7 @@ export function ProfileForm({ initialProfile, canEditNotes }: ProfileFormProps) 
         },
         body: JSON.stringify({
           home_airport: homeAirport.trim() || null,
+          home_city: homeCity.trim() || null,
           seat_preference: seatPreference,
           meal_preference: mealPreference,
           airline_alliance: airlineAlliance,
@@ -98,6 +101,17 @@ export function ProfileForm({ initialProfile, canEditNotes }: ProfileFormProps) 
             maxLength={8}
           />
           <p className="text-xs text-gray-500">Use IATA code when possible (for example: SFO, JFK).</p>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="home_city" className="text-sm font-medium text-gray-700">Home City</label>
+          <Input
+            id="home_city"
+            value={homeCity}
+            onChange={(event) => setHomeCity(event.target.value)}
+            placeholder="Paris"
+          />
+          <p className="text-xs text-gray-500">Your home city for local event recommendations.</p>
         </div>
 
         <div className="space-y-1.5">

--- a/src/app/(dashboard)/settings/profile/page.tsx
+++ b/src/app/(dashboard)/settings/profile/page.tsx
@@ -12,6 +12,7 @@ interface ProfileResponse {
   airline_alliance: 'star_alliance' | 'oneworld' | 'skyteam' | 'none'
   hotel_brand_preference: string | null
   home_airport: string | null
+  home_city: string | null
   currency_preference: string
   temperature_unit: 'fahrenheit' | 'celsius'
   notes: string | null
@@ -26,6 +27,7 @@ function fallbackProfile(userId: string): ProfileResponse {
     airline_alliance: 'none',
     hotel_brand_preference: null,
     home_airport: null,
+    home_city: null,
     currency_preference: 'USD',
     temperature_unit: 'fahrenheit',
     notes: null,

--- a/src/app/api/v1/me/profile/route.ts
+++ b/src/app/api/v1/me/profile/route.ts
@@ -13,6 +13,7 @@ interface UserProfileRow {
   airline_alliance: (typeof ALLIANCE_PREFERENCES)[number]
   hotel_brand_preference: string | null
   home_airport: string | null
+  home_city: string | null
   currency_preference: string
   temperature_unit: 'fahrenheit' | 'celsius'
   notes: string | null
@@ -33,6 +34,7 @@ function defaultProfile(userId: string): UserProfileRow {
     airline_alliance: 'none',
     hotel_brand_preference: null,
     home_airport: null,
+    home_city: null,
     currency_preference: 'USD',
     temperature_unit: 'fahrenheit',
     notes: null,
@@ -151,6 +153,7 @@ async function upsertProfile(request: NextRequest) {
 
   const hotelBrand = normalizeNullableString(body.hotel_brand_preference)
   const homeAirport = normalizeNullableString(body.home_airport)
+  const homeCity = normalizeNullableString(body.home_city)
   const notes = normalizeNullableString(body.notes)
 
   if (body.hotel_brand_preference !== undefined && hotelBrand === undefined) {
@@ -163,6 +166,13 @@ async function upsertProfile(request: NextRequest) {
   if (body.home_airport !== undefined && homeAirport === undefined) {
     return NextResponse.json(
       { error: { code: 'invalid_param', message: 'home_airport must be a string or null.', field: 'home_airport' } },
+      { status: 400 }
+    )
+  }
+
+  if (body.home_city !== undefined && homeCity === undefined) {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: 'home_city must be a string or null.', field: 'home_city' } },
       { status: 400 }
     )
   }
@@ -187,6 +197,7 @@ async function upsertProfile(request: NextRequest) {
     ...(body.airline_alliance !== undefined ? { airline_alliance: body.airline_alliance } : {}),
     ...(body.hotel_brand_preference !== undefined ? { hotel_brand_preference: hotelBrand } : {}),
     ...(body.home_airport !== undefined ? { home_airport: homeAirport ? homeAirport.toUpperCase() : null } : {}),
+    ...(body.home_city !== undefined ? { home_city: homeCity } : {}),
     ...(currencyPreference !== undefined ? { currency_preference: currencyPreference } : {}),
     ...(body.temperature_unit !== undefined ? { temperature_unit: body.temperature_unit } : {}),
     ...(body.notes !== undefined ? { notes } : {}),

--- a/supabase/migrations/20260322000000_add_home_city.sql
+++ b/supabase/migrations/20260322000000_add_home_city.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS home_city TEXT;


### PR DESCRIPTION
## PRD-055 — Demand-Driven Event Pipeline

Events should refresh for cities people are **actually traveling to**, not a static seed list.

### Changes

**Migration**
- Adds `home_city TEXT` column to `user_profiles`

**Settings UI**
- New 'Home City' field in Settings → Profile (free text, right after Home Airport)
- Placeholder: 'Paris', help text explains it's for local event recommendations

**API**
- `/api/v1/me/profile` accepts and returns `home_city`

**Orchestration script** (`scripts/collect-demand-cities.ts`)
- Scans upcoming trips (`end_date >= today`) for city names from `primary_location` + trip items
- Collects `home_city` from all user profiles
- Normalizes city names (strips airport suffixes, venue prefixes, country suffixes, skips non-cities)
- Auto-creates `tracked_cities` entries for new demand cities
- Refreshes up to 10 stale cities per run (>24h since last refresh), sorted by soonest trip
- 30-second delay between cities to respect API rate limits
- Supports `--dry-run` flag

### How it works
```
npx tsx scripts/collect-demand-cities.ts          # run for real
npx tsx scripts/collect-demand-cities.ts --dry-run  # preview only
```

Designed to run as a daily cron (4 AM UTC). Replaces the old `--all` pattern that refreshed every seed city indiscriminately.

### Testing
- Set home_city in settings, verify it persists
- Run `--dry-run` to see demand city list without triggering refreshes
- Verify auto-creation of tracked_cities for cities not in the seed list