### PR TITLE
fix: security audit — fail-closed auth, PII scrubbing, SSRF prevention

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,8 +39,11 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
-      // Allow any HTTPS image — cover images come from Brave search (any domain)
-      { protocol: 'https', hostname: '**' },
+      // Supabase Storage — cover images, feedback images, ticket attachments
+      { protocol: 'https', hostname: '*.supabase.co' },
+      // Unsplash — guide cover images
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'plus.unsplash.com' },
     ],
   },
   // SECURITY: Apply security headers to all routes

--- a/src/app/api/cron/cleanup-ticket-pdfs/route.ts
+++ b/src/app/api/cron/cleanup-ticket-pdfs/route.ts
@@ -15,7 +15,7 @@ const CRON_SECRET = process.env.CRON_SECRET
 export async function GET(request: NextRequest) {
   // Verify this is called by Vercel Cron or internally
   const authHeader = request.headers.get('authorization')
-  if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/cron/nudge-emails/route.ts
+++ b/src/app/api/cron/nudge-emails/route.ts
@@ -15,11 +15,8 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET
 
-  if (cronSecret) {
-    const authHeader = request.headers.get('authorization')
-    if (authHeader !== `Bearer ${cronSecret}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   try {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -84,16 +84,18 @@ export async function POST(request: NextRequest) {
     if (file.size > MAX_IMAGE_BYTES) {
       return NextResponse.json({ error: 'Each image must be 5MB or smaller.' }, { status: 400 })
     }
-    if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+
+    const validatedMimeType = await getValidatedMimeType(file)
+    if (!validatedMimeType) {
       return NextResponse.json({ error: 'Images must be JPG, PNG, WebP, or GIF.' }, { status: 400 })
     }
 
-    const ext = extensionFromMimeType(file.type)
+    const ext = extensionFromMimeType(validatedMimeType)
     const path = `${user.id}/${crypto.randomUUID()}.${ext}`
 
     const { error: uploadError } = await supabase.storage
       .from('feedback-images')
-      .upload(path, file, { contentType: file.type, upsert: false })
+      .upload(path, file, { contentType: validatedMimeType, upsert: false })
 
     if (uploadError) {
       // Clean up any already-uploaded images

--- a/src/app/api/internal/webhooks/process/route.ts
+++ b/src/app/api/internal/webhooks/process/route.ts
@@ -232,7 +232,7 @@ async function processQueueBatch() {
 
 function hasValidCronAuth(request: NextRequest): boolean {
   const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret) return true
+  if (!cronSecret) return false
   return request.headers.get('authorization') === `Bearer ${cronSecret}`
 }
 

--- a/src/app/api/v1/invites/[token]/accept/route.ts
+++ b/src/app/api/v1/invites/[token]/accept/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest, { params }: Params) {
       {
         error: {
           code: 'forbidden',
-          message: `This invite was sent to ${invite.invited_email}. You are signed in as ${userEmail || 'a different account'}.`,
+          message: 'This invite was sent to a different email address. Please sign in with the correct account.',
         },
       },
       { status: 403 }

--- a/src/app/api/v1/webhooks/stripe/route.ts
+++ b/src/app/api/v1/webhooks/stripe/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import type Stripe from 'stripe'
+import { maskEmail } from '@/lib/privacy'
 import {
   mapStripeSubscriptionStatusToTier,
   unixSecondsToIso,
@@ -186,7 +187,7 @@ async function getProfileByEmail(
     .maybeSingle()
 
   if (error) {
-    console.error('[stripe webhook] profile lookup by email failed', { email, error })
+    console.error('[stripe webhook] profile lookup by email failed', { email: maskEmail(email), error })
     return null
   }
 
@@ -293,7 +294,7 @@ async function handleCustomerCreated(
 
   const profile = await getProfileByEmail(supabase, email)
   if (!profile) {
-    console.log('[stripe webhook] customer.created no matching profile', { email })
+    console.log('[stripe webhook] customer.created no matching profile', { email: maskEmail(email) })
     return
   }
 

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { maskEmail } from '@/lib/privacy'
 import { createSecretClient } from '@/lib/supabase/service'
 import { verifyWebhookSignature, type ResendEmailPayload } from '@/lib/resend/verify-webhook'
 import { getResendClient } from '@/lib/resend/client'
@@ -86,7 +87,7 @@ export async function POST(request: NextRequest) {
     const toAddress = webhookData.to?.[0]?.toLowerCase() || ''
     if (FORWARD_ADDRESSES[toAddress]) {
       try {
-        console.log(`Forwarding email to ${toAddress} → ${FORWARD_ADDRESSES[toAddress]}`)
+        console.log(`Forwarding email to ${toAddress} → ${maskEmail(FORWARD_ADDRESSES[toAddress])}`)
         const resendForward = getResendClient()
         
         // Fetch the full email to forward it
@@ -168,7 +169,7 @@ export async function POST(request: NextRequest) {
 
     // If no user found, stop processing but acknowledge receipt
     if (!allowedSender) {
-      console.log(`Email from unrecognized sender: ${fromEmail}`)
+      console.log(`Email from unrecognized sender: ${maskEmail(fromEmail)}`)
       return NextResponse.json({
         message: 'Email stored but sender not recognized',
         email_id: sourceEmail.id,

--- a/src/lib/nudge-emails.ts
+++ b/src/lib/nudge-emails.ts
@@ -7,6 +7,7 @@
  */
 
 import { render } from '@react-email/components'
+import { maskEmail } from '@/lib/privacy'
 import { createSecretClient } from '@/lib/supabase/service'
 import { getResendClient } from '@/lib/resend/client'
 import { OnboardingDay2Email } from '@/components/email/onboarding-day-2'
@@ -87,7 +88,7 @@ export async function checkAndSendNudges(): Promise<number> {
           .eq('id', profile.id)
 
         sent++
-        console.log(`[nudge-emails] Sent day-2 onboarding email to ${profile.email}`)
+        console.log(`[nudge-emails] Sent day-2 onboarding email to ${maskEmail(profile.email!)}`)
         continue
       } catch (err) {
         console.error(`[nudge-emails] Failed day-2 email for ${profile.id}:`, err)
@@ -118,7 +119,7 @@ export async function checkAndSendNudges(): Promise<number> {
           .eq('id', profile.id)
 
         sent++
-        console.log(`[nudge-emails] Sent day-5 onboarding email to ${profile.email}`)
+        console.log(`[nudge-emails] Sent day-5 onboarding email to ${maskEmail(profile.email!)}`)
         continue
       } catch (err) {
         console.error(`[nudge-emails] Failed day-5 email for ${profile.id}:`, err)
@@ -148,7 +149,7 @@ export async function checkAndSendNudges(): Promise<number> {
           .eq('id', profile.id)
 
         sent++
-        console.log(`[nudge-emails] Sent day-14 onboarding email to ${profile.email}`)
+        console.log(`[nudge-emails] Sent day-14 onboarding email to ${maskEmail(profile.email!)}`)
       } catch (err) {
         console.error(`[nudge-emails] Failed day-14 email for ${profile.id}:`, err)
       }

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -1,0 +1,12 @@
+export function maskEmail(email: string): string {
+  const atIndex = email.indexOf('@')
+  if (atIndex <= 0) return '***'
+  const local = email.slice(0, atIndex)
+  const domain = email.slice(atIndex + 1)
+  return `${local.slice(0, 1)}***@${domain}`
+}
+
+export function maskName(name: string): string {
+  if (!name) return '***'
+  return `${name[0]}***`
+}


### PR DESCRIPTION
## Security Audit Findings — 2026-03-26

**Triggered by:** Manual white-hat security review

### Changes

| ID | Severity | Fix | File(s) |
|----|----------|-----|---------|
| C1 | **CRITICAL** | Webhook processor now fails closed when CRON_SECRET unset | `api/internal/webhooks/process/route.ts` |
| H1 | **HIGH** | All cron endpoints fail closed when CRON_SECRET unset | `api/cron/nudge-emails/route.ts`, `api/cron/cleanup-ticket-pdfs/route.ts` |
| H2 | **HIGH** | Invite accept error no longer leaks invited email address | `api/v1/invites/[token]/accept/route.ts` |
| M2 | **MEDIUM** | Feedback image upload now validates MIME via magic bytes, not client header | `api/feedback/route.ts` |
| M4 | **MEDIUM** | Next.js image proxy locked to explicit domains (was wildcard) | `next.config.ts` |
| L1 | **LOW** | PII (emails) scrubbed from all server logs + maskEmail/maskName helpers added | `lib/privacy.ts`, multiple routes |

### Testing
- All cron/webhook endpoints should return 401 when CRON_SECRET is missing
- Invite accept with wrong account should show generic error (no email)
- Feedback image upload should reject non-image files regardless of Content-Type header
- `/_next/image` should only proxy from Supabase and Unsplash domains
- No email addresses should appear in Vercel function logs