### PR TITLE
fix: stop leaking error.message in events API (L-005)

### DIFF
--- a/src/app/api/v1/events/refresh/route.ts
+++ b/src/app/api/v1/events/refresh/route.ts
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest) {
 
   if (userError || !user) {
     return NextResponse.json(
-      { error: { code: 'session_lookup_failed', message: userError?.message ?? 'Could not resolve authenticated user.' } },
+      { error: { code: 'session_lookup_failed', message: 'Could not resolve authenticated user.' } },
       { status: 500 }
     )
   }
@@ -111,9 +111,9 @@ export async function POST(request: NextRequest) {
       citySlug,
     }, { status: 202 })
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to launch refresh.'
+    console.error('[v1/events/refresh]', error instanceof Error ? error.message : error)
     return NextResponse.json(
-      { error: { code: 'launch_failed', message } },
+      { error: { code: 'launch_failed', message: 'Failed to launch refresh.' } },
       { status: 500 }
     )
   }

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -32,9 +32,9 @@ export async function GET(request: NextRequest) {
       segments: data.segments,
     })
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unable to fetch events.'
+    console.error('[v1/events]', error instanceof Error ? error.message : error)
     return NextResponse.json(
-      { error: { code: 'invalid_request', message } },
+      { error: { code: 'invalid_request', message: 'Unable to fetch events.' } },
       { status: 400 }
     )
   }


### PR DESCRIPTION
## Security Audit Finding F-28-01

**Severity:** HIGH  
**Lesson violated:** L-005 (never return raw error.message to clients)

### Changes
- `/api/v1/events`: catch block returned `error.message` directly → now returns static `'Unable to fetch events.'` and logs the real error server-side
- `/api/v1/events/refresh`: catch block returned `error.message` → now returns static `'Failed to launch refresh.'`; also removed `userError?.message` from session_lookup_failed response (was leaking Supabase auth error details)

### Why this matters
Raw error messages can contain DB schema info, table names, constraint names, or internal details. Attackers use this for reconnaissance.

Found by nightly security audit (PRD-062), 2026-03-28.