### PR TITLE
feat: PRD-056 City Events Integration — events on stay cards, page redesign, Places autocomplete

### DIFF
--- a/src/app/(dashboard)/events/HomeCityPrompt.tsx
+++ b/src/app/(dashboard)/events/HomeCityPrompt.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { MapPin } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { CityAutocomplete } from '@/components/ui/city-autocomplete'
+
+export function HomeCityPrompt({ hasHomeCity }: { hasHomeCity: boolean }) {
+  const router = useRouter()
+  const [city, setCity] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (hasHomeCity) {
+    // Home city is set but city isn't in tracked_cities — show a softer prompt
+    return (
+      <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-5 py-6 text-center">
+        <MapPin className="mx-auto mb-2 h-8 w-8 text-slate-300" />
+        <p className="text-sm font-medium text-slate-600">Your home city isn&apos;t tracked yet.</p>
+        <p className="mt-1 text-xs text-slate-400">
+          We&apos;ll add event coverage as we expand to more cities.
+        </p>
+      </div>
+    )
+  }
+
+  const handleSave = async () => {
+    if (!city.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/v1/me/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ home_city: city.trim() }),
+      })
+      if (!res.ok) {
+        setError('Failed to save. Please try again.')
+        return
+      }
+      router.refresh()
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-dashed border-indigo-200 bg-indigo-50/50 px-5 py-6">
+      <div className="mb-3 flex items-center gap-2">
+        <MapPin className="h-4 w-4 text-indigo-500" />
+        <p className="text-sm font-semibold text-slate-800">Set your home city to see local events</p>
+      </div>
+      <p className="mb-4 text-xs text-slate-500">
+        We&apos;ll show you what&apos;s happening nearby whenever you&apos;re not on a trip.
+      </p>
+      <div className="flex items-center gap-2">
+        <div className="flex-1">
+          <CityAutocomplete
+            value={city}
+            onChange={setCity}
+            placeholder="Search for your city…"
+          />
+        </div>
+        <Button size="sm" onClick={handleSave} disabled={saving || !city.trim()}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+      {error ? <p className="mt-2 text-xs text-red-600">{error}</p> : null}
+      <p className="mt-3 text-xs text-slate-400">
+        You can also set this in{' '}
+        <Link href="/settings/profile" className="text-indigo-600 hover:underline">
+          Settings → Profile
+        </Link>
+        .
+      </p>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/events/page.tsx
+++ b/src/app/(dashboard)/events/page.tsx
@@ -2,8 +2,11 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
-import { Ticket, MapPin, Clock, CalendarDays } from 'lucide-react'
+import { Ticket, MapPin, Clock, CalendarDays, Sparkles } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
+import { getTrackedCities, getCityEvents, matchTrackedCityByName } from '@/lib/events/queries'
+import type { CityEvent, TrackedCity } from '@/types/events'
+import { HomeCityPrompt } from './HomeCityPrompt'
 
 interface TicketItem {
   id: string
@@ -24,6 +27,55 @@ interface TicketItem {
 
 type EventFilter = 'upcoming' | 'past' | 'all'
 
+interface HeroData {
+  city: TrackedCity
+  events: CityEvent[]
+}
+
+async function resolveCurrentCity(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  today: string
+): Promise<{ city: TrackedCity; events: CityEvent[] } | null> {
+  const cities = await getTrackedCities(supabase)
+
+  // Check for active trip
+  const { data: activeTrips } = await supabase
+    .from('trips')
+    .select('primary_location')
+    .eq('user_id', userId)
+    .lte('start_date', today)
+    .gte('end_date', today)
+    .not('primary_location', 'is', null)
+    .limit(1)
+
+  let cityName: string | null = null
+
+  if (activeTrips && activeTrips.length > 0) {
+    cityName = activeTrips[0].primary_location as string
+  } else {
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('home_city')
+      .eq('id', userId)
+      .maybeSingle()
+    cityName = profile?.home_city ?? null
+  }
+
+  if (!cityName) return null
+
+  const trackedCity = matchTrackedCityByName(cities, cityName)
+  if (!trackedCity) return null
+
+  const twoWeeksOut = new Date(today)
+  twoWeeksOut.setDate(twoWeeksOut.getDate() + 14)
+  const toDate = twoWeeksOut.toISOString().slice(0, 10)
+
+  const events = await getCityEvents(supabase, trackedCity.id, { from: today, to: toDate })
+
+  return { city: trackedCity, events }
+}
+
 export default async function EventsPage({
   searchParams,
 }: {
@@ -36,6 +88,22 @@ export default async function EventsPage({
   const params = await searchParams
   const filter = (params.filter as EventFilter) || 'upcoming'
   const today = new Date().toISOString().split('T')[0]
+
+  // Resolve "what's happening" hero city and events
+  let heroData: HeroData | null = null
+  let hasHomeCity = false
+
+  try {
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('home_city')
+      .eq('id', user.id)
+      .maybeSingle()
+    hasHomeCity = !!(profile?.home_city)
+    heroData = await resolveCurrentCity(supabase, user.id, today)
+  } catch {
+    // Non-fatal — hero section is best-effort
+  }
 
   // Fetch all ticket items for this user, with their trip info
   let query = supabase
@@ -64,9 +132,9 @@ export default async function EventsPage({
   ]
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
       {/* Header */}
-      <div className="mb-8 flex items-center gap-3">
+      <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-100">
           <Ticket className="h-5 w-5 text-amber-600" />
         </div>
@@ -76,8 +144,66 @@ export default async function EventsPage({
         </div>
       </div>
 
+      {/* What's happening hero */}
+      {heroData ? (
+        <section>
+          <div className="mb-4 flex items-center justify-between gap-2">
+            <h2 className="inline-flex items-center gap-2 text-lg font-semibold text-slate-900">
+              <Sparkles className="h-4 w-4 text-indigo-500" />
+              What&apos;s happening in {heroData.city.city}
+            </h2>
+            <Link
+              href={`/cities/${heroData.city.slug}`}
+              className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+            >
+              View all →
+            </Link>
+          </div>
+
+          {heroData.events.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-indigo-200 bg-indigo-50/50 py-8 text-center">
+              <p className="text-sm text-slate-500">No upcoming events found for {heroData.city.city}.</p>
+            </div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {heroData.events.slice(0, 6).map((event) => (
+                <div
+                  key={event.id}
+                  className="overflow-hidden rounded-xl border border-indigo-100 bg-white shadow-sm"
+                >
+                  <div className="h-28 bg-slate-100">
+                    {event.image_url ? (
+                      <img
+                        src={event.image_url}
+                        alt={event.title}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : null}
+                  </div>
+                  <div className="space-y-1 p-3">
+                    <p className="line-clamp-2 text-sm font-semibold text-slate-900">{event.title}</p>
+                    <p className="text-xs text-slate-500">{formatDate(event.start_date)}</p>
+                    <p className="text-xs uppercase tracking-[0.14em] text-slate-400">{event.category}</p>
+                    {event.venue_name ? (
+                      <p className="flex items-center gap-1 text-xs text-slate-400">
+                        <MapPin className="h-3 w-3" />
+                        {event.venue_name}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : (
+        <HomeCityPrompt hasHomeCity={hasHomeCity} />
+      )}
+
+      <div className="border-t border-gray-100" />
+
       {/* Filter tabs */}
-      <div className="mb-6 flex gap-1 rounded-lg bg-gray-100 p-1 w-fit">
+      <div className="flex gap-1 rounded-lg bg-gray-100 p-1 w-fit">
         {filterTabs.map((tab) => (
           <Link
             key={tab.key}

--- a/src/app/(dashboard)/settings/profile/ProfileForm.tsx
+++ b/src/app/(dashboard)/settings/profile/ProfileForm.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import { CityAutocomplete } from '@/components/ui/city-autocomplete'
 
 type SeatPreference = 'window' | 'aisle' | 'middle' | 'no_preference'
 type MealPreference = 'standard' | 'vegetarian' | 'vegan' | 'kosher' | 'halal' | 'gluten_free' | 'no_preference'
@@ -104,11 +105,10 @@ export function ProfileForm({ initialProfile, canEditNotes }: ProfileFormProps) 
         </div>
 
         <div className="space-y-1.5">
-          <label htmlFor="home_city" className="text-sm font-medium text-gray-700">Home City</label>
-          <Input
-            id="home_city"
+          <label className="text-sm font-medium text-gray-700">Home City</label>
+          <CityAutocomplete
             value={homeCity}
-            onChange={(event) => setHomeCity(event.target.value)}
+            onChange={setHomeCity}
             placeholder="Paris"
           />
           <p className="text-xs text-gray-500">Your home city for local event recommendations.</p>

--- a/src/app/api/v1/places/autocomplete/route.ts
+++ b/src/app/api/v1/places/autocomplete/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
+
+interface PlacePrediction {
+  description: string
+  placeId: string
+  mainText: string
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'invalid_json', message: 'Request body must be valid JSON.' } },
+      { status: 400 }
+    )
+  }
+
+  const query = body.query
+  if (typeof query !== 'string' || query.trim().length < 2) {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: 'query must be at least 2 characters.', field: 'query' } },
+      { status: 400 }
+    )
+  }
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { code: 'configuration_error', message: 'Places API not configured.' } },
+      { status: 500 }
+    )
+  }
+
+  const res = await fetch('https://places.googleapis.com/v1/places:autocomplete', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Goog-Api-Key': apiKey,
+    },
+    body: JSON.stringify({
+      input: query.trim(),
+      includedPrimaryTypes: ['(cities)'],
+    }),
+  })
+
+  if (!res.ok) {
+    console.error('[places/autocomplete] Google API error:', res.status, await res.text())
+    return NextResponse.json(
+      { error: { code: 'upstream_error', message: 'Failed to fetch predictions.' } },
+      { status: 502 }
+    )
+  }
+
+  const data = await res.json() as {
+    suggestions?: Array<{
+      placePrediction?: {
+        placeId: string
+        text?: { text: string }
+        structuredFormat?: { mainText?: { text: string } }
+      }
+    }>
+  }
+
+  const predictions: PlacePrediction[] = (data.suggestions ?? [])
+    .map((suggestion) => {
+      const pp = suggestion.placePrediction
+      if (!pp) return null
+      return {
+        description: pp.text?.text ?? '',
+        placeId: pp.placeId,
+        mainText: pp.structuredFormat?.mainText?.text ?? pp.text?.text ?? '',
+      }
+    })
+    .filter((p): p is PlacePrediction => p !== null)
+
+  return NextResponse.json({ predictions })
+}

--- a/src/app/api/v1/places/reverse-geocode/route.ts
+++ b/src/app/api/v1/places/reverse-geocode/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
+
+export async function POST(request: NextRequest) {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'invalid_json', message: 'Request body must be valid JSON.' } },
+      { status: 400 }
+    )
+  }
+
+  const { lat, lng } = body
+  if (typeof lat !== 'number' || typeof lng !== 'number') {
+    return NextResponse.json(
+      { error: { code: 'invalid_param', message: 'lat and lng must be numbers.' } },
+      { status: 400 }
+    )
+  }
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { code: 'configuration_error', message: 'Places API not configured.' } },
+      { status: 500 }
+    )
+  }
+
+  const url = new URL('https://maps.googleapis.com/maps/api/geocode/json')
+  url.searchParams.set('latlng', `${lat},${lng}`)
+  url.searchParams.set('key', apiKey)
+  url.searchParams.set('result_type', 'locality|administrative_area_level_1')
+
+  const res = await fetch(url.toString())
+  if (!res.ok) {
+    console.error('[places/reverse-geocode] Google API error:', res.status)
+    return NextResponse.json(
+      { error: { code: 'upstream_error', message: 'Failed to reverse geocode.' } },
+      { status: 502 }
+    )
+  }
+
+  const data = await res.json() as {
+    status: string
+    results?: Array<{
+      address_components: Array<{
+        long_name: string
+        types: string[]
+      }>
+    }>
+  }
+
+  if (data.status !== 'OK' || !data.results?.length) {
+    return NextResponse.json(
+      { error: { code: 'not_found', message: 'Could not determine city from coordinates.' } },
+      { status: 404 }
+    )
+  }
+
+  // Prefer locality (city), fall back to administrative_area_level_1 (state/region)
+  let city: string | null = null
+  for (const result of data.results) {
+    const locality = result.address_components.find((c) => c.types.includes('locality'))
+    if (locality) {
+      city = locality.long_name
+      break
+    }
+  }
+  if (!city) {
+    for (const result of data.results) {
+      const admin = result.address_components.find((c) =>
+        c.types.includes('administrative_area_level_1')
+      )
+      if (admin) {
+        city = admin.long_name
+        break
+      }
+    }
+  }
+
+  if (!city) {
+    return NextResponse.json(
+      { error: { code: 'not_found', message: 'Could not determine city from coordinates.' } },
+      { status: 404 }
+    )
+  }
+
+  return NextResponse.json({ city })
+}

--- a/src/components/trips/city-segment-block.tsx
+++ b/src/components/trips/city-segment-block.tsx
@@ -1,10 +1,13 @@
 'use client'
 
+import Link from 'next/link'
+import { Sparkles } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { formatDate, formatDateRange } from '@/lib/utils'
 import type { CitySegment } from '@/lib/trips/city-segments'
 import type { Trip } from '@/types/database'
+import type { CityEvent, TrackedCity } from '@/types/events'
 import { TripItemCard } from './trip-item-card'
 
 interface CitySegmentBlockProps {
@@ -12,6 +15,7 @@ interface CitySegmentBlockProps {
   allTrips: Pick<Trip, 'id' | 'title' | 'start_date'>[]
   currentUserId?: string
   readOnly?: boolean
+  events?: { city: TrackedCity; events: CityEvent[] }
 }
 
 function flagEmoji(countryCode?: string) {
@@ -30,6 +34,7 @@ export function CitySegmentBlock({
   allTrips,
   currentUserId,
   readOnly = false,
+  events,
 }: CitySegmentBlockProps) {
   const hasHotel = segment.items.some((item) => item.kind === 'hotel')
 
@@ -78,6 +83,34 @@ export function CitySegmentBlock({
                 />
             ))}
           </div>
+
+          {events && events.events.length > 0 ? (
+            <div className="border-t border-slate-100 pt-4">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <p className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-700">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  What&apos;s happening in {events.city.city}
+                </p>
+                <Link
+                  href={`/cities/${events.city.slug}?from=${segment.startDate}&to=${segment.endDate}`}
+                  className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+                >
+                  See all →
+                </Link>
+              </div>
+              <div className="space-y-2">
+                {events.events.slice(0, 3).map((event) => (
+                  <div key={event.id} className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-slate-900">{event.title}</p>
+                      <p className="text-xs text-slate-500">{formatDate(event.start_date)}</p>
+                    </div>
+                    <Badge variant="secondary" className="shrink-0 capitalize">{event.category}</Badge>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </div>
       </CardContent>
     </Card>

--- a/src/components/trips/movement-timeline.tsx
+++ b/src/components/trips/movement-timeline.tsx
@@ -5,7 +5,6 @@ import type { TimelineEntry } from '@/lib/trips/city-segments'
 import type { CityEvent, TrackedCity } from '@/types/events'
 import { getWeatherForDate } from '@/lib/weather/item-weather'
 import { CitySegmentBlock } from './city-segment-block'
-import { TripEventsCard } from '@/components/events/trip-events-card'
 import { TransitionCard } from './transition-card'
 
 interface MovementTimelineProps {
@@ -46,22 +45,14 @@ export function MovementTimeline({
           const key = `${entry.segment.city}-${entry.segment.startDate}-${index}`
           const preview = segmentEvents[key]
           return (
-            <div key={key} className="space-y-3">
-              <CitySegmentBlock
-                segment={entry.segment}
-                allTrips={allTrips}
-                currentUserId={currentUserId}
-                readOnly={readOnly}
-              />
-              {preview ? (
-                <TripEventsCard
-                  city={preview.city}
-                  from={entry.segment.startDate}
-                  to={entry.segment.endDate}
-                  events={preview.events}
-                />
-              ) : null}
-            </div>
+            <CitySegmentBlock
+              key={key}
+              segment={entry.segment}
+              allTrips={allTrips}
+              currentUserId={currentUserId}
+              readOnly={readOnly}
+              events={preview}
+            />
           )
         }
 

--- a/src/components/ui/city-autocomplete.tsx
+++ b/src/components/ui/city-autocomplete.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { LocateFixed } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+interface Prediction {
+  description: string
+  placeId: string
+  mainText: string
+}
+
+interface CityAutocompleteProps {
+  value: string
+  onChange: (city: string) => void
+  placeholder?: string
+  className?: string
+}
+
+export function CityAutocomplete({ value, onChange, placeholder = 'Search city…', className }: CityAutocompleteProps) {
+  const [inputValue, setInputValue] = useState(value)
+  const [predictions, setPredictions] = useState<Prediction[]>([])
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [geoLoading, setGeoLoading] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Keep input in sync with controlled value from parent
+  useEffect(() => {
+    setInputValue(value)
+  }, [value])
+
+  const fetchPredictions = useCallback(async (query: string) => {
+    if (query.trim().length < 2) {
+      setPredictions([])
+      setOpen(false)
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch('/api/v1/places/autocomplete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
+      })
+      if (!res.ok) {
+        setPredictions([])
+        return
+      }
+      const data = await res.json() as { predictions: Prediction[] }
+      setPredictions(data.predictions ?? [])
+      setOpen((data.predictions ?? []).length > 0)
+      setActiveIndex(-1)
+    } catch {
+      setPredictions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    setInputValue(newValue)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      fetchPredictions(newValue)
+    }, 300)
+  }
+
+  const handleSelect = (prediction: Prediction) => {
+    setInputValue(prediction.mainText)
+    onChange(prediction.mainText)
+    setOpen(false)
+    setPredictions([])
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((prev) => Math.min(prev + 1, predictions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((prev) => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (activeIndex >= 0 && predictions[activeIndex]) {
+        handleSelect(predictions[activeIndex])
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const handleUseLocation = () => {
+    if (!navigator.geolocation) return
+    setGeoLoading(true)
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        try {
+          const res = await fetch('/api/v1/places/reverse-geocode', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+          })
+          if (!res.ok) return
+          const data = await res.json() as { city: string }
+          if (data.city) {
+            setInputValue(data.city)
+            onChange(data.city)
+            setOpen(false)
+          }
+        } finally {
+          setGeoLoading(false)
+        }
+      },
+      () => {
+        setGeoLoading(false)
+      }
+    )
+  }
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <div className="relative">
+        <Input
+          value={inputValue}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          onFocus={() => predictions.length > 0 && setOpen(true)}
+          placeholder={placeholder}
+          autoComplete="off"
+        />
+        <button
+          type="button"
+          onClick={handleUseLocation}
+          disabled={geoLoading}
+          title="Use current location"
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-400 hover:text-indigo-600 disabled:opacity-50"
+        >
+          <LocateFixed className={cn('h-4 w-4', geoLoading && 'animate-pulse')} />
+        </button>
+      </div>
+
+      {open && predictions.length > 0 ? (
+        <ul className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md">
+          {predictions.map((prediction, index) => (
+            <li key={prediction.placeId}>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => handleSelect(prediction)}
+                className={cn(
+                  'w-full px-3 py-2.5 text-left text-sm transition-colors',
+                  index === activeIndex
+                    ? 'bg-indigo-50 text-indigo-900'
+                    : 'text-gray-800 hover:bg-gray-50'
+                )}
+              >
+                <span className="font-medium">{prediction.mainText}</span>
+                {prediction.description !== prediction.mainText ? (
+                  <span className="ml-1 text-xs text-gray-400">
+                    {prediction.description.replace(prediction.mainText, '').replace(/^,\s*/, '')}
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {loading && !open ? (
+        <div className="absolute right-8 top-1/2 -translate-y-1/2">
+          <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-500" />
+        </div>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## PRD-056 — City Events Integration & Home City UX

### Phase 1: Events inside city stay cards
- `CitySegmentBlock` now renders 'What's happening in {CITY}' inline with top 3 events (title, date, category badge)
- Events moved from separate card below the segment into the segment card itself
- 'See all →' links to `/cities/{slug}?from=…&to=…`

### Phase 2: Events page redesign
- New hero section at top: 'What's happening in {CITY}' with up to 6 events in responsive grid
- Current city resolved from: active trip → home_city → prompt to set home city
- `HomeCityPrompt` client component with inline city autocomplete for setting home city directly from events page
- Existing tickets list preserved below with filter tabs

### Phase 3: Google Places autocomplete
- `POST /api/v1/places/autocomplete` — proxies Google Places Autocomplete (New) API, filtered to cities only, session auth required
- `POST /api/v1/places/reverse-geocode` — Google Geocoding API, extracts locality/admin area for metro normalization
- `CityAutocomplete` component — debounced 300ms, keyboard navigation, 'Use current location' button with browser geolocation
- Settings profile form upgraded from plain Input to CityAutocomplete
- Events page prompt includes inline autocomplete + save

### Files changed (9 files, +635 lines)
- `src/components/trips/city-segment-block.tsx` — events prop + inline rendering
- `src/components/trips/movement-timeline.tsx` — pass events to segment, remove separate card
- `src/components/ui/city-autocomplete.tsx` — new autocomplete component
- `src/app/(dashboard)/events/page.tsx` — redesigned with city events hero
- `src/app/(dashboard)/events/HomeCityPrompt.tsx` — new client component
- `src/app/(dashboard)/settings/profile/ProfileForm.tsx` — autocomplete for home city
- `src/app/api/v1/places/autocomplete/route.ts` — new API route
- `src/app/api/v1/places/reverse-geocode/route.ts` — new API route

### Testing
- Visit a trip with city stays → verify events appear inline on the stay card
- Visit /events with an active trip → verify city events hero shows
- Visit /events with no active trip but home_city set → verify home city events show
- Visit /events with no home_city → verify prompt appears with autocomplete
- Settings → Profile → Home City field → verify autocomplete dropdown works
- 'Use current location' → verify browser permission prompt, then city resolves

### Note
Requires `GOOGLE_PLACES_API_KEY` in Vercel env vars for production.