### PR TITLE
docs: add affiliate endpoint to skill/SKILL.md and mcp/src

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -14,6 +14,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import { registerFamilyTools } from './tools/family.js'
+import { registerAffiliateTools } from './tools/affiliate.js'
 
 const API_KEY = process.env.UBT_API_KEY
 const BASE_URL = (process.env.UBT_BASE_URL || 'https://www.ubtrippin.xyz').replace(/\/$/, '')
@@ -133,8 +134,8 @@ function authHeaders(): Record<string, string> {
   }
 }
 
-async function apiFetch<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, { headers: authHeaders() })
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: authHeaders(), ...init })
 
   if (!res.ok) {
     const body = await res.text().catch(() => '')
@@ -1593,6 +1594,12 @@ server.registerTool(
 // ---------------------------------------------------------------------------
 
 registerFamilyTools(server, apiFetch)
+
+// ---------------------------------------------------------------------------
+// Affiliate Tools
+// ---------------------------------------------------------------------------
+
+registerAffiliateTools(server, apiFetch)
 
 
 // ---------------------------------------------------------------------------

--- a/mcp/src/tools/affiliate.ts
+++ b/mcp/src/tools/affiliate.ts
@@ -1,0 +1,84 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+
+type ApiFetch = <T>(path: string, init?: RequestInit) => Promise<T>
+
+type ToolResult = {
+  content: Array<{
+    type: 'text'
+    text: string
+  }>
+}
+
+function toToolResult(payload: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  }
+}
+
+function toErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}
+
+async function runJsonTool<T>(fn: () => Promise<T>, fallbackMessage: string): Promise<ToolResult> {
+  try {
+    return toToolResult(await fn())
+  } catch (error) {
+    return toToolResult({
+      error: {
+        code: 'tool_error',
+        message: toErrorMessage(error, fallbackMessage),
+      },
+    })
+  }
+}
+
+export function registerAffiliateTools(server: McpServer, apiFetch: ApiFetch): void {
+  server.registerTool(
+    'get_affiliate_dashboard',
+    {
+      title: 'Get Affiliate Dashboard',
+      description:
+        'Returns the authenticated user\'s affiliate dashboard: affiliate code, tier, status, earnings, payout info, and up to 50 recent conversions. Returns 404 if the user has not yet applied.',
+    },
+    async () =>
+      runJsonTool(
+        () => apiFetch<{ data: unknown }>('/api/v1/affiliate'),
+        'Failed to fetch affiliate dashboard.'
+      )
+  )
+
+  server.registerTool(
+    'apply_for_affiliate',
+    {
+      title: 'Apply for Affiliate Program',
+      description:
+        'Submit an affiliate program application. Creates a pending affiliate record with a unique referral code. Returns 409 if an application already exists.',
+      inputSchema: {
+        payout_email: z
+          .string()
+          .email()
+          .optional()
+          .describe('Email address for payout notifications (optional)'),
+        payout_method: z
+          .enum(['stripe_connect', 'paypal'])
+          .optional()
+          .describe('Payout method: stripe_connect (default) or paypal'),
+      },
+    },
+    async ({ payout_email, payout_method }) =>
+      runJsonTool(
+        () =>
+          apiFetch<{ data: unknown }>('/api/v1/affiliate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              ...(payout_email !== undefined && { payout_email }),
+              ...(payout_method !== undefined && { payout_method }),
+            }),
+          }),
+        'Failed to submit affiliate application.'
+      )
+  )
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -511,6 +511,73 @@ Returns your referral code, sharable referral link, and counts for referred user
 
 ---
 
+### Affiliate Program
+
+#### Get Affiliate Dashboard
+```
+GET /api/v1/affiliate
+```
+
+Returns the authenticated user's affiliate dashboard: stats, earnings, and recent conversions.
+
+Response:
+```json
+{
+  "data": {
+    "affiliate_code": "AB3X7QR2",
+    "tier": "standard",
+    "status": "active",
+    "payout_email": "you@example.com",
+    "payout_method": "stripe_connect",
+    "total_conversions": 12,
+    "total_earned_cents": 4800,
+    "total_paid_cents": 2400,
+    "pending_payout_cents": 2400,
+    "conversions": [
+      {
+        "id": "uuid",
+        "commission_cents": 400,
+        "status": "pending",
+        "created_at": "2026-03-01T10:00:00Z",
+        "paid_at": null
+      }
+    ]
+  }
+}
+```
+
+Returns `404 not_found` if the user has not yet applied. Returns up to 50 most recent conversions.
+
+#### Apply for Affiliate Program
+```
+POST /api/v1/affiliate
+Content-Type: application/json
+
+{ "payout_email": "you@example.com", "payout_method": "stripe_connect" }
+```
+
+Submits an affiliate application. Creates a pending affiliate record with a unique referral code.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `payout_email` | string | — | Email for payout notifications |
+| `payout_method` | string | — | `stripe_connect` (default) or `paypal` |
+
+Response (201):
+```json
+{
+  "data": {
+    "affiliate_code": "AB3X7QR2",
+    "status": "pending",
+    "tier": "standard"
+  }
+}
+```
+
+Returns `409 conflict` if an application already exists.
+
+---
+
 ### Family
 
 #### List My Families


### PR DESCRIPTION
Fixes API Parity Report warning from PR #127.

- Added affiliate program docs to skill/SKILL.md (GET + POST /api/v1/affiliate)
- Added MCP tools: get_affiliate_dashboard + apply_for_affiliate
- Updated mcp/src/index.ts to register affiliate tools