### PR TITLE
fix: profile endpoint 500 when profiles row missing

### DIFF
--- a/src/app/api/v1/me/profile/route.ts
+++ b/src/app/api/v1/me/profile/route.ts
@@ -108,7 +108,7 @@ export async function GET() {
         .from('profiles')
         .select('public_username, public_username_changed_at')
         .eq('id', auth.userId)
-        .single(),
+        .maybeSingle(),
     ])
 
   if (userProfileError || publicProfileError) {
@@ -122,11 +122,9 @@ export async function GET() {
   const profile = {
     ...((profileData as Omit<UserProfileRow, 'public_username' | 'public_username_changed_at'> | null) ??
       defaultProfile(auth.userId)),
-    public_username:
-      (publicData as { public_username: string | null; public_username_changed_at: string | null } | null)
+    public_username: (publicData as { public_username: string | null; public_username_changed_at: string | null } | null)
         ?.public_username ?? null,
-    public_username_changed_at:
-      (publicData as { public_username: string | null; public_username_changed_at: string | null } | null)
+    public_username_changed_at: (publicData as { public_username: string | null; public_username_changed_at: string | null } | null)
         ?.public_username_changed_at ?? null,
   } satisfies UserProfileRow
   const loyaltyCount = await getLoyaltyCount(auth.userId, supabase)
@@ -254,7 +252,7 @@ async function upsertProfile(request: NextRequest) {
     .from('profiles')
     .select('public_username, public_username_changed_at')
     .eq('id', auth.userId)
-    .single()
+    .maybeSingle()
 
   if (existingProfileError) {
     console.error('[v1/me/profile POST] Failed to fetch public profile fields:', existingProfileError)


### PR DESCRIPTION
## Bug

`GET /api/v1/me/profile` returns 500 for any user without a row in the `profiles` table. Found by QA crawl 2026-03-23.

## Root Cause

`.single()` on the `profiles` query throws Supabase PGRST116 ('The result contains 0 rows') when no row exists. The error handler catches it as an internal error and returns 500.

## Fix

Changed `.single()` to `.maybeSingle()` in both the GET and PUT/POST paths. When `profiles` row is null, defaults are used (null username, null changed_at).

Two-line fix. Type-checks clean.