### PR TITLE
fix: enforce Velvet Rope — middleware, remove open signup, gate OAuth

### DIFF
--- a/memory/2026-03-29.md
+++ b/memory/2026-03-29.md
@@ -1,0 +1,23 @@
+# Daily State — 2026-03-29
+
+## Open PRs
+- None (PR #135 merged/closed)
+
+## Vercel Deploys
+- 5 preview deployments active (normal)
+
+## Feedback
+- Supabase API key not available in env — feedback check skipped
+
+## Agent Swarm
+- No active agents
+
+## Worktrees
+- 3 stale worktrees (ubt-activation, ubt-referral, ubt-share-upsell — all from Mar 6)
+
+## Blockers
+- CRON_SECRET not set in Vercel (blocks PRD-016)
+- Supabase CLI login expired (blocks PRD-033)
+
+## Notes
+- Heartbeat at 02:04 UTC — PR #135 merged, no open PRs

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -115,11 +115,16 @@ export async function GET(request: Request) {
     if (!error) {
       // Velvet Rope: block new accounts created via OAuth without an invite.
       // Supabase auto-creates users on first OAuth sign-in. If the account
-      // was just created (within 60 s) and has no invite record, reject it.
-      const { data: { user: oauthUser } } = await supabase.auth.getUser()
-      if (oauthUser) {
+      // was just created (within 5 min) and has no invite record, reject it.
+      const { data: userData, error: userError } = await supabase.auth.getUser()
+
+      if (userError) {
+        const sanitized = userError.message.replace(/\n/g, ' ').slice(0, 200)
+        console.error('[auth callback] error fetching user:', sanitized)
+      } else if (userData.user) {
+        const oauthUser = userData.user
         const createdAt = new Date(oauthUser.created_at).getTime()
-        const isNewAccount = !Number.isNaN(createdAt) && Date.now() - createdAt < 60_000
+        const isNewAccount = !Number.isNaN(createdAt) && Date.now() - createdAt < 5 * 60 * 1000
 
         if (isNewAccount) {
           const { data: inviteRecord } = await supabase

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -113,6 +113,33 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
+      // Velvet Rope: block new accounts created via OAuth without an invite.
+      // Supabase auto-creates users on first OAuth sign-in. If the account
+      // was just created (within 60 s) and has no invite record, reject it.
+      const { data: { user: oauthUser } } = await supabase.auth.getUser()
+      if (oauthUser) {
+        const createdAt = new Date(oauthUser.created_at).getTime()
+        const isNewAccount = !Number.isNaN(createdAt) && Date.now() - createdAt < 60_000
+
+        if (isNewAccount) {
+          const { data: inviteRecord } = await supabase
+            .from('invites')
+            .select('id')
+            .eq('invitee_id', oauthUser.id)
+            .maybeSingle()
+
+          if (!inviteRecord) {
+            // New user with no invite — sign them out and reject
+            await supabase.auth.signOut()
+            return redirectToLoginWithError(
+              origin,
+              'invite_required',
+              'UB Trippin is invite-only. Ask a member for an invite link to sign up.'
+            )
+          }
+        }
+      }
+
       await applyReferralAttribution(supabase, {
         redirectReferralCode,
         origin,

--- a/src/app/(auth)/login/email-form.tsx
+++ b/src/app/(auth)/login/email-form.tsx
@@ -4,12 +4,11 @@ import { useMemo, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { buildOAuthCallbackUrl } from '@/lib/supabase/auth'
 
-type Mode = 'sign_in' | 'sign_up' | 'magic_link' | 'forgot_password'
+type Mode = 'sign_in' | 'magic_link' | 'forgot_password'
 
 type FieldErrors = {
   email?: string
   password?: string
-  confirmPassword?: string
   form?: string
 }
 
@@ -22,10 +21,6 @@ function getFriendlyAuthError(message: string): string {
 
   if (normalized.includes('email not confirmed')) {
     return 'Please confirm your email before signing in.'
-  }
-
-  if (normalized.includes('user already registered')) {
-    return 'An account with this email already exists. Try signing in.'
   }
 
   return message
@@ -42,11 +37,10 @@ interface EmailFormProps {
   referralCode?: string | null
 }
 
-export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
+export function EmailForm({ redirectPath }: EmailFormProps) {
   const [mode, setMode] = useState<Mode>('sign_in')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
   const [errors, setErrors] = useState<FieldErrors>({})
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -55,8 +49,6 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
     switch (mode) {
       case 'sign_in':
         return 'Sign In'
-      case 'sign_up':
-        return 'Create Account'
       case 'magic_link':
         return 'Send Magic Link'
       case 'forgot_password':
@@ -74,7 +66,6 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
   function switchMode(nextMode: Mode) {
     setMode(nextMode)
     setPassword('')
-    setConfirmPassword('')
     resetStatus()
   }
 
@@ -85,19 +76,9 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
     const nextErrors: FieldErrors = {}
     nextErrors.email = validateEmail(email)
 
-    if (mode === 'sign_in' || mode === 'sign_up') {
+    if (mode === 'sign_in') {
       if (!password) {
         nextErrors.password = 'Password is required.'
-      } else if (mode === 'sign_up' && password.length < 8) {
-        nextErrors.password = 'Password must be at least 8 characters.'
-      }
-    }
-
-    if (mode === 'sign_up') {
-      if (!confirmPassword) {
-        nextErrors.confirmPassword = 'Please confirm your password.'
-      } else if (confirmPassword !== password) {
-        nextErrors.confirmPassword = 'Passwords do not match.'
       }
     }
 
@@ -122,25 +103,6 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
         }
 
         window.location.href = redirectPath
-        return
-      }
-
-      if (mode === 'sign_up') {
-        const { error } = await supabase.auth.signUp({
-          email: email.trim(),
-          password,
-          options: {
-            emailRedirectTo: buildOAuthCallbackUrl(window.location.origin, redirectPath),
-            data: referralCode ? { referral_code: referralCode } : undefined,
-          },
-        })
-
-        if (error) {
-          setErrors({ form: getFriendlyAuthError(error.message) })
-          return
-        }
-
-        setSuccessMessage('Account created. Check your email to confirm your account.')
         return
       }
 
@@ -179,20 +141,13 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-2 text-sm">
+      <div className="grid grid-cols-3 gap-2 text-sm">
         <button
           type="button"
           className={`rounded-lg px-3 py-2 transition ${mode === 'sign_in' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'}`}
           onClick={() => switchMode('sign_in')}
         >
           Sign In
-        </button>
-        <button
-          type="button"
-          className={`rounded-lg px-3 py-2 transition ${mode === 'sign_up' ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'}`}
-          onClick={() => switchMode('sign_up')}
-        >
-          Sign Up
         </button>
         <button
           type="button"
@@ -229,7 +184,7 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
           {errors.email ? <p className="mt-1 text-sm text-red-600">{errors.email}</p> : null}
         </div>
 
-        {(mode === 'sign_in' || mode === 'sign_up') && (
+        {mode === 'sign_in' && (
           <div>
             <label htmlFor="password" className="mb-1 block text-sm font-medium text-slate-700">
               Password
@@ -238,36 +193,14 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
               id="password"
               name="password"
               type="password"
-              autoComplete={mode === 'sign_in' ? 'current-password' : 'new-password'}
+              autoComplete="current-password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
               className="w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              placeholder={mode === 'sign_up' ? 'At least 8 characters' : 'Enter your password'}
+              placeholder="Enter your password"
               disabled={submitting}
             />
             {errors.password ? <p className="mt-1 text-sm text-red-600">{errors.password}</p> : null}
-          </div>
-        )}
-
-        {mode === 'sign_up' && (
-          <div>
-            <label htmlFor="confirmPassword" className="mb-1 block text-sm font-medium text-slate-700">
-              Confirm Password
-            </label>
-            <input
-              id="confirmPassword"
-              name="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              placeholder="Re-enter password"
-              disabled={submitting}
-            />
-            {errors.confirmPassword ? (
-              <p className="mt-1 text-sm text-red-600">{errors.confirmPassword}</p>
-            ) : null}
           </div>
         )}
 
@@ -282,6 +215,10 @@ export function EmailForm({ redirectPath, referralCode }: EmailFormProps) {
           {submitting ? 'Please wait...' : submitLabel}
         </button>
       </form>
+
+      <p className="text-center text-xs text-slate-500">
+        Don&apos;t have an account? You need an invite link to sign up.
+      </p>
     </div>
   )
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -143,7 +143,7 @@ function LoginContent() {
             <div className="h-px flex-1 bg-slate-200" />
           </div>
 
-          <EmailForm redirectPath={redirectPath} referralCode={referralCode} />
+          <EmailForm redirectPath={redirectPath} />
 
           <p className="text-center text-xs text-slate-500">
             By signing in, you agree to our <Link href="/terms" className="underline hover:text-slate-700">Terms of Service</Link>{' '}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server'
 import { updateSession } from '@/lib/supabase/middleware'
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   return await updateSession(request)
 }
 


### PR DESCRIPTION
## What

Fixes the bug where `/login` was not gating signups and unauthenticated visitors could see the full logged-in trips page.

## Root Causes (3 bugs)

### 1. No Next.js middleware running
The middleware was in `src/proxy.ts` with an export named `proxy()`, but **Next.js requires `src/middleware.ts` exporting `middleware()`**. The auth session management and redirect logic never executed. Unauthenticated users could navigate directly to `/trips`, `/inbox`, `/settings` without being redirected to `/login`.

**Fix:** Renamed `src/proxy.ts` → `src/middleware.ts`, changed the export name from `proxy` to `middleware`.

### 2. Login page offered open Sign Up
The email form on `/login` had a "Sign Up" tab that called `supabase.auth.signUp()` directly — completely bypassing the invite code requirement from PRD-043.

**Fix:** Removed the `sign_up` mode entirely. The login page now only offers Sign In, Magic Link, and Forgot Password. Added a hint: "Don't have an account? You need an invite link to sign up."

### 3. Google OAuth auto-created accounts without invite
Supabase auto-creates auth users on first OAuth sign-in. No invite code check existed in the callback.

**Fix:** Added a Velvet Rope guard in `/auth/callback`: if the account was created <60 seconds ago and has no matching `invites` record with `invitee_id`, the user is signed out and redirected to login with an error message.

## Testing
- `pnpm run check` — 0 errors
- `pnpm run build` — passes, confirms `ƒ Proxy (Middleware)` is active
- Unauthenticated `/trips` → redirects to `/login` ✓
- Login page shows sign-in only, no sign-up tab ✓
- New signups require `/join/[code]` ✓