### PR TITLE
feat: PRD-029 Dispatch Polish — OpenGraph, share button, RSS link

### DIFF
--- a/src/app/dispatches/[slug]/page.tsx
+++ b/src/app/dispatches/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { getAllDispatches, getDispatchBySlug, markdownToHtml } from '@/lib/dispatches'
 import { formatDispatchDate } from '@/lib/format-date'
 import { dispatchProseClasses } from '@/lib/dispatch-styles'
+import { ShareButton } from '@/components/dispatches/share-button'
 
 interface DispatchPageProps {
   params: Promise<{ slug: string }>
@@ -24,9 +25,30 @@ export async function generateMetadata({ params }: DispatchPageProps): Promise<M
     }
   }
 
+  const url = `https://www.ubtrippin.xyz/dispatches/${slug}`
+
   return {
     title: `${dispatch.title} | UBTRIPPIN: THE STORY`,
     description: dispatch.summary,
+    alternates: {
+      types: {
+        'application/rss+xml': '/dispatches/feed.xml',
+      },
+    },
+    openGraph: {
+      title: dispatch.title,
+      description: dispatch.summary,
+      type: 'article',
+      url,
+      siteName: 'UBTRIPPIN',
+      publishedTime: dispatch.date,
+      authors: [dispatch.author],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: dispatch.title,
+      description: dispatch.summary,
+    },
   }
 }
 
@@ -57,7 +79,10 @@ export default async function DispatchPage({ params }: DispatchPageProps) {
           <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
             {dispatch.title}
           </h1>
-          <p className="mt-4 text-sm text-slate-600">{dispatch.author} · COO, UBTRIPPIN</p>
+          <div className="mt-4 flex items-center gap-4">
+            <p className="text-sm text-slate-600">{dispatch.author} · COO, UBTRIPPIN</p>
+            <ShareButton slug={slug} />
+          </div>
         </header>
 
         <section

--- a/src/app/dispatches/page.tsx
+++ b/src/app/dispatches/page.tsx
@@ -35,9 +35,28 @@ export default async function DispatchesPage({
     <div className="min-h-screen bg-white px-6 py-16 sm:px-8">
       <div className="mx-auto w-full max-w-[65ch]">
         <header className="mb-14 border-b border-slate-200 pb-8">
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
-            UBTRIPPIN: THE STORY
-          </h1>
+          <div className="flex items-start justify-between">
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
+              UBTRIPPIN: THE STORY
+            </h1>
+            <a
+              href="/dispatches/feed.xml"
+              title="RSS feed"
+              className="mt-2 flex items-center gap-1 text-xs uppercase tracking-[0.14em] text-slate-400 transition-colors hover:text-[#312e81]"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <path d="M3.75 3a.75.75 0 0 0-.75.75v.5c0 .414.336.75.75.75H4c6.075 0 11 4.925 11 11v.25c0 .414.336.75.75.75h.5a.75.75 0 0 0 .75-.75V16C17 8.82 11.18 3 4 3h-.25Z" />
+                <path d="M3 8.75A.75.75 0 0 1 3.75 8H4a8 8 0 0 1 8 8v.25a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1-.75-.75V16a6 6 0 0 0-6-6h-.25A.75.75 0 0 1 3 9.25v-.5ZM7 15a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
+              </svg>
+              RSS
+            </a>
+          </div>
           <p className="mt-4 text-lg leading-relaxed text-slate-600">
             Weekly dispatches from inside the build
           </p>

--- a/src/components/dispatches/share-button.tsx
+++ b/src/components/dispatches/share-button.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+
+export function ShareButton({ slug }: { slug: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    const url = `https://www.ubtrippin.xyz/dispatches/${slug}`
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-sm uppercase tracking-[0.14em] text-slate-500 transition-colors hover:text-[#312e81]"
+    >
+      {copied ? 'Copied!' : 'Share'}
+    </button>
+  )
+}


### PR DESCRIPTION
Finishes PRD-029. The weekly dispatch system is now complete.

### Changes
- **OpenGraph metadata**: Full OG tags (title, description, type:article, published_time, authors) + Twitter card on every dispatch page
- **RSS alternates**: Link tag so browsers/readers discover the RSS feed
- **Share button**: Copy-to-clipboard on each dispatch with 'Copied!' feedback
- **RSS link**: Visible RSS icon + link in the dispatches list header

### What was already built
- RSS feed at /dispatches/feed.xml ✅
- Markdown static generation ✅  
- SEO title + description ✅
- Weekly cron automation ✅

### X cross-posting
Handled by the agent (bird-ubt CLI) after each publish — no app code needed.