### PR TITLE
fix: show estimated arrival time for en-route flights

### DIFF
--- a/src/components/flights/flight-status-block.tsx
+++ b/src/components/flights/flight-status-block.tsx
@@ -132,11 +132,7 @@ export function FlightStatusBlock({
   // The scheduled time is what the ticket says, but once we have a better
   // estimate (delayed departure, ATC, winds), show the real expected time.
   const isDelayedStatus = status === 'delayed'
-  const depDisplay = depActual
-    ? depActual
-    : isDelayedStatus
-      ? (depEstimated ?? depScheduled)
-      : (depScheduled ?? depEstimated)
+  const depDisplay = depActual ?? depEstimated ?? depScheduled
   const arrDisplay = arrActual
     ? arrActual
     : (arrEstimated ?? arrScheduled)
@@ -201,7 +197,7 @@ export function FlightStatusBlock({
             
             {depDisplay && depScheduled && depDisplay !== depScheduled && (
               <p className="text-sm text-slate-500 mt-1">
-                {depActual ? `Departed ${depActual}` : `Originally ${depScheduled}`}
+                Originally {depScheduled}
               </p>
             )}
           </div>
@@ -229,7 +225,7 @@ export function FlightStatusBlock({
             
             {arrDisplay && arrScheduled && arrDisplay !== arrScheduled && (
               <p className="text-sm text-slate-500 mt-1">
-                {arrActual ? `Arrived ${arrActual}` : `Originally ${arrScheduled}`}
+                Originally {arrScheduled}
               </p>
             )}
           </div>

--- a/src/components/flights/flight-status-block.tsx
+++ b/src/components/flights/flight-status-block.tsx
@@ -127,17 +127,19 @@ export function FlightStatusBlock({
   const arrActual = formatTimeInZone(actualArrival, arrTz)
 
   // Determine what time to show.
-  // Default: scheduled time (what the ticket says).
-  // If delayed and not yet departed: show estimated (the current expected time).
-  // Once departed/landed: revert to scheduled unless there was a delay,
-  // in which case show the actual departure but annotate with "originally".
+  // Departure: show actual if departed, estimated if delayed, else scheduled.
+  // Arrival: always show the best available estimate — actual > estimated > scheduled.
+  // The scheduled time is what the ticket says, but once we have a better
+  // estimate (delayed departure, ATC, winds), show the real expected time.
   const isDelayedStatus = status === 'delayed'
-  const depDisplay = isDelayedStatus
-    ? (depEstimated ?? depScheduled)
-    : (depScheduled ?? depActual)
-  const arrDisplay = isDelayedStatus
-    ? (arrEstimated ?? arrScheduled)
-    : (arrScheduled ?? arrActual)
+  const depDisplay = depActual
+    ? depActual
+    : isDelayedStatus
+      ? (depEstimated ?? depScheduled)
+      : (depScheduled ?? depEstimated)
+  const arrDisplay = arrActual
+    ? arrActual
+    : (arrEstimated ?? arrScheduled)
   
   // Compute gate-to-gate duration from the best available times (ISO/UTC)
   const depIso = actualDeparture ?? estimatedDeparture ?? scheduledDeparture
@@ -197,14 +199,9 @@ export function FlightStatusBlock({
               <p className="text-3xl font-light text-slate-400">--:--</p>
             )}
             
-            {isDelayedStatus && depScheduled && depEstimated && depScheduled !== depEstimated && (
-              <p className="text-sm text-amber-600 mt-1">
-                Originally {depScheduled}
-              </p>
-            )}
-            {!isDelayedStatus && depActual && depScheduled && depActual !== depScheduled && (
+            {depDisplay && depScheduled && depDisplay !== depScheduled && (
               <p className="text-sm text-slate-500 mt-1">
-                Departed {depActual}
+                {depActual ? `Departed ${depActual}` : `Originally ${depScheduled}`}
               </p>
             )}
           </div>
@@ -230,14 +227,9 @@ export function FlightStatusBlock({
               <p className="text-3xl font-light text-slate-400">--:--</p>
             )}
             
-            {isDelayedStatus && arrScheduled && arrEstimated && arrScheduled !== arrEstimated && (
-              <p className="text-sm text-amber-600 mt-1">
-                Originally {arrScheduled}
-              </p>
-            )}
-            {!isDelayedStatus && arrActual && arrScheduled && arrActual !== arrScheduled && (
+            {arrDisplay && arrScheduled && arrDisplay !== arrScheduled && (
               <p className="text-sm text-slate-500 mt-1">
-                Arrived {arrActual}
+                {arrActual ? `Arrived ${arrActual}` : `Originally ${arrScheduled}`}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Problem

When a flight departs late (e.g. VS4 JFK→LHR, scheduled 7:00 PM, departed 8:18 PM), the live flight page still shows the **scheduled** arrival time (5:18 AM) instead of the **estimated** arrival (~6:30 AM).

Ian caught this mid-flight — the page said 5:18 AM but actual landing was closer to 6:30 AM.

## Root Cause

`arrDisplay` logic only showed estimated arrival when `status === 'delayed'`:
```ts
const arrDisplay = isDelayedStatus
  ? (arrEstimated ?? arrScheduled)
  : (arrScheduled ?? arrActual)
```

Once the flight transitioned to `en_route`, `isDelayedStatus` became false, and it fell back to showing the scheduled time — ignoring the estimated arrival entirely.

## Fix

Arrival now always shows the best available time: `actual > estimated > scheduled`.

Departure shows: actual (if departed) > estimated (if delayed) > scheduled.

Annotations simplified: show 'Originally X:XX' when the displayed time differs from scheduled, regardless of status.

## Testing
- TypeScript compiles clean
- ESLint clean (0 errors, 0 warnings on changed file)