### PR TITLE
fix: feedback responses — GitHub link, Praise tab, readable dates

### DIFF
--- a/src/app/(dashboard)/help/page.tsx
+++ b/src/app/(dashboard)/help/page.tsx
@@ -327,6 +327,15 @@ const sections: HelpSection[] = [
               to request full account deletion.
             </p>
           </div>
+          <div>
+            <h3 className="font-semibold text-slate-800">Is the code open source?</h3>
+            <p>
+              Yes. UBTRIPPIN is open source. View the code, report issues, or contribute on{" "}
+              <a href="https://github.com/fistfulayen/ubtrippin" target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:text-indigo-500">
+                GitHub
+              </a>.
+            </p>
+          </div>
         </div>
       </>
     ),

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -43,6 +43,15 @@ export default async function DashboardLayout({
           <Link href="/terms" className="hover:text-gray-700 transition-colors">
             Terms of Service
           </Link>
+          <span aria-hidden="true">•</span>
+          <a
+            href="https://github.com/fistfulayen/ubtrippin"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gray-700 transition-colors"
+          >
+            GitHub
+          </a>
         </div>
       </footer>
     </div>

--- a/src/components/feedback/feedback-board.tsx
+++ b/src/components/feedback/feedback-board.tsx
@@ -52,6 +52,7 @@ const TYPE_FILTERS: Array<{ value: 'all' | FeedbackType; label: string }> = [
   { value: 'bug', label: 'Bug' },
   { value: 'feature', label: 'Feature' },
   { value: 'general', label: 'General' },
+  { value: 'praise', label: 'Praise' },
 ]
 
 function formatResponseTime(hours: number): string {
@@ -413,6 +414,7 @@ export function FeedbackBoard({ initialItems, currentUserId, currentUserName, av
                 <option value="general">General</option>
                 <option value="feature">Feature</option>
                 <option value="bug">Bug</option>
+                <option value="praise">Praise</option>
               </Select>
             </div>
 

--- a/src/components/feedback/feedback-utils.ts
+++ b/src/components/feedback/feedback-utils.ts
@@ -1,4 +1,4 @@
-export type FeedbackType = 'bug' | 'feature' | 'general'
+export type FeedbackType = 'bug' | 'feature' | 'general' | 'praise'
 export type FeedbackStatus = 'new' | 'under_review' | 'planned' | 'in_progress' | 'shipped' | 'declined'
 
 export interface FeedbackBoardItem {
@@ -31,6 +31,7 @@ export const TYPE_LABELS: Record<FeedbackType, string> = {
   bug: 'Bug',
   feature: 'Feature',
   general: 'General',
+  praise: 'Praise',
 }
 
 export const STATUS_LABELS: Record<FeedbackStatus, string> = {
@@ -46,6 +47,7 @@ export const TYPE_BADGE_CLASS: Record<FeedbackType, string> = {
   bug: 'bg-rose-50 text-rose-700 border border-rose-100',
   feature: 'bg-emerald-50 text-emerald-700 border border-emerald-100',
   general: 'bg-slate-50 text-slate-700 border border-slate-100',
+  praise: 'bg-yellow-50 text-yellow-700 border border-yellow-100',
 }
 
 export const STATUS_BADGE_CLASS: Record<FeedbackStatus, string> = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { format } from 'date-fns'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -10,21 +11,9 @@ export function formatDate(date: string | Date | null | undefined): string {
   // For date-only strings (YYYY-MM-DD), parse as local date to avoid timezone shift.
   // new Date("2026-03-19") = midnight UTC = March 18 in US timezones. Adding T00:00 forces local.
   if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    const d = new Date(date + 'T00:00:00')
-    return d.toLocaleDateString('en-US', {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    })
+    return format(new Date(date + 'T00:00:00'), 'EEE d MMM yyyy')
   }
-  const d = new Date(date)
-  return d.toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  return format(new Date(date), 'EEE d MMM yyyy')
 }
 
 /**


### PR DESCRIPTION
Addresses 4 feedback items from today's triage:

## Changes

### 1. GitHub link in footer + FAQ
- Added GitHub repo link to dashboard footer (was only on public footer)
- Added 'Is the code open source?' FAQ entry on help page
- **Feedback:** 'Revision control' → marked shipped

### 2. Praise tab on feedback board
- New `praise` feedback type with yellow badge
- Filter button + create option added
- **Feedback:** 'Praise Be' → marked shipped

### 3. Human-readable dates
- Changed `formatDate()` output from 'Thu, Mar 19, 2026' to 'Wed 19 Mar 2026'
- Uses date-fns `format(d, 'EEE d MMM yyyy')` — always includes year so day-of-week is correct
- Applies everywhere `formatDate` is called (timeline, share page, cards)
- **Feedback:** 'add dates to summary' → marked shipped

### 4. Expense reports feedback
- **Feedback:** 'Expn reports' → marked as under_review (PRD to follow)

Build passes clean.