### PR TITLE
feat: PRD-028 Token Cost Optimization — tracking, admin endpoint, CLI

### DIFF
--- a/cli/ubt
+++ b/cli/ubt
@@ -3798,6 +3798,70 @@ except: print(0)
   fi
 }
 
+cmd_costs() {
+  local result
+  result=$(_api "${API_V1}/admin/token-usage")
+
+  if [ "${FORMAT:-pretty}" = "json" ]; then
+    echo "$result" | _json
+    return
+  fi
+
+  echo "$result" | _python3c "
+import json, sys
+
+payload = json.load(sys.stdin)
+if 'error' in payload:
+    print(f\"Error: {payload['error']['message']}\")
+    sys.exit(1)
+
+tw = payload.get('this_week', {})
+lw = payload.get('last_week', {})
+trend = payload.get('trend', {})
+top = payload.get('top_expensive', [])
+
+def fmt_cost(val):
+    return f'\${float(val):.4f}' if val is not None else 'n/a'
+
+def fmt_pct(val):
+    if val is None:
+        return 'n/a'
+    sign = '+' if val > 0 else ''
+    return f'{sign}{val:.1f}%'
+
+print('Token Cost Report')
+print('=================')
+print()
+print('This week (last 7 days):')
+print(f\"  Extractions:   {tw.get('count', 0)}\")
+print(f\"  Input tokens:  {tw.get('input_tokens', 0):,}\")
+print(f\"  Output tokens: {tw.get('output_tokens', 0):,}\")
+print(f\"  Total cost:    {fmt_cost(tw.get('total_cost_usd'))}\")
+print(f\"  Avg/extraction:{fmt_cost(tw.get('avg_cost_per_extraction'))}\")
+print()
+print('Last week (7–14 days ago):')
+print(f\"  Extractions:   {lw.get('count', 0)}\")
+print(f\"  Input tokens:  {lw.get('input_tokens', 0):,}\")
+print(f\"  Output tokens: {lw.get('output_tokens', 0):,}\")
+print(f\"  Total cost:    {fmt_cost(lw.get('total_cost_usd'))}\")
+print()
+print('Trend (this vs last week):')
+print(f\"  Cost:   {fmt_pct(trend.get('cost_change_pct'))}\")
+print(f\"  Volume: {fmt_pct(trend.get('volume_change_pct'))}\")
+
+if top:
+    print()
+    print('Top 5 most expensive extractions this week:')
+    for i, row in enumerate(top, 1):
+        eid = row.get('source_email_id') or row.get('id', 'unknown')
+        cost = fmt_cost(row.get('total_cost_usd'))
+        inp = row.get('input_tokens', 0)
+        out = row.get('output_tokens', 0)
+        ts = row.get('created_at', '')[:19].replace('T', ' ')
+        print(f\"  {i}. {cost}  in={inp:,} out={out:,}  {ts}  [{eid[:8]}...]\")
+"
+}
+
 # Usage
 usage() {
   cat <<EOF
@@ -3881,6 +3945,7 @@ Commands:
   profile loyalty delete <id>           Delete a loyalty program *
   profile loyalty lookup <provider_key> Lookup by provider (alliance fallback aware) *
   profile loyalty export                Export loyalty vault JSON *
+  costs                                 Show token usage and cost report (admin) *
   users                                 List all users (admin)
   health                                Check service health
   rls-check                             Verify RLS policies
@@ -4101,6 +4166,7 @@ case "${1:-}" in
       *)    echo "Usage: ubt tickets <list|add|show>"; exit 1 ;;
     esac
     ;;
+  costs)    cmd_costs ;;
   users)    cmd_users ;;
   health)   cmd_health ;;
   rls-check) cmd_rls_check ;;

--- a/src/app/api/v1/admin/token-usage/route.ts
+++ b/src/app/api/v1/admin/token-usage/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server'
+import { requireSessionAuth, isSessionAuthError } from '@/lib/api/session-auth'
+import { createClient } from '@/lib/supabase/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function getAllowedAdminEmails(): Set<string> {
+  const raw = process.env.ADMIN_EMAILS ?? ''
+  return new Set(
+    raw
+      .split(',')
+      .map((v) => v.trim().toLowerCase())
+      .filter(Boolean)
+  )
+}
+
+export async function GET() {
+  const auth = await requireSessionAuth()
+  if (isSessionAuthError(auth)) return auth
+
+  const allowedEmails = getAllowedAdminEmails()
+  if (allowedEmails.size === 0) {
+    return NextResponse.json(
+      { error: { code: 'server_misconfigured', message: 'ADMIN_EMAILS is not configured.' } },
+      { status: 500 }
+    )
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await auth.supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'session_lookup_failed', message: userError?.message ?? 'Could not resolve authenticated user.' } },
+      { status: 500 }
+    )
+  }
+
+  const email = user.email?.toLowerCase().trim()
+  if (!email || !allowedEmails.has(email)) {
+    return NextResponse.json(
+      { error: { code: 'forbidden', message: 'Admin access only.' } },
+      { status: 403 }
+    )
+  }
+
+  const supabase = await createClient()
+
+  const now = new Date()
+  const thisWeekStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const lastWeekStart = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000).toISOString()
+
+  // This week aggregate
+  const { data: thisWeekRows, error: err1 } = await supabase
+    .from('token_usage')
+    .select('input_tokens, output_tokens, total_cost_usd')
+    .gte('created_at', thisWeekStart)
+
+  // Last week aggregate
+  const { data: lastWeekRows, error: err2 } = await supabase
+    .from('token_usage')
+    .select('input_tokens, output_tokens, total_cost_usd')
+    .gte('created_at', lastWeekStart)
+    .lt('created_at', thisWeekStart)
+
+  // Top 5 most expensive this week
+  const { data: topExpensive, error: err3 } = await supabase
+    .from('token_usage')
+    .select('id, source_email_id, total_cost_usd, input_tokens, output_tokens, created_at')
+    .gte('created_at', thisWeekStart)
+    .order('total_cost_usd', { ascending: false })
+    .limit(5)
+
+  if (err1 || err2 || err3) {
+    const msg = err1?.message ?? err2?.message ?? err3?.message ?? 'Query failed'
+    return NextResponse.json({ error: { code: 'query_failed', message: msg } }, { status: 500 })
+  }
+
+  function aggregate(rows: { input_tokens: number; output_tokens: number; total_cost_usd: number }[]) {
+    const count = rows.length
+    const input_tokens = rows.reduce((s, r) => s + (r.input_tokens ?? 0), 0)
+    const output_tokens = rows.reduce((s, r) => s + (r.output_tokens ?? 0), 0)
+    const total_cost_usd = rows.reduce((s, r) => s + Number(r.total_cost_usd ?? 0), 0)
+    const avg_cost_per_extraction = count > 0 ? total_cost_usd / count : 0
+    return { count, input_tokens, output_tokens, total_cost_usd, avg_cost_per_extraction }
+  }
+
+  const thisWeek = aggregate(thisWeekRows ?? [])
+  const lastWeek = aggregate(lastWeekRows ?? [])
+
+  const costChange =
+    lastWeek.total_cost_usd > 0
+      ? ((thisWeek.total_cost_usd - lastWeek.total_cost_usd) / lastWeek.total_cost_usd) * 100
+      : null
+  const volumeChange =
+    lastWeek.count > 0 ? ((thisWeek.count - lastWeek.count) / lastWeek.count) * 100 : null
+
+  return NextResponse.json({
+    this_week: thisWeek,
+    last_week: lastWeek,
+    trend: {
+      cost_change_pct: costChange !== null ? Math.round(costChange * 10) / 10 : null,
+      volume_change_pct: volumeChange !== null ? Math.round(volumeChange * 10) / 10 : null,
+    },
+    top_expensive: topExpensive ?? [],
+  })
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -309,6 +309,49 @@ export async function POST(request: NextRequest) {
           .eq('id', sourceEmail.id)
       }
 
+      // Pre-filter: skip obvious non-booking emails (newsletters, marketing) before
+      // hitting the LLM to avoid burning tokens on junk forwards.
+      const emailSubject = (fullEmail.subject || '').toLowerCase()
+      const NEWSLETTER_PATTERNS = [
+        /unsubscribe/i,
+        /weekly digest/i,
+        /monthly digest/i,
+        /newsletter/i,
+        /you['']?re subscribed/i,
+        /marketing email/i,
+        /promotional email/i,
+        /sale ends/i,
+        /limited.{0,20}offer/i,
+        /\bblack friday\b/i,
+        /\bcyber monday\b/i,
+        /\bflash sale\b/i,
+        /don['']?t miss out/i,
+        /\bpromo\b.*\bcode\b/i,
+      ]
+      const isNewsletter = NEWSLETTER_PATTERNS.some((p) => p.test(emailSubject))
+
+      if (isNewsletter) {
+        console.log(`[token-filter] Skipping newsletter/marketing email: "${fullEmail.subject}"`)
+        try {
+          await supabase.from('token_usage').insert({
+            user_id: userId,
+            source_email_id: sourceEmail.id,
+            model: 'claude-sonnet-4',
+            input_tokens: 0,
+            output_tokens: 0,
+            total_cost_usd: 0,
+            extraction_type: 'skipped',
+          })
+        } catch (trackErr) {
+          console.warn('[token-filter] Failed to log skip (non-fatal):', trackErr)
+        }
+        await supabase
+          .from('source_emails')
+          .update({ parse_status: 'failed', parse_error: 'Skipped: newsletter/marketing email' })
+          .eq('id', sourceEmail.id)
+        return NextResponse.json({ message: 'Email skipped (newsletter/marketing)', email_id: sourceEmail.id })
+      }
+
       // Count this extraction against the user's monthly limit
       await incrementExtractionCount(userId, supabase)
 
@@ -325,7 +368,7 @@ export async function POST(request: NextRequest) {
         fullEmail.subject || '',
         fullEmail.text || fullEmail.html || '',
         attachmentText || undefined,
-        { senderDomain, supabase }
+        { senderDomain, supabase, userId, sourceEmailId: sourceEmail.id }
       )
 
       // Update source email with extraction result and attachment text

--- a/src/lib/ai/extract-travel-data.ts
+++ b/src/lib/ai/extract-travel-data.ts
@@ -35,6 +35,8 @@ export interface ExtractionResult {
 export interface ExtractTravelDataOptions {
   senderDomain?: string
   supabase?: import('@supabase/supabase-js').SupabaseClient
+  userId?: string
+  sourceEmailId?: string
 }
 
 interface DateNormalizationContext {
@@ -112,11 +114,28 @@ export async function extractTravelData(
 
   const prompt = buildExtractionPrompt(subject, body, attachmentText)
 
-  const { text } = await generateText({
+  const { text, usage } = await generateText({
     model: gateway('anthropic/claude-sonnet-4'),
     system: systemPrompt,
     prompt,
   })
+
+  // Track token usage (best-effort — never block extraction on failure)
+  try {
+    const inputCost = (usage.inputTokens / 1_000_000) * 3
+    const outputCost = (usage.outputTokens / 1_000_000) * 15
+    await dbClient.from('token_usage').insert({
+      user_id: options?.userId ?? null,
+      source_email_id: options?.sourceEmailId ?? null,
+      model: 'claude-sonnet-4',
+      input_tokens: usage.inputTokens,
+      output_tokens: usage.outputTokens,
+      total_cost_usd: inputCost + outputCost,
+      extraction_type: 'email',
+    })
+  } catch (trackErr) {
+    console.warn('[extract-travel-data] Token tracking failed (non-fatal):', trackErr)
+  }
 
   // Parse JSON from response
   try {

--- a/src/lib/ai/extract-travel-data.ts
+++ b/src/lib/ai/extract-travel-data.ts
@@ -122,8 +122,8 @@ export async function extractTravelData(
 
   // Track token usage (best-effort — never block extraction on failure)
   try {
-    const inputCost = (usage.inputTokens / 1_000_000) * 3
-    const outputCost = (usage.outputTokens / 1_000_000) * 15
+    const inputCost = ((usage.inputTokens ?? 0) / 1_000_000) * 3
+    const outputCost = ((usage.outputTokens ?? 0) / 1_000_000) * 15
     await dbClient.from('token_usage').insert({
       user_id: options?.userId ?? null,
       source_email_id: options?.sourceEmailId ?? null,

--- a/supabase/migrations/20260323000000_token_usage.sql
+++ b/supabase/migrations/20260323000000_token_usage.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS public.token_usage (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id),
+  source_email_id UUID,
+  model TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  total_cost_usd NUMERIC(10,6) NOT NULL DEFAULT 0,
+  extraction_type TEXT DEFAULT 'email',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE public.token_usage ENABLE ROW LEVEL SECURITY;
+CREATE POLICY token_usage_select ON public.token_usage FOR SELECT USING (true);
+CREATE INDEX idx_token_usage_created_at ON public.token_usage (created_at DESC);
+CREATE INDEX idx_token_usage_user_id ON public.token_usage (user_id);


### PR DESCRIPTION
## PRD-028 — Token Cost Optimization

### What's in this PR
- **Migration**: `token_usage` table with RLS, indexes on created_at and user_id
- **Token tracking**: Every AI extraction logs input/output tokens and USD cost to `token_usage`
- **Email pre-filter**: Newsletters and marketing emails skip LLM extraction (saves tokens)
- **Admin endpoint**: `GET /api/v1/admin/token-usage` — this week vs last week stats, trends, top 5 expensive extractions
- **CLI**: `ubt costs` — displays token usage and cost from terminal

### Cost calculation
- Anthropic Claude Sonnet 4: $3/M input tokens, $15/M output tokens
- Tracked per extraction, aggregated in admin endpoint

### Files (4 changed, +194 lines)
- `supabase/migrations/20260323000000_token_usage.sql`
- `src/lib/ai/extract-travel-data.ts` — tracking insert after extraction
- `src/app/api/v1/admin/token-usage/route.ts` — admin metrics endpoint
- `src/app/api/webhooks/resend/route.ts` — email pre-filter
- `cli/ubt` — costs subcommand