### PR TITLE
fix: hide forwarding email on demo trip for unauthenticated users

### DIFF
--- a/src/app/trips/demo/page.tsx
+++ b/src/app/trips/demo/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
 import { DEMO_TRIP, DEMO_ITEMS } from '@/lib/trips/demo-trip-data'
 import { DemoTripBanner } from '@/components/trips/demo-trip-banner'
+import { createClient } from '@/lib/supabase/server'
 
 const KIND_LABELS: Record<string, string> = {
   flight: '✈️ Flight',
@@ -24,7 +25,10 @@ function formatDate(dateStr: string | null | undefined): string {
   })
 }
 
-export default function DemoTripPage() {
+export default async function DemoTripPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
       {/* Back link */}
@@ -36,8 +40,8 @@ export default function DemoTripPage() {
         Back to trips
       </Link>
 
-      {/* Demo banner with copy button (client component) */}
-      <DemoTripBanner />
+      {/* Demo banner — only show email address to logged-in users */}
+      <DemoTripBanner isLoggedIn={!!user} />
 
       {/* Trip header */}
       <div className="rounded-2xl border border-[#cbd5e1] bg-white p-6">

--- a/src/components/trips/demo-trip-banner.tsx
+++ b/src/components/trips/demo-trip-banner.tsx
@@ -2,16 +2,31 @@
 
 import { useState } from 'react'
 import { Check, Copy } from 'lucide-react'
+import Link from 'next/link'
 
 const EMAIL = 'trips@ubtrippin.xyz'
 
-export function DemoTripBanner() {
+export function DemoTripBanner({ isLoggedIn = false }: { isLoggedIn?: boolean }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(EMAIL)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <div className="rounded-xl border border-yellow-300 bg-yellow-50 px-5 py-4">
+        <p className="text-sm text-yellow-800">
+          This is a sample trip.{' '}
+          <Link href="/login" className="font-semibold underline underline-offset-2 hover:text-yellow-900">
+            Sign in
+          </Link>
+          {' '}to create your own.
+        </p>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
Unauthenticated visitors to /trips/demo now see 'This is a sample trip. Sign in to create your own.' instead of the forwarding email address.

Logged-in users still get the full email + copy button.

Ian: 'Let's not share the address unless users are logged in.'