### PR TITLE
fix: restore runner logo and sample trip on landing page

### DIFF
--- a/memory/2026-03-28.md
+++ b/memory/2026-03-28.md
@@ -1,0 +1,24 @@
+# Daily State — 2026-03-28
+
+## Open PRs (2)
+- #132: fix: stop leaking error.message in events API (L-005) — security/audit-2026-03-28 — OPEN
+- #131: feat: PRD-043 Velvet Rope — invite-only signup with join codes — feat/velvet-rope-invite-only — OPEN
+
+## Vercel Deploys
+- 5 preview deployments active (normal)
+
+## Feedback
+- Supabase API key not available in env — feedback check skipped
+
+## Agent Swarm
+- No active agents
+
+## Worktrees
+- 3 stale worktrees (ubt-activation, ubt-referral, ubt-share-upsell — all from Mar 6)
+
+## Blockers
+- CRON_SECRET not set in Vercel (blocks PRD-016)
+- Supabase CLI login expired (blocks PRD-033)
+
+## Notes
+- Heartbeat at 06:04 UTC — all systems nominal

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import Image from 'next/image'
+import Link from 'next/link'
 
 export const metadata = {
   title: 'UB Trippin',
@@ -21,7 +23,16 @@ export default async function HomePage() {
     <div className="min-h-screen bg-white flex flex-col items-center justify-center px-6 py-16">
       <div className="w-full max-w-prose space-y-8 text-lg text-slate-700 leading-relaxed">
 
-        <h1 className="text-3xl font-bold text-slate-900 tracking-tight">UB Trippin</h1>
+        <div className="flex items-center gap-4">
+          <Image
+            src="/runner_transparent.png"
+            alt="UB Trippin"
+            width={64}
+            height={64}
+            className="w-16 h-16"
+          />
+          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">UB Trippin</h1>
+        </div>
 
         <p>
           Hi, I&apos;m Trip Livingston, an AI agent. My owner built UB Trippin to replace his
@@ -51,10 +62,43 @@ export default async function HomePage() {
           github.com/fistfulayen/ubtrippin
         </code>
 
-        {/* Placeholder hero — swap for a real screenshot when ready */}
-        <div className="rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 flex items-center justify-center h-56 text-slate-400 text-sm italic mt-4">
-          A beautifully organized trip.
-        </div>
+        <Link
+          href="/trips/demo"
+          className="block rounded-xl border border-slate-200 bg-slate-50 overflow-hidden mt-4 hover:border-indigo-300 transition-colors group"
+        >
+          <div className="px-6 py-5">
+            <p className="text-sm font-semibold text-slate-900 mb-1">Tokyo Adventure</p>
+            <p className="text-sm text-slate-500">Mar 15 – Mar 22, 2026 · Tokyo, Japan</p>
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center gap-3">
+                <span className="text-base">✈️</span>
+                <div>
+                  <p className="text-sm font-medium text-slate-800">ANA Flight NH 7 — San Francisco to Tokyo Narita</p>
+                  <p className="text-xs text-slate-400">Mar 15 · SFO → NRT</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-base">🏨</span>
+                <div>
+                  <p className="text-sm font-medium text-slate-800">Park Hyatt Tokyo — 5 nights, Shinjuku</p>
+                  <p className="text-xs text-slate-400">Mar 16 · Tokyo, Japan</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-base">🍽️</span>
+                <div>
+                  <p className="text-sm font-medium text-slate-800">Sukiyabashi Jiro — Omakase dinner</p>
+                  <p className="text-xs text-slate-400">Mar 17 · Ginza, Tokyo</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="px-6 py-3 bg-slate-100 border-t border-slate-200 text-center">
+            <span className="text-sm text-indigo-600 font-medium group-hover:text-indigo-700">
+              See the full sample trip →
+            </span>
+          </div>
+        </Link>
 
         <p className="text-sm text-slate-400 pt-4">
           Already have an account?{' '}


### PR DESCRIPTION
Two fixes for the Velvet Rope landing page:

1. **Runner logo restored** — the Trippin guy is back in the header
2. **Sample trip card** — replaces the empty dashed placeholder with a clickable card showing the Tokyo Adventure demo trip, linking to /trips/demo

Ian's request: 'I want my logo back on the page. The Trippin guy. Also, there is no sample trip on the page.'